### PR TITLE
fix: resolve PostgreSQL max(uuid) error in conversations API

### DIFF
--- a/services/proxy/src/routes/api.ts
+++ b/services/proxy/src/routes/api.ts
@@ -487,10 +487,10 @@ apiRoutes.get('/conversations', async c => {
           SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) as total_tokens,
           COUNT(DISTINCT branch_id) as branch_count,
           ARRAY_AGG(DISTINCT model) FILTER (WHERE model IS NOT NULL) as models_used,
-          MAX(CASE WHEN rn = 1 THEN request_id END) as latest_request_id,
+          (array_agg(request_id ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_request_id,
           BOOL_OR(is_subtask) as is_subtask,
           -- Get the parent_task_request_id from the first subtask in the conversation
-          MAX(CASE WHEN is_subtask = true AND subtask_rn = 1 THEN parent_task_request_id END) as parent_task_request_id,
+          (array_agg(parent_task_request_id ORDER BY subtask_rn) FILTER (WHERE is_subtask = true AND subtask_rn = 1))[1] as parent_task_request_id,
           COUNT(CASE WHEN is_subtask THEN 1 END) as subtask_message_count
         FROM ranked_requests
         GROUP BY conversation_id, domain, account_id


### PR DESCRIPTION
## Summary
- Fixed SQL error in `/api/conversations` endpoint that was preventing conversations from loading
- Replaced `MAX()` function with `array_agg()[1]` for UUID columns

## Problem
The conversations API was failing with error: `function max(uuid) does not exist`

This occurred because PostgreSQL doesn't support the MAX() aggregate function on UUID data types. The query was trying to use:
- `MAX(CASE WHEN rn = 1 THEN request_id END)` 
- `MAX(CASE WHEN is_subtask = true AND subtask_rn = 1 THEN parent_task_request_id END)`

Both `request_id` and `parent_task_request_id` are UUID columns.

## Solution
Replaced the MAX() calls with array aggregation:
- `(array_agg(request_id ORDER BY rn) FILTER (WHERE rn = 1))[1]`
- `(array_agg(parent_task_request_id ORDER BY subtask_rn) FILTER (WHERE is_subtask = true AND subtask_rn = 1))[1]`

This approach:
1. Collects the UUID values into an array
2. Orders them appropriately 
3. Filters for the specific condition
4. Takes the first element `[1]`

## Test plan
✅ Tested the SQL query directly against the database - works correctly
✅ The query now returns conversation data without errors
✅ Both latest_request_id and parent_task_request_id fields are populated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)