### PR TITLE
feat: increase request timeout to 10 minutes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,15 @@ Docker configurations are in the `docker/` directory. Each service has its own o
 
 ## Key Implementation Details
 
+### Request Timeout Configuration
+
+The proxy supports long-running Claude API requests with configurable timeouts:
+
+- **Default timeout**: 10 minutes (600,000ms) for Claude API requests
+- **Server timeout**: 11 minutes (660,000ms) to prevent premature connection closure
+- **Retry timeout**: Slightly longer than request timeout to allow for retries
+- Configure via `CLAUDE_API_TIMEOUT` and `PROXY_SERVER_TIMEOUT` environment variables
+
 ### Conversation Tracking & Branching
 
 The proxy automatically tracks conversations and detects branches using message hashing:
@@ -178,6 +187,8 @@ When `DEBUG=true`:
 - `ENABLE_CLIENT_AUTH` - Enable client API key authentication (default: true). Set to false to allow anyone to use the proxy without authentication
 - `DASHBOARD_CACHE_TTL` - Dashboard cache TTL in seconds (default: 30). Set to 0 to disable caching
 - `SLOW_QUERY_THRESHOLD_MS` - Threshold in milliseconds for logging slow SQL queries (default: 5000)
+- `CLAUDE_API_TIMEOUT` - Timeout for Claude API requests in milliseconds (default: 600000 / 10 minutes)
+- `PROXY_SERVER_TIMEOUT` - Server-level timeout in milliseconds (default: 660000 / 11 minutes)
 
 ## Important Notes
 

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -31,13 +31,14 @@ export const config = {
     host: env.string('HOST', '0.0.0.0'),
     env: env.string('NODE_ENV', 'development'),
     isProduction: process.env.NODE_ENV === 'production',
+    timeout: env.int('PROXY_SERVER_TIMEOUT', 660000), // 11 minutes (longer than max request + retries)
   },
 
   // API configuration
   api: {
     claudeBaseUrl: env.string('CLAUDE_API_BASE_URL', 'https://api.anthropic.com'),
     claudeApiKey: env.string('CLAUDE_API_KEY', ''),
-    claudeTimeout: env.int('CLAUDE_API_TIMEOUT', 300000), // 5 minutes
+    claudeTimeout: env.int('CLAUDE_API_TIMEOUT', 600000), // 10 minutes
     oauthClientId: env.string('CLAUDE_OAUTH_CLIENT_ID', ''),
   },
 

--- a/services/proxy/src/container.ts
+++ b/services/proxy/src/container.ts
@@ -63,7 +63,10 @@ class Container {
       config.api.claudeApiKey,
       config.auth.credentialsDir
     )
-    this.claudeApiClient = new ClaudeApiClient()
+    this.claudeApiClient = new ClaudeApiClient({
+      baseUrl: config.api.claudeBaseUrl,
+      timeout: config.api.claudeTimeout,
+    })
 
     // Wire up dependencies
     this.notificationService.setAuthService(this.authenticationService)

--- a/services/proxy/src/main.ts
+++ b/services/proxy/src/main.ts
@@ -233,6 +233,23 @@ async function main() {
       fetch: app.fetch,
     })
 
+    // Set server timeout to be longer than the max request + retry time
+    // This prevents the server from closing connections prematurely
+    // Note: The Hono node server wraps the underlying Node.js server
+    const { config } = await import('@claude-nexus/shared')
+    const serverTimeout = config.server.timeout
+    
+    // Access the underlying Node.js server if available
+    if (server && 'timeout' in server && typeof (server as any).timeout === 'number') {
+      (server as any).timeout = serverTimeout
+      if ('headersTimeout' in server) {
+        (server as any).headersTimeout = serverTimeout
+      }
+      console.log(`\n⏱️  Server timeout: ${serverTimeout}ms (${Math.floor(serverTimeout / 60000)} minutes)`)
+    } else {
+      console.log(`\n⏱️  Note: Server timeout configuration not applied (using framework defaults)`)
+    }
+
     console.log(`\n✅ Server started successfully`)
     console.log(`🌐 Listening on http://${hostname}:${port}`)
     console.log(`📊 Token stats: http://${hostname}:${port}/token-stats`)

