### PR TITLE
feat: update dashboard to show branch types and include all conversations

### DIFF
--- a/services/dashboard/src/services/api-client.ts
+++ b/services/dashboard/src/services/api-client.ts
@@ -110,6 +110,10 @@ interface ConversationSummary {
   messageCount: number
   totalTokens: number
   branchCount: number
+  // New branch type counts
+  subtaskBranchCount?: number
+  compactBranchCount?: number
+  userBranchCount?: number
   modelsUsed: string[]
   latestRequestId?: string
   latestModel?: string

--- a/services/proxy/src/routes/api.ts
+++ b/services/proxy/src/routes/api.ts
@@ -493,6 +493,10 @@ apiRoutes.get('/conversations', async c => {
           COUNT(*) as message_count,
           SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) as total_tokens,
           COUNT(DISTINCT branch_id) as branch_count,
+          -- Add branch type counts for the new feature
+          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id LIKE 'subtask_%') as subtask_branch_count,
+          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id LIKE 'compact_%') as compact_branch_count,
+          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id IS NOT NULL AND branch_id NOT LIKE 'subtask_%' AND branch_id NOT LIKE 'compact_%') as user_branch_count,
           ARRAY_AGG(DISTINCT model) FILTER (WHERE model IS NOT NULL) as models_used,
           (array_agg(request_id ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_request_id,
           (array_agg(model ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_model,
@@ -537,6 +541,10 @@ apiRoutes.get('/conversations', async c => {
         messageCount: parseInt(row.message_count),
         totalTokens: parseInt(row.total_tokens),
         branchCount: parseInt(row.branch_count),
+        // Add new branch type counts
+        subtaskBranchCount: parseInt(row.subtask_branch_count || 0),
+        compactBranchCount: parseInt(row.compact_branch_count || 0),
+        userBranchCount: parseInt(row.user_branch_count || 0),
         modelsUsed: row.models_used,
         latestRequestId: row.latest_request_id,
         latestModel: row.latest_model,


### PR DESCRIPTION
## Summary

This PR updates the dashboard overview page to align with the new architecture where subtasks are branches of existing conversations rather than separate conversations:

1. **Removed subtask filtering** - All conversations now display at the same level without hierarchy
2. **Enhanced branch column** - Shows branch type counts with icons instead of just a total number
3. **Added UI overflow protection** - Prevents display issues when conversations have many branches

## Changes

### 1. Remove Subtask Filtering
- Removed 40+ lines of complex hierarchical grouping logic from `overview.ts`
- All conversations now display in a flat list, making the dashboard simpler and more accurate

### 2. Branch Type Display
- Added SQL queries to count branch types efficiently:
  - `subtask_branch_count`: Branches matching `subtask_%` pattern
  - `compact_branch_count`: Branches matching `compact_%` pattern  
  - `user_branch_count`: All other non-null branches
- Updated the branches column to show categorized counts with icons:
  - 💻 for subtask branches
  - 📦 for compact branches
  - 🗨 for user branches
- Example display: "2💻, 3📦, 6🗨" instead of just "11"

### 3. UI Improvements
- Added truncation logic: displays "99+..." when total branches exceed 99
- Added hover tooltips showing full branch breakdown (e.g., "Branches: 5 subtasks, 3 compacted, 94 user branches")
- Maintained color coding: blue for multiple branches, gray for single branch

### Technical Details

**Backend (`api.ts`):**
- Modified the conversations SQL query to include branch type counts using `COUNT DISTINCT FILTER` clauses
- Maintained backward compatibility by keeping the original `branchCount` field
- All counting happens at the SQL level for optimal performance

**Frontend (`overview.ts`):**
- Removed complex subtask filtering logic (lines 111-149)
- Updated branch display logic to show categorized counts
- Added overflow protection and tooltips

**Type Definitions (`api-client.ts`):**
- Added optional fields: `subtaskBranchCount`, `compactBranchCount`, `userBranchCount`
- Maintained backward compatibility with existing API consumers

## Testing

- ✅ TypeScript compilation passes
- ✅ Build completes successfully
- ✅ ESLint passes (only existing warnings)
- ✅ Pre-commit hooks pass

## Screenshots

Before: Conversations were filtered and hierarchically grouped, branches showed only a number
After: All conversations display flat, branches show type breakdown with icons

## Review Notes

This change was reviewed by Gemini Pro with the following feedback addressed:
- Added UI overflow protection for conversations with many branches
- Added hover tooltips for better user experience
- Maintained backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)