### PR TITLE
feat: add AI inference time metric to conversation UI

### DIFF
--- a/services/dashboard/src/routes/conversation-detail.ts
+++ b/services/dashboard/src/routes/conversation-detail.ts
@@ -308,6 +308,10 @@ conversationDetailRoutes.get('/conversation/:id', async c => {
     // Calculate stats
     const totalDuration =
       new Date(conversation.last_message).getTime() - new Date(conversation.first_message).getTime()
+    
+    // Calculate AI inference time (sum of all request durations)
+    const totalInferenceTime = conversation.requests.reduce((sum, req) => sum + (req.duration_ms || 0), 0)
+    
     const branchStats = conversation.branches.reduce(
       (acc, branch) => {
         const branchRequests = conversation.requests.filter(r => (r.branch_id || 'main') === branch)
@@ -387,6 +391,7 @@ conversationDetailRoutes.get('/conversation/:id', async c => {
       const totalTokens = filteredRequests.reduce((sum, r) => sum + r.total_tokens, 0)
       const timestamps = filteredRequests.map(r => new Date(r.timestamp).getTime())
       const duration = timestamps.length > 0 ? Math.max(...timestamps) - Math.min(...timestamps) : 0
+      const inferenceTime = filteredRequests.reduce((sum, req) => sum + (req.duration_ms || 0), 0)
 
       // Calculate sub-tasks for filtered branch
       let branchSubtasks = 0
@@ -408,6 +413,7 @@ conversationDetailRoutes.get('/conversation/:id', async c => {
         totalTokens: totalTokens,
         branchCount: 1,
         duration: duration,
+        inferenceTime: inferenceTime,
         requestCount: filteredRequests.length,
         totalSubtasks: branchSubtasks,
       }
@@ -418,6 +424,7 @@ conversationDetailRoutes.get('/conversation/:id', async c => {
         totalTokens: conversation.total_tokens,
         branchCount: Object.keys(branchStats).length,
         duration: totalDuration,
+        inferenceTime: totalInferenceTime,
         requestCount: conversation.requests.length,
         totalSubtasks: totalSubtasksSpawned,
       }
@@ -457,6 +464,10 @@ conversationDetailRoutes.get('/conversation/:id', async c => {
         <div class="conversation-stat-card">
           <div class="conversation-stat-label">Duration</div>
           <div class="conversation-stat-value">${formatDuration(displayStats.duration)}</div>
+        </div>
+        <div class="conversation-stat-card">
+          <div class="conversation-stat-label">AI Inference Time</div>
+          <div class="conversation-stat-value">${formatDuration(displayStats.inferenceTime)}</div>
         </div>
       </div>
 

--- a/services/dashboard/src/types/conversation.ts
+++ b/services/dashboard/src/types/conversation.ts
@@ -14,6 +14,7 @@ export interface ConversationRequest {
   request_tokens?: number
   response_tokens?: number
   duration?: number
+  duration_ms?: number
   hasToolUse?: boolean
   hasToolResult?: boolean
   messageTypeSummary?: string[]


### PR DESCRIPTION
## Summary
- Add new "AI Inference Time" metric to the conversation detail page
- Shows the sum of all request durations (`duration_ms` field) in a conversation
- Handles branch filtering appropriately - shows branch-specific inference time when a branch is selected

## Changes
- Added calculation of total inference time by summing `duration_ms` from all requests
- Added new stat card in the conversation stats grid to display "AI Inference Time"
- Updated `ConversationRequest` type to include the `duration_ms` field
- Works seamlessly with existing branch filtering functionality

## Test plan
- [x] Type checking passes
- [x] Dashboard builds successfully
- [ ] Manually test the new metric displays correctly in the conversation UI
- [ ] Verify branch filtering shows correct branch-specific inference times
- [ ] Ensure the metric handles missing/null duration_ms values gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)