### PR TITLE
feat: add proxy support for /api/.env endpoint

### DIFF
--- a/credentials/README.md
+++ b/credentials/README.md
@@ -13,6 +13,7 @@ Example: `example.com.credentials.json`
 ```json
 {
   "type": "api_key" | "oauth",
+  "accountId": "acc_unique_id",       // Unique account identifier
   "api_key": "sk-ant-...",           // For type: api_key
   "oauth": { ... },                  // For type: oauth
   "client_api_key": "cnp_live_...",  // Required for proxy authentication

--- a/credentials/example.com.credentials.json
+++ b/credentials/example.com.credentials.json
@@ -1,5 +1,6 @@
 {
   "type": "oauth",
+  "accountId": "acc_example_account",
   "oauth": {
     "accessToken": "sk-ant-...",
     "refreshToken": "sk-ant-...",

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -49,6 +49,7 @@ See `.env.example` in the root directory for all available environment variables
 ## API Endpoints
 
 - `POST /v1/messages` - Main Claude API proxy endpoint
+- `ALL /api/.env` - Environment endpoint proxy (Note: This endpoint is not documented in the official Anthropic API)
 - `GET /health` - Health check
 - `GET /token-stats` - Token usage statistics
 - `GET /client-setup/:filename` - Client configuration files
@@ -57,7 +58,8 @@ See `.env.example` in the root directory for all available environment variables
 
 The service uses dependency injection via a container pattern:
 
-- `MessageController` - Handles API requests
+- `MessageController` - Handles /v1/messages API requests
+- `EnvController` - Handles /api/.env API requests
 - `ProxyService` - Core proxy logic
 - `AuthenticationService` - API key and OAuth handling
 - `MetricsService` - Token tracking and telemetry

--- a/services/proxy/src/app.ts
+++ b/services/proxy/src/app.ts
@@ -77,6 +77,7 @@ export async function createProxyApp(): Promise<
   // Apply before rate limiting to protect against unauthenticated requests
   if (config.features.enableClientAuth !== false) {
     app.use('/v1/*', clientAuthMiddleware())
+    app.use('/api/.env', clientAuthMiddleware())
   }
 
   // Rate limiting
@@ -190,6 +191,10 @@ export async function createProxyApp(): Promise<
   app.post('/v1/messages', c => messageController.handle(c))
   app.options('/v1/messages', c => messageController.handleOptions(c))
 
+  // Generic API proxy handler for additional endpoints
+  const envController = container.getEnvController()
+  app.all('/api/.env', c => envController.handle(c))
+
   // Root endpoint
   app.get('/', c => {
     return c.json({
@@ -198,6 +203,7 @@ export async function createProxyApp(): Promise<
       status: 'operational',
       endpoints: {
         api: '/v1/messages',
+        env: '/api/.env',
         health: '/health',
         stats: '/token-stats',
         'client-setup': '/client-setup/*',

--- a/services/proxy/src/container.ts
+++ b/services/proxy/src/container.ts
@@ -1,5 +1,6 @@
 import { Pool } from 'pg'
 import { MessageController } from './controllers/MessageController.js'
+import { EnvController } from './controllers/EnvController.js'
 import { ProxyService } from './services/ProxyService.js'
 import { AuthenticationService } from './services/AuthenticationService.js'
 import { ClaudeApiClient } from './services/ClaudeApiClient.js'
@@ -21,6 +22,7 @@ class Container {
   private claudeApiClient?: ClaudeApiClient
   private proxyService?: ProxyService
   private messageController?: MessageController
+  private envController?: EnvController
 
   constructor() {
     this.initializeServices()
@@ -80,6 +82,7 @@ class Container {
     )
 
     this.messageController = new MessageController(this.proxyService)
+    this.envController = new EnvController(this.proxyService)
   }
 
   getDbPool(): Pool | undefined {
@@ -130,6 +133,13 @@ class Container {
       throw new Error('MessageController not initialized')
     }
     return this.messageController
+  }
+
+  getEnvController(): EnvController {
+    if (!this.envController) {
+      throw new Error('EnvController not initialized')
+    }
+    return this.envController
   }
 
   async cleanup(): Promise<void> {

--- a/services/proxy/src/controllers/EnvController.ts
+++ b/services/proxy/src/controllers/EnvController.ts
@@ -6,7 +6,7 @@ import { serializeError } from '../types/errors'
 
 /**
  * Controller for handling /api/.env endpoint
- * 
+ *
  * NOTE: This endpoint is not documented in the official Anthropic API.
  * Implementation is provided for compatibility but may need adjustment
  * based on actual API behavior.
@@ -31,11 +31,7 @@ export class EnvController {
       const body = c.req.method === 'GET' ? undefined : await c.req.json().catch(() => ({}))
 
       // Delegate to service with a special request format
-      const response = await this.proxyService.handleEnvRequest(
-        body,
-        requestContext,
-        c.req.method
-      )
+      const response = await this.proxyService.handleEnvRequest(body, requestContext, c.req.method)
 
       return response
     } catch (error) {

--- a/services/proxy/src/controllers/EnvController.ts
+++ b/services/proxy/src/controllers/EnvController.ts
@@ -1,0 +1,59 @@
+import { Context } from 'hono'
+import { ProxyService } from '../services/ProxyService'
+import { RequestContext } from '../domain/value-objects/RequestContext'
+import { getRequestLogger } from '../middleware/logger'
+import { serializeError } from '../types/errors'
+
+/**
+ * Controller for handling /api/.env endpoint
+ * 
+ * NOTE: This endpoint is not documented in the official Anthropic API.
+ * Implementation is provided for compatibility but may need adjustment
+ * based on actual API behavior.
+ */
+export class EnvController {
+  constructor(private proxyService: ProxyService) {}
+
+  /**
+   * Handle all methods for /api/.env
+   */
+  async handle(c: Context): Promise<Response> {
+    const logger = getRequestLogger(c)
+    const requestContext = RequestContext.fromHono(c)
+
+    try {
+      logger.info('Handling /api/.env request', {
+        method: c.req.method,
+        path: c.req.path,
+      })
+
+      // For GET requests, we can forward directly without a body
+      const body = c.req.method === 'GET' ? undefined : await c.req.json().catch(() => ({}))
+
+      // Delegate to service with a special request format
+      const response = await this.proxyService.handleEnvRequest(
+        body,
+        requestContext,
+        c.req.method
+      )
+
+      return response
+    } catch (error) {
+      logger.error('Env request failed', error instanceof Error ? error : undefined, {
+        method: c.req.method,
+      })
+
+      const errorObj = error instanceof Error ? error : new Error(String(error))
+      const errorResponse = serializeError(errorObj)
+
+      let statusCode = 500
+      if ((error as any).statusCode) {
+        statusCode = (error as any).statusCode
+      } else if ((error as any).upstreamStatus) {
+        statusCode = (error as any).upstreamStatus
+      }
+
+      return c.json(errorResponse, statusCode as any)
+    }
+  }
+}

--- a/services/proxy/src/services/ClaudeApiClient.ts
+++ b/services/proxy/src/services/ClaudeApiClient.ts
@@ -53,7 +53,7 @@ export class ClaudeApiClient {
     auth: AuthResult
   ): Promise<Response> {
     const url = `${this.config.baseUrl}${endpoint}`
-    
+
     // Create headers from auth result
     const headers: Record<string, string> = {
       ...auth.headers,

--- a/services/proxy/src/services/ProxyService.ts
+++ b/services/proxy/src/services/ProxyService.ts
@@ -580,11 +580,7 @@ export class ProxyService {
    * Handle an env endpoint request
    * NOTE: This endpoint is not documented in the official Anthropic API
    */
-  async handleEnvRequest(
-    body: any,
-    context: RequestContext,
-    method: string
-  ): Promise<Response> {
+  async handleEnvRequest(body: any, context: RequestContext, method: string): Promise<Response> {
     const log = {
       info: (message: string, metadata?: Record<string, any>) => {
         logger.info(message, { requestId: context.requestId, domain: context.host, metadata })
@@ -620,16 +616,11 @@ export class ProxyService {
       })
 
       // Forward to Claude using a generic endpoint approach
-      const claudeResponse = await this.apiClient.forwardToEndpoint(
-        '/api/.env',
-        method,
-        body,
-        auth
-      )
+      const claudeResponse = await this.apiClient.forwardToEndpoint('/api/.env', method, body, auth)
 
       // For non-streaming responses, return directly
       const responseBody = await claudeResponse.text()
-      
+
       // Try to parse as JSON, otherwise return as text
       let parsedBody: any
       try {


### PR DESCRIPTION
## Summary
- Added proxy support for the `/api/.env` endpoint as requested
- Created a generic endpoint forwarding mechanism to support additional endpoints beyond `/v1/messages`
- Applied the same authentication and security measures as the main messages endpoint

## Implementation Details

### New Components
- **EnvController**: Handles requests to `/api/.env` with support for all HTTP methods
- **ProxyService.handleEnvRequest**: Specialized handler for the env endpoint
- **ClaudeApiClient.forwardToEndpoint**: Generic method to forward requests to any Claude API endpoint

### Security
- Applied client authentication middleware to the new endpoint
- Uses the same domain-based credential system
- Maintains existing rate limiting and monitoring

### Important Note
The `/api/.env` endpoint is **not documented** in the official Anthropic API documentation. This implementation provides the requested proxy support but may need adjustment based on actual API behavior.

## Testing
- TypeScript compilation passes
- All type checks pass
- Follows existing patterns in the codebase

## Next Steps
Since this endpoint is not documented, we should:
1. Verify with the team what this endpoint is supposed to do
2. Test against the actual Claude API to see if it exists
3. Consider if this should be a custom endpoint serving proxy environment info instead

🤖 Generated with [Claude Code](https://claude.ai/code)