### PR TITLE
fix: handle duplicate tool_use and tool_result messages in conversation hashing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,8 @@ The proxy automatically tracks conversations and detects branches using message 
 - String content and array content are normalized to produce consistent hashes
 - Example: `"hello"` and `[{type: "text", text: "hello"}]` produce the same hash
 - **System reminders are filtered out**: Content items starting with `<system-reminder>` are ignored during hashing
-- This ensures conversations link correctly regardless of content format or system reminder presence
+- **Duplicate messages are deduplicated**: When tool_use or tool_result messages have duplicate IDs, only the first occurrence is included in the hash
+- This ensures conversations link correctly regardless of content format, system reminder presence, or duplicate messages from the Claude API
 
 **API Endpoints:**
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,7 @@
     }
   },
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir ./dist --target bun && bun build ./src/types/index.ts --outdir ./dist/types --target bun && bun build ./src/config/index.ts --outdir ./dist/config --target bun && bun x tsc src/**/*.ts --declaration --outDir dist --module esnext --target es2022 --moduleResolution node",
+    "build": "rm -rf dist && bun build ./src/index.ts --outdir ./dist --target bun && bun build ./src/types/index.ts --outdir ./dist/types --target bun && bun build ./src/config/index.ts --outdir ./dist/config --target bun && bun x tsc",
     "watch": "bun build ./src/index.ts --outdir ./dist --target bun --watch",
     "typecheck": "bun x tsc --noEmit"
   },

--- a/packages/shared/src/utils/conversation-hash.test.ts
+++ b/packages/shared/src/utils/conversation-hash.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'bun:test'
+import { hashMessage, extractMessageHashes } from './conversation-hash'
+import type { ClaudeMessage } from '../types/claude'
+
+describe('conversation-hash', () => {
+  describe('hashMessage with duplicate handling', () => {
+    it('should deduplicate tool_use items with the same ID', () => {
+      const messageWithDuplicates: ClaudeMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_01ABC',
+            name: 'Task',
+            input: { prompt: 'Do something' }
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_01ABC', // Duplicate ID
+            name: 'Task',
+            input: { prompt: 'Do something' }
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_02XYZ',
+            name: 'Another',
+            input: { data: 'test' }
+          }
+        ]
+      }
+
+      const messageWithoutDuplicates: ClaudeMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_01ABC',
+            name: 'Task',
+            input: { prompt: 'Do something' }
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_02XYZ',
+            name: 'Another',
+            input: { data: 'test' }
+          }
+        ]
+      }
+
+      // Both should produce the same hash
+      const hash1 = hashMessage(messageWithDuplicates)
+      const hash2 = hashMessage(messageWithoutDuplicates)
+      
+      expect(hash1).toBe(hash2)
+    })
+
+    it('should deduplicate tool_result items with the same tool_use_id', () => {
+      const messageWithDuplicates: ClaudeMessage = {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_01ABC',
+            content: 'Result 1'
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_01ABC', // Duplicate tool_use_id
+            content: 'Result 2'
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_02XYZ',
+            content: 'Another result'
+          }
+        ]
+      }
+
+      const messageWithoutDuplicates: ClaudeMessage = {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_01ABC',
+            content: 'Result 1'
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_02XYZ',
+            content: 'Another result'
+          }
+        ]
+      }
+
+      // Both should produce the same hash
+      const hash1 = hashMessage(messageWithDuplicates)
+      const hash2 = hashMessage(messageWithoutDuplicates)
+      
+      expect(hash1).toBe(hash2)
+    })
+
+    it('should handle mixed content with duplicates correctly', () => {
+      const messageWithDuplicates: ClaudeMessage = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'tool_use',
+            id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
+            name: 'Task',
+            input: { prompt: 'Search for something' }
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_01UEqF2pLX6enA7LDCaXr8No', // Duplicate
+            name: 'Task',
+            input: { prompt: 'Search for something' }
+          },
+          { type: 'text', text: 'More text' },
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
+            content: 'Found it'
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No', // Duplicate
+            content: 'Found it again'
+          }
+        ]
+      }
+
+      const messageWithoutDuplicates: ClaudeMessage = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'tool_use',
+            id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
+            name: 'Task',
+            input: { prompt: 'Search for something' }
+          },
+          { type: 'text', text: 'More text' },
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
+            content: 'Found it'
+          }
+        ]
+      }
+      
+      // Both should produce the same hash
+      const hash1 = hashMessage(messageWithDuplicates)
+      const hash2 = hashMessage(messageWithoutDuplicates)
+      
+      expect(hash1).toBe(hash2)
+    })
+
+    it('should produce same hash for messages with and without duplicates when duplicates are removed', () => {
+      const messageWithDuplicates: ClaudeMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_01ABC',
+            name: 'Task',
+            input: { prompt: 'Do something' }
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_01ABC', // Duplicate
+            name: 'Task',
+            input: { prompt: 'Do something' }
+          }
+        ]
+      }
+
+      const messageWithoutDuplicates: ClaudeMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_01ABC',
+            name: 'Task',
+            input: { prompt: 'Do something' }
+          }
+        ]
+      }
+
+      const hash1 = hashMessage(messageWithDuplicates)
+      const hash2 = hashMessage(messageWithoutDuplicates)
+
+      expect(hash1).toBe(hash2)
+    })
+  })
+
+  describe('extractMessageHashes with duplicate handling', () => {
+    it('should handle conversation with duplicate tool messages correctly', () => {
+      const messages: ClaudeMessage[] = [
+        {
+          role: 'user',
+          content: 'Hello'
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
+              name: 'Task',
+              input: { prompt: 'Search' }
+            },
+            {
+              type: 'tool_use',
+              id: 'toolu_01UEqF2pLX6enA7LDCaXr8No', // Duplicate
+              name: 'Task',
+              input: { prompt: 'Search' }
+            }
+          ]
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
+              content: 'Result'
+            },
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No', // Duplicate
+              content: 'Result'
+            },
+            { type: 'text', text: 'Continue' }
+          ]
+        }
+      ]
+
+      const { currentMessageHash, parentMessageHash } = extractMessageHashes(messages)
+
+      // Should produce valid hashes
+      expect(currentMessageHash).toBeTruthy()
+      expect(currentMessageHash).toHaveLength(64) // SHA-256 hex length
+      expect(parentMessageHash).toBeTruthy()
+      expect(parentMessageHash).toHaveLength(64)
+    })
+  })
+})

