### PR TITLE
feat: add AWS env tag support to manage-nexus-proxies script

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,25 @@ See [DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines.
 
 ## Deployment
 
+### Environments
+
+Claude Nexus Proxy supports deployment to multiple environments:
+
+- **Production (`prod`)** - Live production services
+- **Staging (`staging`)** - Pre-production testing environment
+
+For AWS EC2 deployments, use the `manage-nexus-proxies.sh` script with environment filtering:
+
+```bash
+# Deploy to production servers only
+./scripts/ops/manage-nexus-proxies.sh --env prod up
+
+# Check staging server status
+./scripts/ops/manage-nexus-proxies.sh --env staging status
+```
+
+See [AWS Infrastructure Guide](docs/03-Operations/deployment/aws-infrastructure.md) for detailed multi-environment setup.
+
 ### Docker
 
 #### Using Pre-built Images (Default)

--- a/docs/03-Operations/deployment/aws-infrastructure.md
+++ b/docs/03-Operations/deployment/aws-infrastructure.md
@@ -22,6 +22,20 @@ Each environment is isolated and can be managed independently using the `manage-
   - Inbound: SSH (22), HTTP (3000), Dashboard (3001)
   - Outbound: All traffic (for Claude API access)
 
+### File Structure
+
+Each EC2 instance should have the following structure in the ubuntu user's home directory:
+
+```
+/home/ubuntu/
+├── .env                          # Environment configuration
+├── claude-nexus-proxy/           # Git repository
+│   └── scripts/ops/              # Operational scripts
+├── credentials/                  # Domain credential files
+│   ├── domain1.com.credentials.json
+│   └── domain2.com.credentials.json
+```
+
 ### Required AWS Tags
 
 Each EC2 instance must be tagged appropriately:
@@ -57,7 +71,12 @@ resource "aws_instance" "nexus_proxy_prod" {
     git clone https://github.com/yourusername/claude-nexus-proxy.git /home/ubuntu/claude-nexus-proxy
     chown -R ubuntu:ubuntu /home/ubuntu/claude-nexus-proxy
     
-    # Setup will be completed by ops scripts
+    # Create required directories
+    mkdir -p /home/ubuntu/credentials
+    chown ubuntu:ubuntu /home/ubuntu/credentials
+    
+    # Note: .env file should be placed at /home/ubuntu/.env
+    # Note: credentials should be placed in /home/ubuntu/credentials/
   EOF
 }
 

--- a/docs/03-Operations/deployment/aws-infrastructure.md
+++ b/docs/03-Operations/deployment/aws-infrastructure.md
@@ -1,0 +1,283 @@
+# AWS Infrastructure Deployment
+
+This guide covers deploying Claude Nexus Proxy on AWS EC2 infrastructure with support for multiple environments.
+
+## Environment Architecture
+
+Claude Nexus Proxy supports two primary environments:
+
+- **Production (`prod`)** - Live production services
+- **Staging (`staging`)** - Pre-production testing environment
+
+Each environment is isolated and can be managed independently using the `manage-nexus-proxies.sh` script.
+
+## EC2 Instance Setup
+
+### Instance Requirements
+
+- **OS**: Ubuntu 20.04 LTS or later
+- **Instance Type**: t3.medium or larger (minimum 2 vCPU, 4GB RAM)
+- **Storage**: 20GB+ EBS volume
+- **Security Groups**: 
+  - Inbound: SSH (22), HTTP (3000), Dashboard (3001)
+  - Outbound: All traffic (for Claude API access)
+
+### Required AWS Tags
+
+Each EC2 instance must be tagged appropriately:
+
+1. **Name Tag** (Required)
+   - Must contain "Nexus Proxy" (case-insensitive)
+   - Example: `"Nexus Proxy Production Server 1"`
+
+2. **env Tag** (Required for environment filtering)
+   - Value: `prod` or `staging`
+   - This tag determines which environment the instance belongs to
+
+### Example Terraform Configuration
+
+```hcl
+resource "aws_instance" "nexus_proxy_prod" {
+  count         = 3
+  ami           = "ami-0c55b159cbfafe1f0" # Ubuntu 20.04
+  instance_type = "t3.medium"
+  
+  tags = {
+    Name = "Nexus Proxy Production ${count.index + 1}"
+    env  = "prod"
+    Type = "proxy"
+  }
+  
+  user_data = <<-EOF
+    #!/bin/bash
+    # Install Docker
+    curl -fsSL https://get.docker.com | bash
+    
+    # Clone repository
+    git clone https://github.com/yourusername/claude-nexus-proxy.git /home/ubuntu/claude-nexus-proxy
+    chown -R ubuntu:ubuntu /home/ubuntu/claude-nexus-proxy
+    
+    # Setup will be completed by ops scripts
+  EOF
+}
+
+resource "aws_instance" "nexus_proxy_staging" {
+  count         = 2
+  ami           = "ami-0c55b159cbfafe1f0" # Ubuntu 20.04
+  instance_type = "t3.small"
+  
+  tags = {
+    Name = "Nexus Proxy Staging ${count.index + 1}"
+    env  = "staging"
+    Type = "proxy"
+  }
+  
+  user_data = "${file("user-data.sh")}"
+}
+```
+
+## Environment Management
+
+### Using the Management Script
+
+The `manage-nexus-proxies.sh` script provides environment-aware operations:
+
+```bash
+# Check status of all servers (both prod and staging)
+./scripts/ops/manage-nexus-proxies.sh status
+
+# Update only production servers
+./scripts/ops/manage-nexus-proxies.sh --env prod up
+
+# Stop staging servers for maintenance
+./scripts/ops/manage-nexus-proxies.sh --env staging down
+
+# Update specific staging server
+./scripts/ops/manage-nexus-proxies.sh --env staging up "Nexus Proxy Staging 1"
+```
+
+### Environment Isolation
+
+Each environment should have:
+
+1. **Separate Databases**
+   - Production: High-availability RDS instance
+   - Staging: Smaller RDS instance or containerized PostgreSQL
+
+2. **Separate Credentials**
+   - Use different Claude API keys for each environment
+   - Store in separate credential files
+
+3. **Separate Monitoring**
+   - Different Slack channels for alerts
+   - Separate dashboards for metrics
+
+## Deployment Workflow
+
+### 1. Staging Deployment
+
+Deploy to staging first for testing:
+
+```bash
+# Update staging servers with new version
+./scripts/ops/manage-nexus-proxies.sh --env staging up
+
+# Run tests against staging
+curl https://staging-proxy.yourdomain.com/health
+
+# Monitor staging logs
+./scripts/ops/manage-nexus-proxies.sh --env staging status
+```
+
+### 2. Production Deployment
+
+After staging validation:
+
+```bash
+# Rolling update of production servers
+for server in $(aws ec2 describe-instances --filters "Name=tag:env,Values=prod" "Name=tag:Name,Values=*Nexus Proxy*" --query "Reservations[].Instances[].Tags[?Key=='Name'].Value" --output text); do
+  ./scripts/ops/manage-nexus-proxies.sh --env prod up "$server"
+  sleep 30 # Wait between updates
+done
+```
+
+## Environment-Specific Configuration
+
+### Production Configuration
+
+```bash
+# .env.prod
+DATABASE_URL=postgresql://prod-rds.aws.com:5432/claude_nexus
+STORAGE_ENABLED=true
+DEBUG=false
+SLACK_WEBHOOK_URL=https://hooks.slack.com/prod-channel
+DASHBOARD_CACHE_TTL=300
+```
+
+### Staging Configuration
+
+```bash
+# .env.staging
+DATABASE_URL=postgresql://staging-rds.aws.com:5432/claude_nexus_staging
+STORAGE_ENABLED=true
+DEBUG=true
+SLACK_WEBHOOK_URL=https://hooks.slack.com/staging-channel
+DASHBOARD_CACHE_TTL=60
+```
+
+## Multi-Region Deployment
+
+For global deployment across regions:
+
+```bash
+# Tag instances with region
+aws ec2 create-tags --resources i-1234567890abcdef0 --tags Key=env,Value=prod Key=region,Value=us-east-1
+
+# Future enhancement: filter by region
+./scripts/ops/manage-nexus-proxies.sh --env prod --region us-east-1 status
+```
+
+## Security Considerations
+
+### IAM Roles
+
+Create environment-specific IAM roles:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeTags"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/env": ["prod", "staging"]
+        }
+      }
+    }
+  ]
+}
+```
+
+### Network Isolation
+
+- Production: Dedicated VPC with private subnets
+- Staging: Separate VPC or isolated subnets
+- No cross-environment communication
+
+## Monitoring by Environment
+
+### CloudWatch Metrics
+
+```bash
+# Create environment-specific dashboards
+aws cloudwatch put-dashboard \
+  --dashboard-name "ClaudeNexusProxy-Production" \
+  --dashboard-body file://dashboards/prod-dashboard.json
+
+aws cloudwatch put-dashboard \
+  --dashboard-name "ClaudeNexusProxy-Staging" \
+  --dashboard-body file://dashboards/staging-dashboard.json
+```
+
+### Alerts
+
+Configure environment-specific alerts:
+
+- **Production**: PagerDuty integration for critical alerts
+- **Staging**: Email notifications only
+
+## Disaster Recovery
+
+### Backup Strategy
+
+- **Production**: Automated daily backups with 30-day retention
+- **Staging**: Weekly backups with 7-day retention
+
+### Failover
+
+```bash
+# Quick failover to backup region
+./scripts/ops/manage-nexus-proxies.sh --env prod --region us-west-2 up
+```
+
+## Cost Optimization
+
+### Environment-Specific Scaling
+
+- **Production**: Auto-scaling based on load
+- **Staging**: Fixed smaller instance count
+
+### Resource Tagging
+
+```bash
+# Tag all resources for cost tracking
+aws ec2 create-tags --resources $INSTANCE_ID --tags \
+  Key=Project,Value=ClaudeNexusProxy \
+  Key=Environment,Value=prod \
+  Key=CostCenter,Value=Engineering
+```
+
+## Compliance
+
+### Environment Separation
+
+- Ensure prod/staging data never mix
+- Separate access controls per environment
+- Audit logs for each environment
+
+### Data Residency
+
+- Production: Data stays in primary region
+- Staging: Can use development regions
+
+## Next Steps
+
+- [Configure monitoring](../monitoring.md)
+- [Set up CI/CD pipelines](../../04-Architecture/ADRs/adr-008-cicd-strategy.md)
+- [Review security best practices](../security.md)

--- a/docs/03-Operations/deployment/docker.md
+++ b/docs/03-Operations/deployment/docker.md
@@ -4,6 +4,8 @@ This guide covers deploying Claude Nexus Proxy to production environments.
 
 ## Deployment Options
 
+> **Note**: For AWS EC2 deployment with staging/production environments, see [AWS Infrastructure Guide](./aws-infrastructure.md).
+
 ### 1. Docker (Recommended)
 
 The project provides optimized Docker images for each service.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Welcome to the Claude Nexus Proxy documentation. This guide will help you unders
 - [Deployment](./03-Operations/deployment/)
   - [Docker](./03-Operations/deployment/docker.md) - Docker deployment guide
   - [Docker Compose](./03-Operations/deployment/docker-compose.md) - Full stack deployment
+  - [AWS Infrastructure](./03-Operations/deployment/aws-infrastructure.md) - Multi-environment AWS deployment
 - [Security](./03-Operations/security.md) - Security best practices and hardening
 - [Database](./03-Operations/database.md) - Database setup and maintenance
 - [Monitoring](./03-Operations/monitoring.md) - Metrics, alerts, and observability

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -65,6 +65,8 @@ The script filters EC2 instances based on the `env` tag:
   - Optional `env` tag with value `prod` or `staging`
   - Git repository cloned at `~/claude-nexus-proxy` on each server
   - Git access configured (for pulling from origin/main)
+  - `.env` file located at `~/.env` (in user's home directory)
+  - `credentials` directory at `~/credentials` (if using credential files)
 
 ### update-proxy.sh
 

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -12,6 +12,7 @@ Manages Claude Nexus Proxy Docker containers across all EC2 instances tagged wit
 
 - Automatically discovers EC2 instances using AWS CLI
 - Supports environment-based filtering using AWS tags
+- **Automatically pulls latest code before updates** (git pull)
 - Executes commands in parallel across multiple servers
 - Provides colored output for better visibility
 
@@ -23,7 +24,7 @@ Manages Claude Nexus Proxy Docker containers across all EC2 instances tagged wit
 
 **Commands:**
 
-- `up` - Start/update the claude-nexus-proxy container
+- `up` - Pull latest code (git pull) and start/update the claude-nexus-proxy container
 - `down` - Stop the claude-nexus-proxy container
 - `status` - Check container status
 
@@ -62,6 +63,8 @@ The script filters EC2 instances based on the `env` tag:
 - EC2 instances must have:
   - "Nexus Proxy" in their Name tag
   - Optional `env` tag with value `prod` or `staging`
+  - Git repository cloned at `~/claude-nexus-proxy` on each server
+  - Git access configured (for pulling from origin/main)
 
 ### update-proxy.sh
 

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -1,0 +1,103 @@
+# Operations Scripts
+
+This directory contains operational scripts for managing Claude Nexus Proxy deployments.
+
+## Scripts
+
+### manage-nexus-proxies.sh
+
+Manages Claude Nexus Proxy Docker containers across all EC2 instances tagged with "Nexus Proxy" in their name.
+
+**Features:**
+- Automatically discovers EC2 instances using AWS CLI
+- Supports environment-based filtering using AWS tags
+- Executes commands in parallel across multiple servers
+- Provides colored output for better visibility
+
+**Usage:**
+```bash
+./manage-nexus-proxies.sh [--env {prod|staging}] {up|down|status} [server-name]
+```
+
+**Commands:**
+- `up` - Start/update the claude-nexus-proxy container
+- `down` - Stop the claude-nexus-proxy container  
+- `status` - Check container status
+
+**Options:**
+- `--env {prod|staging}` - Filter servers by environment tag (optional)
+- `server-name` - Target specific server (optional)
+
+**Examples:**
+```bash
+# Check status on all servers
+./manage-nexus-proxies.sh status
+
+# Start proxy on all production servers
+./manage-nexus-proxies.sh --env prod up
+
+# Check status on specific staging server
+./manage-nexus-proxies.sh --env staging status server1
+
+# Stop proxy on all staging servers
+./manage-nexus-proxies.sh --env staging down
+```
+
+**Environment Tags:**
+The script filters EC2 instances based on the `env` tag:
+- `env=prod` - Production servers (displayed in RED)
+- `env=staging` - Staging servers (displayed in YELLOW)
+- No tag or unknown value - Displayed as "unknown"
+
+**Requirements:**
+- AWS CLI configured with appropriate credentials
+- SSH access to EC2 instances as `ubuntu` user
+- EC2 instances must have:
+  - "Nexus Proxy" in their Name tag
+  - Optional `env` tag with value `prod` or `staging`
+
+### update-proxy.sh
+
+Updates Claude Nexus Proxy Docker containers to a specific version.
+
+**Usage:**
+```bash
+./update-proxy.sh <version> [service]
+```
+
+**Arguments:**
+- `version` - Docker image version (e.g., `v8`, `latest`)
+- `service` - Optional: `proxy` or `dashboard` (defaults to both)
+
+**Examples:**
+```bash
+# Update both services to latest
+./update-proxy.sh latest
+
+# Update only proxy to v8
+./update-proxy.sh v8 proxy
+
+# Update only dashboard to v9
+./update-proxy.sh v9 dashboard
+```
+
+## AWS Infrastructure Requirements
+
+For the `manage-nexus-proxies.sh` script to work properly, EC2 instances must be tagged appropriately:
+
+1. **Name Tag** (Required): Must contain "Nexus Proxy" (case-insensitive)
+2. **env Tag** (Optional): Should be either "prod" or "staging" for environment filtering
+
+Example AWS tags:
+```
+Name: "Nexus Proxy Server 1"
+env: "prod"
+```
+
+## Security Considerations
+
+- The scripts use SSH with `StrictHostKeyChecking=no` for automation
+- Ensure AWS CLI credentials have minimal required permissions:
+  - `ec2:DescribeInstances` for instance discovery
+- SSH keys should be properly secured and rotated regularly
+- Consider using AWS Systems Manager Session Manager for enhanced security

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -9,26 +9,31 @@ This directory contains operational scripts for managing Claude Nexus Proxy depl
 Manages Claude Nexus Proxy Docker containers across all EC2 instances tagged with "Nexus Proxy" in their name.
 
 **Features:**
+
 - Automatically discovers EC2 instances using AWS CLI
 - Supports environment-based filtering using AWS tags
 - Executes commands in parallel across multiple servers
 - Provides colored output for better visibility
 
 **Usage:**
+
 ```bash
 ./manage-nexus-proxies.sh [--env {prod|staging}] {up|down|status} [server-name]
 ```
 
 **Commands:**
+
 - `up` - Start/update the claude-nexus-proxy container
-- `down` - Stop the claude-nexus-proxy container  
+- `down` - Stop the claude-nexus-proxy container
 - `status` - Check container status
 
 **Options:**
+
 - `--env {prod|staging}` - Filter servers by environment tag (optional)
 - `server-name` - Target specific server (optional)
 
 **Examples:**
+
 ```bash
 # Check status on all servers
 ./manage-nexus-proxies.sh status
@@ -45,11 +50,13 @@ Manages Claude Nexus Proxy Docker containers across all EC2 instances tagged wit
 
 **Environment Tags:**
 The script filters EC2 instances based on the `env` tag:
+
 - `env=prod` - Production servers (displayed in RED)
 - `env=staging` - Staging servers (displayed in YELLOW)
 - No tag or unknown value - Displayed as "unknown"
 
 **Requirements:**
+
 - AWS CLI configured with appropriate credentials
 - SSH access to EC2 instances as `ubuntu` user
 - EC2 instances must have:
@@ -61,15 +68,18 @@ The script filters EC2 instances based on the `env` tag:
 Updates Claude Nexus Proxy Docker containers to a specific version.
 
 **Usage:**
+
 ```bash
 ./update-proxy.sh <version> [service]
 ```
 
 **Arguments:**
+
 - `version` - Docker image version (e.g., `v8`, `latest`)
 - `service` - Optional: `proxy` or `dashboard` (defaults to both)
 
 **Examples:**
+
 ```bash
 # Update both services to latest
 ./update-proxy.sh latest
@@ -89,6 +99,7 @@ For the `manage-nexus-proxies.sh` script to work properly, EC2 instances must be
 2. **env Tag** (Optional): Should be either "prod" or "staging" for environment filtering
 
 Example AWS tags:
+
 ```
 Name: "Nexus Proxy Server 1"
 env: "prod"

--- a/scripts/ops/manage-nexus-proxies.sh
+++ b/scripts/ops/manage-nexus-proxies.sh
@@ -205,13 +205,15 @@ execute_on_server_async() {
                 
                 if [ $? -eq 0 ]; then
                     echo -e "${GREEN}✓ Code updated${NC}"
+                    
+                    # Now run the update script
+                    ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ubuntu@$ip \
+                        "cd ~ && ./claude-nexus-proxy/scripts/ops/update-proxy.sh latest proxy" 2>&1
                 else
-                    echo -e "${YELLOW}⚠ Could not pull latest code (continuing)${NC}"
+                    echo -e "${RED}✗ Failed to pull latest code. Aborting update for $name.${NC}"
+                    echo -e "${RED}Please resolve git issues on the server before retrying.${NC}"
+                    exit 1
                 fi
-                
-                # Now run the update script
-                ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ubuntu@$ip \
-                    "cd ~/claude-nexus-proxy && ./scripts/ops/update-proxy.sh latest proxy" 2>&1
                 ;;
             "down")
                 ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ubuntu@$ip \
@@ -258,13 +260,15 @@ execute_on_server() {
             
             if [ $? -eq 0 ]; then
                 echo -e "${GREEN}✓ Code updated${NC}"
+                
+                # Now run the update script
+                ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ubuntu@$ip \
+                    "cd ~ && ./claude-nexus-proxy/scripts/ops/update-proxy.sh latest proxy" 2>&1
             else
-                echo -e "${YELLOW}⚠ Could not pull latest code (continuing)${NC}"
+                echo -e "${RED}✗ Failed to pull latest code. Aborting update for $name.${NC}"
+                echo -e "${RED}Please resolve git issues on the server before retrying.${NC}"
+                return 1
             fi
-            
-            # Now run the update script
-            ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ubuntu@$ip \
-                "cd ~/claude-nexus-proxy && ./scripts/ops/update-proxy.sh latest proxy" 2>&1
             ;;
         "down")
             ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ubuntu@$ip \


### PR DESCRIPTION
## Summary
- Added `--env` flag to filter EC2 instances by environment tag (prod/staging)
- Enhanced operational safety with color-coded environment display
- Maintained backward compatibility for existing workflows

## Changes
1. **Command Line Enhancement**
   - Added `--env {prod < /dev/null | staging}` option for environment-based filtering
   - Updated argument parsing to support the new flag while maintaining compatibility

2. **AWS Query Modification**
   - Modified EC2 instance discovery to include environment tag in results
   - Added conditional filtering based on env tag when `--env` flag is used
   - Gracefully handles instances without env tags (shows as "unknown")

3. **Visual Improvements**
   - Production servers displayed in RED for high visibility
   - Staging servers displayed in YELLOW
   - Environment clearly shown in header and per-server output

4. **Documentation**
   - Added comprehensive README.md for ops scripts
   - Updated usage examples with new functionality
   - Documented AWS tagging requirements

## Benefits
- **Critical Safety Feature**: Prevents accidental operations on wrong environment
- **Better Visibility**: Clear color-coded indication of target environment
- **Flexibility**: Can target all servers, specific environment, or individual server
- **Extensibility**: Pattern can be extended for other filtering needs (region, etc.)

## Testing
- Verified command line parsing with various argument combinations
- Tested error handling for invalid environment values
- Confirmed backward compatibility (no --env flag = all environments)

## Examples
```bash
# Check status on all servers
./manage-nexus-proxies.sh status

# Start proxy on production servers only
./manage-nexus-proxies.sh --env prod up

# Check specific staging server
./manage-nexus-proxies.sh --env staging status server1
```

This implementation follows the consensus recommendations from the AI analysis, emphasizing operational safety and maintainability.