--- a/services/proxy/src/main.ts
+++ b/services/proxy/src/main.ts
@@ -238,14 +238,16 @@ async function main() {
     // Note: The Hono node server wraps the underlying Node.js server
     const { config } = await import('@claude-nexus/shared')
     const serverTimeout = config.server.timeout
-    
+
     // Access the underlying Node.js server if available
     if (server && 'timeout' in server && typeof (server as any).timeout === 'number') {
-      (server as any).timeout = serverTimeout
+      ;(server as any).timeout = serverTimeout
       if ('headersTimeout' in server) {
-        (server as any).headersTimeout = serverTimeout
+        ;(server as any).headersTimeout = serverTimeout
       }
-      console.log(`\n⏱️  Server timeout: ${serverTimeout}ms (${Math.floor(serverTimeout / 60000)} minutes)`)
+      console.log(
+        `\n⏱️  Server timeout: ${serverTimeout}ms (${Math.floor(serverTimeout / 60000)} minutes)`
+      )
     } else {
       console.log(`\n⏱️  Note: Server timeout configuration not applied (using framework defaults)`)
     }

--- a/services/proxy/src/server.ts
+++ b/services/proxy/src/server.ts
@@ -42,7 +42,10 @@ async function startServer() {
   // 2. Create services with their dependencies
   const authService = new AuthenticationService(config.api.claudeApiKey, config.auth.credentialsDir)
 
-  const apiClient = new ClaudeApiClient()
+  const apiClient = new ClaudeApiClient({
+    baseUrl: config.api.claudeBaseUrl,
+    timeout: config.api.claudeTimeout,
+  })
   const notificationService = new NotificationService()
 
   // Wire up auth service to notification service

--- a/services/proxy/src/services/ClaudeApiClient.ts
+++ b/services/proxy/src/services/ClaudeApiClient.ts
@@ -21,7 +21,7 @@ export class ClaudeApiClient {
   constructor(
     private config: ClaudeApiConfig = {
       baseUrl: 'https://api.anthropic.com',
-      timeout: 300000, // 5 minutes
+      timeout: 600000, // 10 minutes
     }
   ) {}
 

--- a/services/proxy/src/services/ProxyService.ts
+++ b/services/proxy/src/services/ProxyService.ts
@@ -65,7 +65,11 @@ export class ProxyService {
     // Collect test sample if enabled
     let sampleId: string | undefined
     if (context.honoContext) {
-      sampleId = await testSampleCollector.collectSample(context.honoContext, rawRequest, request.requestType)
+      sampleId = await testSampleCollector.collectSample(
+        context.honoContext,
+        rawRequest,
+        request.requestType
+      )
     }
 
     // Extract conversation data if storage is enabled
@@ -233,16 +237,11 @@ export class ProxyService {
 
     // Update test sample with response if enabled
     if (sampleId) {
-      await testSampleCollector.updateSampleWithResponse(
-        sampleId,
-        claudeResponse,
-        jsonResponse,
-        {
-          inputTokens: response.inputTokens,
-          outputTokens: response.outputTokens,
-          toolCalls: response.toolCallCount,
-        }
-      )
+      await testSampleCollector.updateSampleWithResponse(sampleId, claudeResponse, jsonResponse, {
+        inputTokens: response.inputTokens,
+        outputTokens: response.outputTokens,
+        toolCalls: response.toolCallCount,
+      })
     }
 
     // Return the response
@@ -398,7 +397,7 @@ export class ProxyService {
       // Process each chunk
       for await (const chunk of this.apiClient.processStreamingResponse(claudeResponse, response)) {
         await writer.write(encoder.encode(chunk))
-        
+
         // Collect chunks for test sample if enabled
         if (sampleId) {
           try {
@@ -429,18 +428,13 @@ export class ProxyService {
       if (sampleId) {
         // Reconstruct the full response from chunks
         const fullResponse = this.reconstructResponseFromChunks(streamingChunks)
-        
-        await testSampleCollector.updateSampleWithResponse(
-          sampleId,
-          claudeResponse,
-          fullResponse,
-          {
-            inputTokens: response.inputTokens,
-            outputTokens: response.outputTokens,
-            toolCalls: response.toolCallCount,
-            streamingChunks: streamingChunks,
-          }
-        )
+
+        await testSampleCollector.updateSampleWithResponse(sampleId, claudeResponse, fullResponse, {
+          inputTokens: response.inputTokens,
+          outputTokens: response.outputTokens,
+          toolCalls: response.toolCallCount,
+          streamingChunks: streamingChunks,
+        })
       }
 
       // Track metrics after streaming completes

--- a/services/proxy/src/services/ProxyService.ts
+++ b/services/proxy/src/services/ProxyService.ts
@@ -411,7 +411,7 @@ export class ProxyService {
                 }
               }
             }
-          } catch (parseError) {
+          } catch (_parseError) {
             // Ignore parsing errors for test collection
           }
         }

--- a/services/proxy/src/services/TestSampleCollector.ts
+++ b/services/proxy/src/services/TestSampleCollector.ts
@@ -90,7 +90,7 @@ export class TestSampleCollector {
       this.pendingSamples.set(sampleId, { sample, filename })
 
       logger.debug(`Test sample prepared: ${filename}`)
-      
+
       return sampleId
     } catch (error) {
       logger.error('Failed to collect test sample', error instanceof Error ? error : undefined)

--- a/services/proxy/src/services/TestSampleCollector.ts
+++ b/services/proxy/src/services/TestSampleCollector.ts
@@ -150,7 +150,9 @@ export class TestSampleCollector {
   }
 
   private sanitizeResponseBody(body: any): any {
-    if (!body) return body
+    if (!body) {
+      return body
+    }
 
     // Create a deep copy
     const sanitized = JSON.parse(JSON.stringify(body))

--- a/services/proxy/src/utils/retry.ts
+++ b/services/proxy/src/utils/retry.ts
@@ -186,7 +186,7 @@ export const retryConfigs = {
     maxDelay: 60000,
     factor: 2,
     jitter: true,
-    timeout: 300000, // 5 minutes
+    timeout: 610000, // 10 minutes + 10 seconds (allows one full 10-minute attempt)
   },
 
   // Specific for Claude API rate limits


### PR DESCRIPTION
## Summary
- Increased default Claude API timeout from 5 minutes to 10 minutes (600,000ms)
- Added server-level timeout configuration to prevent premature connection closure
- Updated retry configurations to properly handle longer timeouts

## Changes
- Updated `CLAUDE_API_TIMEOUT` default from 300,000ms to 600,000ms in shared config
- Added `PROXY_SERVER_TIMEOUT` configuration (default: 660,000ms / 11 minutes)
- Updated ClaudeApiClient to use configuration-based timeout
- Modified aggressive retry timeout to support full 10-minute attempts
- Added server timeout configuration to prevent Node.js from closing connections
- Updated CLAUDE.md documentation with new timeout settings

## Test plan
- [x] Build passes with `bun run build`
- [x] TypeScript check passes with `bun run typecheck`
- [ ] Test with a long-running Claude API request
- [ ] Verify timeout environment variables work correctly
- [ ] Confirm server doesn't close connections prematurely

## Infrastructure Note
⚠️ **Important**: Any load balancers, reverse proxies (nginx), or cloud infrastructure (AWS ALB) in front of this service must have their idle timeouts configured to be at least 11 minutes to support the increased request timeout.

🤖 Generated with [Claude Code](https://claude.ai/code)