### PR TITLE
fix: prevent cross-conversation branching in ConversationLinker

### DIFF
--- a/packages/shared/src/utils/db-query-executors.ts
+++ b/packages/shared/src/utils/db-query-executors.ts
@@ -48,6 +48,11 @@ export function createQueryExecutors(pool: Pool): {
       query += ` AND timestamp < $${params.length}`
     }
 
+    if (criteria.conversationId) {
+      params.push(criteria.conversationId)
+      query += ` AND conversation_id = $${params.length}`
+    }
+
     const result = await pool.query(query, params)
     return result.rows
   }


### PR DESCRIPTION
## Summary
- Fixed a bug where the system created unnecessary branches when two independent conversations had the same message content
- Branch detection now only considers messages within the same conversation
- Added defensive null handling for legacy data

## Problem
The ConversationLinker was checking for "existing children" across ALL conversations instead of just within the same conversation. This caused spurious branching when different conversations happened to share similar message content.

Example: Request `5fc62005-1c46-455f-a72a-fe1636074833` was incorrectly placed on branch `branch_20250630111656` instead of `main` because another conversation had already continued from a message with the same hash.

## Solution
1. Added `conversationId` field to `ParentQueryCriteria` interface
2. Updated `findChildrenOfParent` method to accept and pass conversation ID
3. Modified database query executor to filter by conversation ID when provided
4. Added defensive null handling for legacy data without conversation IDs

## Test plan
- [x] Verified the fix with the problematic request using dry-run mode
- [x] Tested that branch detection still works correctly within the same conversation
- [x] Confirmed existing database indexes support the new query pattern
- [ ] Run full conversation rebuild to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)