--- a/packages/shared/src/utils/conversation-hash.test.ts
+++ b/packages/shared/src/utils/conversation-hash.test.ts
@@ -12,21 +12,21 @@ describe('conversation-hash', () => {
             type: 'tool_use',
             id: 'toolu_01ABC',
             name: 'Task',
-            input: { prompt: 'Do something' }
+            input: { prompt: 'Do something' },
           },
           {
             type: 'tool_use',
             id: 'toolu_01ABC', // Duplicate ID
             name: 'Task',
-            input: { prompt: 'Do something' }
+            input: { prompt: 'Do something' },
           },
           {
             type: 'tool_use',
             id: 'toolu_02XYZ',
             name: 'Another',
-            input: { data: 'test' }
-          }
-        ]
+            input: { data: 'test' },
+          },
+        ],
       }
 
       const messageWithoutDuplicates: ClaudeMessage = {
@@ -36,21 +36,21 @@ describe('conversation-hash', () => {
             type: 'tool_use',
             id: 'toolu_01ABC',
             name: 'Task',
-            input: { prompt: 'Do something' }
+            input: { prompt: 'Do something' },
           },
           {
             type: 'tool_use',
             id: 'toolu_02XYZ',
             name: 'Another',
-            input: { data: 'test' }
-          }
-        ]
+            input: { data: 'test' },
+          },
+        ],
       }
 
       // Both should produce the same hash
       const hash1 = hashMessage(messageWithDuplicates)
       const hash2 = hashMessage(messageWithoutDuplicates)
-      
+
       expect(hash1).toBe(hash2)
     })
 
@@ -61,19 +61,19 @@ describe('conversation-hash', () => {
           {
             type: 'tool_result',
             tool_use_id: 'toolu_01ABC',
-            content: 'Result 1'
+            content: 'Result 1',
           },
           {
             type: 'tool_result',
             tool_use_id: 'toolu_01ABC', // Duplicate tool_use_id
-            content: 'Result 2'
+            content: 'Result 2',
           },
           {
             type: 'tool_result',
             tool_use_id: 'toolu_02XYZ',
-            content: 'Another result'
-          }
-        ]
+            content: 'Another result',
+          },
+        ],
       }
 
       const messageWithoutDuplicates: ClaudeMessage = {
@@ -82,20 +82,20 @@ describe('conversation-hash', () => {
           {
             type: 'tool_result',
             tool_use_id: 'toolu_01ABC',
-            content: 'Result 1'
+            content: 'Result 1',
           },
           {
             type: 'tool_result',
             tool_use_id: 'toolu_02XYZ',
-            content: 'Another result'
-          }
-        ]
+            content: 'Another result',
+          },
+        ],
       }
 
       // Both should produce the same hash
       const hash1 = hashMessage(messageWithDuplicates)
       const hash2 = hashMessage(messageWithoutDuplicates)
-      
+
       expect(hash1).toBe(hash2)
     })
 
@@ -108,26 +108,26 @@ describe('conversation-hash', () => {
             type: 'tool_use',
             id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
             name: 'Task',
-            input: { prompt: 'Search for something' }
+            input: { prompt: 'Search for something' },
           },
           {
             type: 'tool_use',
             id: 'toolu_01UEqF2pLX6enA7LDCaXr8No', // Duplicate
             name: 'Task',
-            input: { prompt: 'Search for something' }
+            input: { prompt: 'Search for something' },
           },
           { type: 'text', text: 'More text' },
           {
             type: 'tool_result',
             tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
-            content: 'Found it'
+            content: 'Found it',
           },
           {
             type: 'tool_result',
             tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No', // Duplicate
-            content: 'Found it again'
-          }
-        ]
+            content: 'Found it again',
+          },
+        ],
       }
 
       const messageWithoutDuplicates: ClaudeMessage = {
@@ -138,21 +138,21 @@ describe('conversation-hash', () => {
             type: 'tool_use',
             id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
             name: 'Task',
-            input: { prompt: 'Search for something' }
+            input: { prompt: 'Search for something' },
           },
           { type: 'text', text: 'More text' },
           {
             type: 'tool_result',
             tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
-            content: 'Found it'
-          }
-        ]
+            content: 'Found it',
+          },
+        ],
       }
