### PR TITLE
fix: update dashboard service to use .ts imports instead of .js

### DIFF
--- a/services/dashboard/src/app.ts
+++ b/services/dashboard/src/app.ts
@@ -1,14 +1,14 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 // Remove static file serving - will inline CSS instead
-import { container } from './container.js'
-import { loggingMiddleware, logger } from './middleware/logger.js'
+import { container } from './container.ts'
+import { loggingMiddleware, logger } from './middleware/logger.ts'
 // Use the new API-based dashboard routes
-import { dashboardRoutes } from './routes/dashboard-api.js'
-import { conversationDetailRoutes } from './routes/conversation-detail.js'
-import { dashboardAuth } from './middleware/auth.js'
+import { dashboardRoutes } from './routes/dashboard-api.ts'
+import { conversationDetailRoutes } from './routes/conversation-detail.ts'
+import { dashboardAuth } from './middleware/auth.ts'
 import { getErrorMessage, hasStatusCode } from '@claude-nexus/shared'
-import { sparkProxyRoutes } from './routes/spark-proxy.js'
+import { sparkProxyRoutes } from './routes/spark-proxy.ts'
 
 /**
  * Create and configure the Dashboard application

--- a/services/dashboard/src/container.ts
+++ b/services/dashboard/src/container.ts
@@ -1,7 +1,7 @@
 import { Pool } from 'pg'
-import { StorageReader } from './storage/reader.js'
-import { ProxyApiClient } from './services/api-client.js'
-import { logger } from './middleware/logger.js'
+import { StorageReader } from './storage/reader.ts'
+import { ProxyApiClient } from './services/api-client.ts'
+import { logger } from './middleware/logger.ts'
 import { config } from '@claude-nexus/shared/config'
 
 /**

--- a/services/dashboard/src/layout/index.ts
+++ b/services/dashboard/src/layout/index.ts
@@ -1,5 +1,5 @@
 import { html, raw } from 'hono/html'
-import { dashboardStyles } from './styles.js'
+import { dashboardStyles } from './styles.ts'
 
 /**
  * Dashboard HTML layout template

--- a/services/dashboard/src/main.ts
+++ b/services/dashboard/src/main.ts
@@ -30,8 +30,8 @@ for (const envPath of envPaths) {
 
 // Now import other modules after env is loaded
 import { serve } from '@hono/node-server'
-import { createDashboardApp } from './app.js'
-import { container } from './container.js'
+import { createDashboardApp } from './app.ts'
+import { container } from './container.ts'
 
 // Parse command line arguments
 const args = process.argv.slice(2)

--- a/services/dashboard/src/routes/dashboard-api.ts
+++ b/services/dashboard/src/routes/dashboard-api.ts
@@ -1,12 +1,12 @@
 import { Hono } from 'hono'
-import { ProxyApiClient } from '../services/api-client.js'
+import { ProxyApiClient } from '../services/api-client.ts'
 
 // Import route modules
-import { authRoutes } from './auth.js'
-import { overviewRoutes } from './overview.js'
-import { requestsRoutes } from './requests.js'
-import { requestDetailsRoutes } from './request-details.js'
-import { tokenUsageRoutes } from './token-usage.js'
+import { authRoutes } from './auth.ts'
+import { overviewRoutes } from './overview.ts'
+import { requestsRoutes } from './requests.ts'
+import { requestDetailsRoutes } from './request-details.ts'
+import { tokenUsageRoutes } from './token-usage.ts'
 
 export const dashboardRoutes = new Hono<{
   Variables: {

--- a/services/dashboard/src/types/storage-service.ts
+++ b/services/dashboard/src/types/storage-service.ts
@@ -2,7 +2,7 @@
  * Interface for storage service improvements
  */
 
-import type { ConversationSummary } from './conversation.js'
+import type { ConversationSummary } from './conversation.ts'
 
 export interface StorageServiceEnhancements {
   /**

--- a/services/dashboard/src/utils/conversation-graph.ts
+++ b/services/dashboard/src/utils/conversation-graph.ts
@@ -1,4 +1,4 @@
-import { calculateSimpleLayout } from './simple-graph-layout.js'
+import { calculateSimpleLayout } from './simple-graph-layout.ts'
 
 /**
  * Escape HTML special characters

--- a/services/dashboard/src/utils/conversation.ts
+++ b/services/dashboard/src/utils/conversation.ts
@@ -1,7 +1,7 @@
 import { marked } from 'marked'
 import sanitizeHtml from 'sanitize-html'
-import { formatDuration as formatDurationUtil } from './formatters.js'
-import { isSparkRecommendation, parseSparkRecommendation } from './spark.js'
+import { formatDuration as formatDurationUtil } from './formatters.ts'
+import { isSparkRecommendation, parseSparkRecommendation } from './spark.ts'
 import { stripSystemReminder } from '@claude-nexus/shared'
 
 export interface ParsedMessage {

--- a/services/dashboard/src/utils/simple-graph-layout.ts
+++ b/services/dashboard/src/utils/simple-graph-layout.ts
@@ -1,4 +1,4 @@
-import { ConversationGraph, GraphLayout, LayoutNode, LayoutEdge } from './conversation-graph.js'
+import { ConversationGraph, GraphLayout, LayoutNode, LayoutEdge } from './conversation-graph.ts'
 
 /**
  * Simple layout algorithm for conversation graphs

--- a/services/dashboard/tsconfig.json
+++ b/services/dashboard/tsconfig.json
@@ -15,6 +15,8 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "baseUrl": ".",
     "paths": {
       "@claude-nexus/shared": ["../../packages/shared/src/index.ts"],


### PR DESCRIPTION
## Summary
- Updates dashboard service to use `.ts` extensions in imports instead of `.js`
- Adds `allowImportingTsExtensions` and `noEmit` to dashboard's tsconfig.json
- Aligns with root project configuration

## Problem
The dashboard service was using `.js` extensions in imports which caused confusion and potential issues with the dist folder during development. When running `bun run typecheck` or other build commands, the dist folder could interfere with module resolution.

## Solution
- Updated tsconfig.json to enable TypeScript imports with `.ts` extensions
- Changed all import statements from `.js` to `.ts` (total of 22 imports across 10 files)
- Leverages Bun's native TypeScript support for both development and building
- Build process still works because Bun's bundler operates independently of TypeScript compilation

## Testing
- ✅ `bun run typecheck` - passes
- ✅ `bun run build` - creates dist/ successfully
- ✅ `bun run dev` - runs without issues
- ✅ All imports properly resolved

## Benefits
- Eliminates confusion between source (.ts) and compiled (.js) files
- Better developer experience
- Consistent with root project configuration
- No more dist folder interference during development