### PR TITLE
fix: correct PostgreSQL column name in migration 004

### DIFF
--- a/scripts/db/migrations/004-optimize-conversation-window-functions.ts
+++ b/scripts/db/migrations/004-optimize-conversation-window-functions.ts
@@ -104,7 +104,7 @@ async function optimizeConversationWindowFunctions() {
     const statsResult = await pool.query(`
       SELECT 
         schemaname,
-        tablename,
+        relname,
         n_live_tup as row_count,
         n_dead_tup as dead_rows,
         last_vacuum,
@@ -112,7 +112,7 @@ async function optimizeConversationWindowFunctions() {
         last_analyze,
         last_autoanalyze
       FROM pg_stat_user_tables
-      WHERE tablename = 'api_requests'
+      WHERE relname = 'api_requests'
     `)
 
     if (statsResult.rows.length > 0) {


### PR DESCRIPTION
## Summary
- Fixed SQL error in migration 004 that was preventing successful execution
- Changed column reference from `tablename` to `relname` when querying `pg_stat_user_tables`

## Problem
The migration script was failing with error: `column "tablename" does not exist`

This occurred because the `pg_stat_user_tables` PostgreSQL system view uses `relname` as the column name for table names, not `tablename` (which is used in other views like `pg_indexes`).

## Solution
Updated the SQL query in the migration script to correctly use `relname`:
- Changed the SELECT clause to select `relname` instead of `tablename`
- Changed the WHERE clause to filter by `relname` instead of `tablename`

## Test plan
✅ Ran the migration locally - it now completes successfully
✅ Verified table statistics are correctly retrieved and displayed
✅ All required indexes are created as expected

🤖 Generated with [Claude Code](https://claude.ai/code)