### PR TITLE
feat: improve conversation details page formatting

### DIFF
--- a/services/dashboard/src/storage/reader.ts
+++ b/services/dashboard/src/storage/reader.ts
@@ -623,6 +623,7 @@ export class StorageReader {
         is_subtask: row.is_subtask,
         task_tool_invocation: row.task_tool_invocation,
         body: { last_message: row.last_message },
+        response_body: row.response_body,
       }))
 
       const conversation = {

--- a/services/dashboard/src/storage/reader.ts
+++ b/services/dashboard/src/storage/reader.ts
@@ -575,7 +575,7 @@ export class StorageReader {
 
       const conversationRow = conversationRows[0]
 
-      // Now get all requests for this conversation with optimized last_message
+      // Now get all requests for this conversation with optimized last_message and response_body
       const requestsQuery = `
         SELECT 
           request_id, domain, timestamp, model, 
@@ -583,6 +583,7 @@ export class StorageReader {
           error, request_type, tool_call_count, conversation_id,
           current_message_hash, parent_message_hash, branch_id, message_count,
           parent_task_request_id, is_subtask, task_tool_invocation,
+          response_body,
           CASE 
             WHEN body -> 'messages' IS NOT NULL AND jsonb_array_length(body -> 'messages') > 0 THEN
               body -> 'messages' -> -1

--- a/services/dashboard/src/types/conversation.ts
+++ b/services/dashboard/src/types/conversation.ts
@@ -23,6 +23,7 @@ export interface ConversationRequest {
   is_subtask?: boolean
   task_tool_invocation?: any
   body?: any
+  response_body?: any
 }
 
 export interface ConversationSummary {


### PR DESCRIPTION
## Description

This PR improves the conversation details page to display both the user's last message and Claude's response summary, providing better context at a glance.

## Changes

- **Enhanced database query**: Modified `getConversationById` to include `response_body` in the query
- **New helper function**: Created `getResponseSummary` to extract and format Claude's response
- **Improved UI layout**: 
  - Shows Claude's response summary on the first line (with 🤖 icon)
  - Shows user's last message on the second line (with 👤 icon)
  - Both messages are properly truncated to maintain compact display
  - Better visual separation between user and assistant messages

## Visual Changes

Before: Only showed the last user message (truncated to 80 chars)
After: Shows both Claude's response and user's message with clear visual distinction

## Testing

- Built successfully without errors
- Linting passed (only pre-existing warnings)
- Type definitions updated appropriately

## Implementation Notes

The implementation follows the consensus reached with gemini-2.5-pro, emphasizing:
- High user value with low implementation complexity
- Robust handling of different content types (text, tool_use, tool_result)
- Graceful error handling for missing or malformed responses
- Consistency with existing UI patterns