### PR TITLE
Fix: Correct subtask grouping in conversation overview

### DIFF
--- a/services/dashboard/src/routes/overview.ts
+++ b/services/dashboard/src/routes/overview.ts
@@ -107,10 +107,10 @@ overviewRoutes.get('/', async c => {
     // Separate conversations into parents and subtasks
     const nonSubtaskConversations = filteredBranches.filter(conv => !conv.isSubtask)
     const subtaskConversations = filteredBranches.filter(conv => conv.isSubtask)
-    
+
     // Create a map to group subtasks by their parent conversation ID
     const subtasksByParentId = new Map<string, typeof filteredBranches>()
-    
+
     // Group subtasks by their parent conversation ID
     subtaskConversations.forEach(subtask => {
       if (subtask.parentConversationId) {
@@ -120,23 +120,24 @@ overviewRoutes.get('/', async c => {
         subtasksByParentId.get(subtask.parentConversationId)!.push(subtask)
       }
     })
-    
+
     // Build the final list with conversations and their subtasks
     const groupedConversations: typeof filteredBranches = []
-    
+
     // Add each non-subtask conversation followed by its subtasks
     nonSubtaskConversations.forEach(parent => {
       groupedConversations.push(parent)
       const subtasks = subtasksByParentId.get(parent.conversationId) || []
       subtasks.forEach(subtask => groupedConversations.push(subtask))
     })
-    
+
     // Add orphaned subtasks (those without a parent in the current page)
     subtaskConversations.forEach(subtask => {
       // Check if this subtask has already been added (it has a parent in the current page)
-      const hasParentInCurrentPage = subtask.parentConversationId && 
+      const hasParentInCurrentPage =
+        subtask.parentConversationId &&
         nonSubtaskConversations.some(c => c.conversationId === subtask.parentConversationId)
-      
+
       if (!hasParentInCurrentPage) {
         // This subtask is orphaned (parent not in current page or no parent ID)
         groupedConversations.push(subtask)

--- a/services/dashboard/src/routes/overview.ts
+++ b/services/dashboard/src/routes/overview.ts
@@ -108,7 +108,9 @@ overviewRoutes.get('/', async c => {
     const parentConversations: typeof filteredBranches = []
     const subtasksByParentId = new Map<string, typeof filteredBranches>()
     const orphanedSubtasks: typeof filteredBranches = []
-    const allParentConvIds = new Set(filteredBranches.filter(c => !c.isSubtask).map(c => c.conversationId))
+    const allParentConvIds = new Set(
+      filteredBranches.filter(c => !c.isSubtask).map(c => c.conversationId)
+    )
 
     for (const conv of filteredBranches) {
       if (conv.isSubtask) {

--- a/services/dashboard/src/services/api-client.ts
+++ b/services/dashboard/src/services/api-client.ts
@@ -112,6 +112,7 @@ interface ConversationSummary {
   latestRequestId?: string
   isSubtask?: boolean
   parentTaskRequestId?: string
+  parentConversationId?: string
   subtaskMessageCount?: number
 }
 


### PR DESCRIPTION
## Summary
- Fixed bug where all subtasks were incorrectly grouped under the same conversation
- Subtasks now correctly appear under the conversation that spawned them
- Orphaned subtasks (whose parent is not visible) are shown separately

## Problem
The dashboard was incorrectly assigning all subtasks to the first parent conversation found, regardless of which conversation actually spawned the subtask. This was due to missing data - we had `parent_task_request_id` but not `parent_conversation_id`.

## Solution
1. Enhanced `/api/conversations` endpoint to include `parent_conversation_id` by joining with the api_requests table
2. Updated dashboard to use this parent_conversation_id for proper grouping
3. Replaced the incorrect grouping logic with a simple and correct implementation

## Changes
- **API**: Added LEFT JOIN to fetch parent conversation ID for subtasks
- **Dashboard**: Fixed grouping logic to use parent_conversation_id
- **Types**: Updated TypeScript interfaces to include the new field

## Test plan
- [x] Type checking passes
- [x] Build succeeds
- [ ] Verify subtasks appear under correct parent conversations in dashboard
- [ ] Verify orphaned subtasks appear at the end
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)