### PR TITLE
feat(dashboard): hide branch count display when only 1 branch exists

### DIFF
--- a/services/dashboard/src/routes/overview.ts
+++ b/services/dashboard/src/routes/overview.ts
@@ -283,8 +283,9 @@ overviewRoutes.get('/', async c => {
                                   if (parts.length > 0) {
                                     displayText = parts.join(', ')
                                   } else {
-                                    // Just show the number of branches (no icon for main-only conversations)
-                                    displayText = branch.branchCount.toString()
+                                    // Only show branch count if more than 1
+                                    displayText =
+                                      branch.branchCount > 1 ? branch.branchCount.toString() : ''
                                   }
                                   // Truncate if too many branches to prevent UI overflow
                                   const totalBranches =
@@ -299,9 +300,7 @@ overviewRoutes.get('/', async c => {
                                   const titleText =
                                     totalBranches > 0 || hasMultipleBranches
                                       ? `Total branches: ${branch.branchCount} (${branch.subtaskBranchCount} subtasks, ${branch.compactBranchCount} compacted, ${branch.userBranchCount} user branches)`
-                                      : branch.branchCount === 1
-                                        ? 'Single branch (main)'
-                                        : ''
+                                      : '' // No tooltip for single branch with no special types
 
                                   return `<span style="color: ${hasMultipleBranches ? '#2563eb' : '#6b7280'}; font-weight: ${hasMultipleBranches ? '600' : 'normal'};" ${titleText ? `title="${titleText}"` : ''}>
                                     ${displayText}


### PR DESCRIPTION
## Summary
- Hide the branch count display when there's only 1 branch (showing empty string instead of "1")
- Remove unnecessary tooltip for single branches
- Keep display for subtasks and compact branches as requested

## Implementation Details
- Modified `services/dashboard/src/routes/overview.ts` to conditionally display branch count
- Updated tooltip logic to match the empty display for single branches
- No breaking changes - purely visual refinement

## Testing
- Build and type checks pass successfully
- Pre-commit hooks pass
- Manually tested the display behavior

## Screenshots
Before: Single branch conversations showed "1" in gray
After: Single branch conversations show nothing (empty cell)

🤖 Generated with [Claude Code](https://claude.ai/code)