### PR TITLE
Exclude quota requests from storage

### DIFF
--- a/services/proxy/src/middleware/logger.ts
+++ b/services/proxy/src/middleware/logger.ts
@@ -46,6 +46,7 @@ interface LogEntry {
   model?: string
   data?: any
   params?: Record<string, any>
+  requestType?: string
 }
 
 // Logger configuration

--- a/services/proxy/tests/metrics-service.test.ts
+++ b/services/proxy/tests/metrics-service.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { MetricsService } from '../src/services/MetricsService'
+import { ProxyRequest } from '../src/domain/entities/ProxyRequest'
+import { ProxyResponse } from '../src/domain/entities/ProxyResponse'
+import { RequestContext } from '../src/domain/value-objects/RequestContext'
+import { StorageAdapter } from '../src/storage/StorageAdapter'
+
+describe('MetricsService', () => {
+  let metricsService: MetricsService
+  let mockStorageAdapter: StorageAdapter
+  let mockStoreRequest: any
+  let mockStoreResponse: any
+
+  beforeEach(() => {
+    // Create mock storage adapter
+    mockStoreRequest = mock(() => Promise.resolve())
+    mockStoreResponse = mock(() => Promise.resolve())
+    
+    mockStorageAdapter = {
+      storeRequest: mockStoreRequest,
+      storeResponse: mockStoreResponse,
+      storeStreamingChunk: mock(() => Promise.resolve()),
+      close: mock(() => Promise.resolve()),
+    } as any
+
+    // Create metrics service with storage enabled
+    metricsService = new MetricsService(
+      {
+        enableTokenTracking: true,
+        enableStorage: true,
+        enableTelemetry: false,
+      },
+      mockStorageAdapter
+    )
+  })
+
+  describe('request storage filtering', () => {
+    it('should store inference requests', async () => {
+      const request = new ProxyRequest(
+        {
+          model: 'claude-3-opus-20240229',
+          messages: [
+            { role: 'system', content: 'System prompt 1' },
+            { role: 'system', content: 'System prompt 2' },
+            { role: 'user', content: 'Hello' },
+          ],
+        },
+        'example.com',
+        'test-request-id',
+        'test-api-key'
+      )
+
+      const response = new ProxyResponse('test-request-id', false)
+      response.processResponse({
+        id: 'test-id',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello' }],
+        model: 'claude-3-opus-20240229',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+        },
+      })
+
+      const context = new RequestContext({
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {},
+        host: 'example.com',
+        requestId: 'test-request-id',
+      })
+
+      await metricsService.trackRequest(request, response, context)
+
+      // Verify storage was called for inference request
+      expect(mockStoreRequest).toHaveBeenCalled()
+      expect(mockStoreResponse).toHaveBeenCalled()
+    })
+
+    it('should NOT store quota requests', async () => {
+      const request = new ProxyRequest(
+        {
+          model: 'claude-3-5-haiku-20241022',
+          messages: [
+            {
+              role: 'user',
+              content: 'quota',
+            },
+          ],
+          metadata: {
+            user_id: 'claude-1',
+          },
+          max_tokens: 1,
+        },
+        'example.com',
+        'test-request-id',
+        'test-api-key'
+      )
+
+      const response = new ProxyResponse('test-request-id', false)
+      response.processResponse({
+        id: 'test-id',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Quota response' }],
+        model: 'claude-3-5-haiku-20241022',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 1,
+        },
+      })
+
+      const context = new RequestContext({
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {},
+        host: 'example.com',
+        requestId: 'test-request-id',
+      })
+
+      await metricsService.trackRequest(request, response, context)
+
+      // Verify storage was NOT called for quota request
+      expect(mockStoreRequest).not.toHaveBeenCalled()
+      expect(mockStoreResponse).not.toHaveBeenCalled()
+    })
+
+    it('should NOT store query_evaluation requests', async () => {
+      const request = new ProxyRequest(
+        {
+          model: 'claude-3-opus-20240229',
+          messages: [
+            { role: 'system', content: 'Single system message' },
+            { role: 'user', content: 'Hello' },
+          ],
+        },
+        'example.com',
+        'test-request-id',
+        'test-api-key'
+      )
+
+      const response = new ProxyResponse('test-request-id', false)
+      response.processResponse({
+        id: 'test-id',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello' }],
+        model: 'claude-3-opus-20240229',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+        },
+      })
+
+      const context = new RequestContext({
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {},
+        host: 'example.com',
+        requestId: 'test-request-id',
+      })
+
+      await metricsService.trackRequest(request, response, context)
+
+      // Verify storage was NOT called for query_evaluation request
+      expect(mockStoreRequest).not.toHaveBeenCalled()
+      expect(mockStoreResponse).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/services/proxy/tests/metrics-service.test.ts
+++ b/services/proxy/tests/metrics-service.test.ts
@@ -15,7 +15,7 @@ describe('MetricsService', () => {
     // Create mock storage adapter
     mockStoreRequest = mock(() => Promise.resolve())
     mockStoreResponse = mock(() => Promise.resolve())
-    
+
     mockStorageAdapter = {
       storeRequest: mockStoreRequest,
       storeResponse: mockStoreResponse,


### PR DESCRIPTION
## Summary
- Prevents "quota" type requests from being stored in the database
- Uses a Set-based approach for maintainable filtering of non-storable request types
- Adds debug logging for better observability when requests are filtered

## Changes
- Modified `MetricsService` to use a `NON_STORABLE_REQUEST_TYPES` Set instead of individual conditions
- Added "quota" to the list of request types that should not be stored (alongside "query_evaluation")
- Added debug logging when requests are filtered from storage
- Created comprehensive tests to verify the filtering behavior
- Fixed TypeScript type definition for LogEntry to include requestType

## Test plan
- [x] Added unit tests for MetricsService that verify:
  - Inference requests are stored
  - Quota requests are NOT stored
  - Query evaluation requests are NOT stored
- [x] All tests pass locally
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)