-      
+
       // Both should produce the same hash
       const hash1 = hashMessage(messageWithDuplicates)
       const hash2 = hashMessage(messageWithoutDuplicates)
-      
+
       expect(hash1).toBe(hash2)
     })
 
@@ -164,15 +164,15 @@ describe('conversation-hash', () => {
             type: 'tool_use',
             id: 'toolu_01ABC',
             name: 'Task',
-            input: { prompt: 'Do something' }
+            input: { prompt: 'Do something' },
           },
           {
             type: 'tool_use',
             id: 'toolu_01ABC', // Duplicate
             name: 'Task',
-            input: { prompt: 'Do something' }
-          }
-        ]
+            input: { prompt: 'Do something' },
+          },
+        ],
       }
 
       const messageWithoutDuplicates: ClaudeMessage = {
@@ -182,9 +182,9 @@ describe('conversation-hash', () => {
             type: 'tool_use',
             id: 'toolu_01ABC',
             name: 'Task',
-            input: { prompt: 'Do something' }
-          }
-        ]
+            input: { prompt: 'Do something' },
+          },
+        ],
       }
 
       const hash1 = hashMessage(messageWithDuplicates)
@@ -199,7 +199,7 @@ describe('conversation-hash', () => {
       const messages: ClaudeMessage[] = [
         {
           role: 'user',
-          content: 'Hello'
+          content: 'Hello',
         },
         {
           role: 'assistant',
@@ -208,15 +208,15 @@ describe('conversation-hash', () => {
               type: 'tool_use',
               id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
               name: 'Task',
-              input: { prompt: 'Search' }
+              input: { prompt: 'Search' },
             },
             {
               type: 'tool_use',
               id: 'toolu_01UEqF2pLX6enA7LDCaXr8No', // Duplicate
               name: 'Task',
-              input: { prompt: 'Search' }
-            }
-          ]
+              input: { prompt: 'Search' },
+            },
+          ],
         },
         {
           role: 'user',
@@ -224,16 +224,16 @@ describe('conversation-hash', () => {
             {
               type: 'tool_result',
               tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No',
-              content: 'Result'
+              content: 'Result',
             },
             {
               type: 'tool_result',
               tool_use_id: 'toolu_01UEqF2pLX6enA7LDCaXr8No', // Duplicate
-              content: 'Result'
+              content: 'Result',
             },
-            { type: 'text', text: 'Continue' }
-          ]
-        }
+            { type: 'text', text: 'Continue' },
+          ],
+        },
       ]
 
       const { currentMessageHash, parentMessageHash } = extractMessageHashes(messages)

--- a/packages/shared/src/utils/conversation-hash.ts
+++ b/packages/shared/src/utils/conversation-hash.ts
@@ -20,7 +20,7 @@ export function hashMessage(message: ClaudeMessage): string {
 /**
  * Normalizes message content for consistent hashing
  * Handles both string and array content types
- * 
+ *
  * Important: This function deduplicates tool_use and tool_result items by their IDs
  * to handle cases where the Claude API might send duplicate messages. Only the first
  * occurrence of each unique tool_use ID or tool_result tool_use_id is included in

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -16,5 +16,5 @@
     "composite": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug where duplicate messages with the same tool_use ID or tool_result tool_use_id would break conversation linking. The hash computation now deduplicates these messages, keeping only the first occurrence of each unique ID.

## Problem

Request `03b9be37-8599-4655-945c-a1e1c69b4203` contains duplicate tool_use and tool_result messages with the same ID (`toolu_01UEqF2pLX6enA7LDCaXr8No`). This causes incorrect conversation hash computation and breaks conversation linking.

## Solution

- Added deduplication logic to the `normalizeMessageContent` function in the shared package
- When processing array content, we now track seen tool_use IDs and tool_result tool_use_ids
- Duplicate messages are filtered out before hash computation
- Only the first occurrence of each unique ID is included

## Changes

- ✨ Add deduplication logic to handle duplicate tool messages
- ✅ Add comprehensive tests for duplicate message handling
- 📝 Update documentation in CLAUDE.md to explain the behavior
- 🔧 Update build config to exclude test files from TypeScript compilation

## Test Plan

- [x] Added unit tests to verify deduplication works correctly
- [x] Tested with messages that have duplicate tool_use items
- [x] Tested with messages that have duplicate tool_result items
- [x] Verified that messages with and without duplicates produce the same hash
- [x] All tests pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)