### PR TITLE
feat: add read-only mode support for dashboard without API key

### DIFF
--- a/services/dashboard/src/components/spark-recommendation-inline.ts
+++ b/services/dashboard/src/components/spark-recommendation-inline.ts
@@ -453,22 +453,6 @@ export async function renderSparkRecommendationInline(
         })
       })
 
-      // Helper to get cookie value
-      function getCookie(name) {
-        const value = '; ' + document.cookie
-        const parts = value.split('; ' + name + '=')
-        if (parts.length === 2) return parts.pop().split(';').shift()
-        return ''
-      }
-      
-      // Get dashboard API key from cookie
-      // Note: The dashboard_auth cookie is set with httpOnly=false to allow JavaScript access
-      // This is needed for making authenticated API calls from the browser to the proxy service
-      function getDashboardApiKey() {
-        // Get from cookie - this works because httpOnly is set to false in auth.ts
-        const cookieValue = getCookie('dashboard_auth') || ''
-        return cookieValue
-      }
 
       // Submit feedback
       async function submitInlineSparkFeedback(sessionId) {

--- a/services/dashboard/src/components/spark-recommendation-inline.ts
+++ b/services/dashboard/src/components/spark-recommendation-inline.ts
@@ -11,7 +11,8 @@ export async function renderSparkRecommendationInline(
   recommendation: SparkRecommendation,
   sessionId: string,
   messageIndex: number,
-  existingFeedback?: Record<string, unknown>
+  existingFeedback?: Record<string, unknown>,
+  isReadOnly?: boolean
 ): Promise<string> {
   // Render markdown content
   const dirtyHtml = await marked.parse(recommendation.response)
@@ -105,16 +106,19 @@ export async function renderSparkRecommendationInline(
         <button 
           class="spark-feedback-toggle"
           onclick="toggleSparkFeedback('${sessionId}')"
+          ${isReadOnly ? 'disabled title="Feedback is disabled in read-only mode"' : ''}
         >
           <span class="toggle-icon">▼</span>
-          ${hasFeedback ? 'View Feedback' : 'Add Feedback'}
+          ${hasFeedback ? 'View Feedback' : isReadOnly ? 'Feedback Disabled' : 'Add Feedback'}
         </button>
         
         <div class="spark-inline-feedback" id="${feedbackId}" style="display: none;">
           ${
             hasFeedback
               ? renderInlineExistingFeedback(existingFeedback)
-              : renderInlineFeedbackForm(sessionId)
+              : isReadOnly
+                ? '<p style="text-align: center; color: #64748b; margin: 1rem 0;">Feedback is disabled in read-only mode</p>'
+                : renderInlineFeedbackForm(sessionId)
           }
         </div>
       </div>
@@ -293,8 +297,13 @@ export async function renderSparkRecommendationInline(
         transition: background 0.2s;
       }
 
-      .spark-feedback-toggle:hover {
+      .spark-feedback-toggle:hover:not(:disabled) {
         background: #e0f2fe;
+      }
+
+      .spark-feedback-toggle:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
       }
 
       .toggle-icon {

--- a/services/dashboard/src/config.ts
+++ b/services/dashboard/src/config.ts
@@ -1,0 +1,22 @@
+/**
+ * Dashboard-specific configuration
+ */
+
+/**
+ * Whether the dashboard is running in read-only mode
+ * This is determined by the absence of DASHBOARD_API_KEY
+ */
+export const isReadOnly = !process.env.DASHBOARD_API_KEY
+
+/**
+ * Get the dashboard API key from environment
+ */
+export const dashboardApiKey = process.env.DASHBOARD_API_KEY
+
+/**
+ * Export configuration flags for easy access
+ */
+export const dashboardConfig = {
+  isReadOnly,
+  dashboardApiKey,
+} as const

--- a/services/dashboard/src/layout/styles.ts
+++ b/services/dashboard/src/layout/styles.ts
@@ -241,6 +241,16 @@ export const dashboardStyles = `
   .btn-secondary:hover {
     background: var(--btn-secondary-hover);
   }
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .btn:disabled:hover {
+    background: var(--btn-primary-bg);
+  }
+  .btn-secondary:disabled:hover {
+    background: var(--btn-secondary-bg);
+  }
 
   select {
     padding: 0.5rem;
@@ -1195,6 +1205,58 @@ export const dashboardStyles = `
 
   .status-value.never_synced {
     color: var(--text-muted);
+  }
+  
+  /* Read-only banner styles */
+  .read-only-banner {
+    background: var(--color-warning-bg);
+    color: var(--color-warning-text);
+    padding: 0.75rem 1rem;
+    text-align: center;
+    font-weight: 500;
+    font-size: 0.875rem;
+    border-bottom: 1px solid var(--color-warning);
+  }
+
+  /* Toast notification styles */
+  #toast-container {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 1000;
+  }
+  
+  .toast {
+    background: var(--toast-bg);
+    border: 1px solid var(--toast-border);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    margin-bottom: 0.5rem;
+    max-width: 400px;
+    box-shadow: var(--shadow-md);
+    animation: slideIn 0.3s ease-out;
+  }
+  
+  .toast-error {
+    background: var(--color-error-bg);
+    border-color: var(--color-error);
+  }
+  
+  .toast-message {
+    color: var(--toast-text);
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  
+  @keyframes slideIn {
+    from {
+      transform: translateX(100%);
+      opacity: 0;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
   }
   
   /* Dark mode toggle styles */

--- a/services/dashboard/src/main.ts
+++ b/services/dashboard/src/main.ts
@@ -97,7 +97,7 @@ Options:
 Environment Variables:
   PORT                        Server port (default: 3001)
   HOST                        Server hostname (default: 0.0.0.0)
-  DASHBOARD_API_KEY           API key for dashboard access (required)
+  DASHBOARD_API_KEY           API key for dashboard access (optional - omit for read-only mode)
   DATABASE_URL                PostgreSQL connection string (required)
   PROXY_API_URL               URL of the proxy service for real-time updates (optional)
 
@@ -108,7 +108,8 @@ Examples:
   claude-nexus-dashboard --env-file .env.production
 
 Dashboard Access:
-  The dashboard requires DASHBOARD_API_KEY to be set.
+  If DASHBOARD_API_KEY is set, the dashboard requires authentication.
+  If DASHBOARD_API_KEY is not set, the dashboard runs in read-only mode.
   Access the dashboard at http://localhost:3001/
 
 Note: The dashboard automatically loads .env file from the current directory.
@@ -146,11 +147,7 @@ if (hostIndex !== -1 && args[hostIndex + 1]) {
 // Main function
 async function main() {
   try {
-    // Validate required configuration
-    if (!process.env.DASHBOARD_API_KEY) {
-      console.error('❌ Error: DASHBOARD_API_KEY environment variable is required')
-      process.exit(1)
-    }
+    // Note: DASHBOARD_API_KEY is now optional - if not set, dashboard runs in read-only mode
 
     if (!process.env.DATABASE_URL && !process.env.DB_HOST) {
       console.error('❌ Error: DATABASE_URL or DB_* environment variables are required')
@@ -162,7 +159,9 @@ async function main() {
     console.log('Mode: Web Dashboard for monitoring and analytics')
 
     console.log('\nConfiguration:')
-    console.log(`  - Authentication: Configured`)
+    console.log(
+      `  - Mode: ${process.env.DASHBOARD_API_KEY ? 'Authenticated (read-write)' : 'Read-only (no auth required)'}`
+    )
     console.log(`  - Database: ${process.env.DATABASE_URL ? 'URL configured' : 'Host configured'}`)
 
     if (process.env.PROXY_API_URL) {

--- a/services/dashboard/src/middleware/auth.ts
+++ b/services/dashboard/src/middleware/auth.ts
@@ -1,11 +1,21 @@
-import { Context, Next } from 'hono'
+import { Context, Next, MiddlewareHandler } from 'hono'
 import { getCookie } from 'hono/cookie'
+import { isReadOnly, dashboardApiKey } from '../config.js'
+
+export type AuthContext = {
+  isAuthenticated: boolean
+  isReadOnly: boolean
+}
 
 /**
  * Dashboard authentication middleware
  * Protects dashboard routes with API key authentication
+ * Supports read-only mode when DASHBOARD_API_KEY is not set
  */
-export const dashboardAuth = async (c: Context, next: Next) => {
+export const dashboardAuth: MiddlewareHandler<{ Variables: { auth: AuthContext } }> = async (
+  c,
+  next
+) => {
   // Skip auth for login page
   if (
     c.req.path === '/dashboard/login' ||
@@ -16,9 +26,20 @@ export const dashboardAuth = async (c: Context, next: Next) => {
     return next()
   }
 
+  // Set read-only mode in context
+  c.set('auth', {
+    isAuthenticated: false,
+    isReadOnly: isReadOnly,
+  })
+
+  // If in read-only mode, allow access without authentication
+  if (isReadOnly) {
+    return next()
+  }
+
   // Check for dashboard API key in environment
-  const dashboardKey = process.env.DASHBOARD_API_KEY
-  if (!dashboardKey) {
+  if (!dashboardApiKey) {
+    // This should not happen given the isReadOnly check above, but keep for safety
     return c.html(
       `
       <div style="text-align: center; padding: 50px; font-family: sans-serif;">
@@ -32,13 +53,21 @@ export const dashboardAuth = async (c: Context, next: Next) => {
 
   // Check cookie authentication
   const authCookie = getCookie(c, 'dashboard_auth')
-  if (authCookie === dashboardKey) {
+  if (authCookie === dashboardApiKey) {
+    c.set('auth', {
+      isAuthenticated: true,
+      isReadOnly: false,
+    })
     return next()
   }
 
   // Check header authentication (for API calls)
   const headerKey = c.req.header('X-Dashboard-Key')
-  if (headerKey === dashboardKey) {
+  if (headerKey === dashboardApiKey) {
+    c.set('auth', {
+      isAuthenticated: true,
+      isReadOnly: false,
+    })
     return next()
   }
 
@@ -57,6 +86,46 @@ export const dashboardAuth = async (c: Context, next: Next) => {
 
   // Return 401 for API requests
   return c.json({ error: 'Unauthorized' }, 401)
+}
+
+/**
+ * Middleware to protect write routes in read-only mode
+ * This should be applied globally to POST, PUT, DELETE, PATCH methods
+ */
+export const protectWriteRoutes: MiddlewareHandler<{ Variables: { auth: AuthContext } }> = async (
+  c,
+  next
+) => {
+  const auth = c.get('auth')
+
+  // If in read-only mode, block ALL write operations regardless of authentication
+  if (auth?.isReadOnly) {
+    // Return user-friendly error for HTMX requests
+    const hxRequest = c.req.header('HX-Request')
+    if (hxRequest) {
+      // Prevent HTMX from swapping the main content
+      c.header('HX-Reswap', 'none')
+      c.header('HX-Retarget', '#toast-container')
+
+      return c.html(
+        `<div id="toast-container" class="toast toast-error" hx-swap-oob="true">
+          <div class="toast-message">This action is not available in read-only mode.</div>
+        </div>`,
+        403
+      )
+    }
+
+    // Return JSON error for API requests
+    return c.json(
+      {
+        error: 'Forbidden',
+        message: 'The dashboard is in read-only mode. Write operations are not allowed.',
+      },
+      403
+    )
+  }
+
+  return next()
 }
 
 /**

--- a/services/dashboard/src/middleware/auth.ts
+++ b/services/dashboard/src/middleware/auth.ts
@@ -89,46 +89,6 @@ export const dashboardAuth: MiddlewareHandler<{ Variables: { auth: AuthContext }
 }
 
 /**
- * Middleware to protect write routes in read-only mode
- * This should be applied globally to POST, PUT, DELETE, PATCH methods
- */
-export const protectWriteRoutes: MiddlewareHandler<{ Variables: { auth: AuthContext } }> = async (
-  c,
-  next
-) => {
-  const auth = c.get('auth')
-
-  // If in read-only mode, block ALL write operations regardless of authentication
-  if (auth?.isReadOnly) {
-    // Return user-friendly error for HTMX requests
-    const hxRequest = c.req.header('HX-Request')
-    if (hxRequest) {
-      // Prevent HTMX from swapping the main content
-      c.header('HX-Reswap', 'none')
-      c.header('HX-Retarget', '#toast-container')
-
-      return c.html(
-        `<div id="toast-container" class="toast toast-error" hx-swap-oob="true">
-          <div class="toast-message">This action is not available in read-only mode.</div>
-        </div>`,
-        403
-      )
-    }
-
-    // Return JSON error for API requests
-    return c.json(
-      {
-        error: 'Forbidden',
-        message: 'The dashboard is in read-only mode. Write operations are not allowed.',
-      },
-      403
-    )
-  }
-
-  return next()
-}
-
-/**
  * Optional: Domain-scoped authentication
  * Allows restricting dashboard access to specific domains
  */

--- a/services/dashboard/src/middleware/csrf.ts
+++ b/services/dashboard/src/middleware/csrf.ts
@@ -19,6 +19,12 @@ function generateToken(): string {
  */
 export function csrfProtection() {
   return async (c: Context, next: Next) => {
+    // Skip CSRF protection in read-only mode since all writes are blocked
+    const auth = c.get('auth')
+    if (auth?.isReadOnly) {
+      return next()
+    }
+
     const method = c.req.method.toUpperCase()
 
     // Get or generate CSRF token

--- a/services/dashboard/src/middleware/rate-limit.ts
+++ b/services/dashboard/src/middleware/rate-limit.ts
@@ -1,0 +1,70 @@
+import { Context, MiddlewareHandler } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+import { isReadOnly } from '../config.js'
+
+interface RateLimitData {
+  count: number
+  resetTime: number
+}
+
+// In-memory store for rate limiting (per IP)
+const rateLimitStore = new Map<string, RateLimitData>()
+
+/**
+ * Rate limiting middleware for read-only mode
+ * Only applies when dashboard is in read-only mode to prevent abuse
+ */
+export const rateLimitForReadOnly = (
+  requests = 100, // 100 requests
+  windowMs = 60000 // per minute
+): MiddlewareHandler => {
+  return async (c: Context, next) => {
+    // Only apply rate limiting in read-only mode
+    if (!isReadOnly) {
+      return next()
+    }
+
+    // Get client IP
+    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown'
+
+    const now = Date.now()
+    const data = rateLimitStore.get(ip) || {
+      count: 0,
+      resetTime: now + windowMs,
+    }
+
+    // Reset if window has passed
+    if (now > data.resetTime) {
+      data.count = 0
+      data.resetTime = now + windowMs
+    }
+
+    data.count++
+    rateLimitStore.set(ip, data)
+
+    // Add rate limit headers
+    c.header('X-RateLimit-Limit', requests.toString())
+    c.header('X-RateLimit-Remaining', Math.max(0, requests - data.count).toString())
+    c.header('X-RateLimit-Reset', new Date(data.resetTime).toISOString())
+
+    // Check if limit exceeded
+    if (data.count > requests) {
+      throw new HTTPException(429, {
+        message: 'Too many requests. Please try again later.',
+      })
+    }
+
+    await next()
+  }
+}
+
+// Cleanup old entries periodically to prevent memory leaks
+setInterval(() => {
+  const now = Date.now()
+  for (const [ip, data] of rateLimitStore.entries()) {
+    if (now > data.resetTime + 300000) {
+      // 5 minutes after reset
+      rateLimitStore.delete(ip)
+    }
+  }
+}, 300000) // Every 5 minutes

--- a/services/dashboard/src/middleware/rate-limit.ts
+++ b/services/dashboard/src/middleware/rate-limit.ts
@@ -24,8 +24,11 @@ export const rateLimitForReadOnly = (
       return next()
     }
 
-    // Get client IP
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown'
+    // Get client IP - parse X-Forwarded-For carefully to avoid spoofing
+    const xff = c.req.header('x-forwarded-for')
+    // Take the first IP from the comma-separated list (original client)
+    // Note: This can still be spoofed if not behind a trusted proxy
+    const ip = xff ? xff.split(',')[0].trim() : c.req.header('x-real-ip') || 'unknown'
 
     const now = Date.now()
     const data = rateLimitStore.get(ip) || {

--- a/services/dashboard/src/routes/auth.ts
+++ b/services/dashboard/src/routes/auth.ts
@@ -3,6 +3,7 @@ import { html } from 'hono/html'
 import { setCookie } from 'hono/cookie'
 import { timingSafeEqual } from 'crypto'
 import { layout } from '../layout/index.js'
+import { isReadOnly } from '../config.js'
 
 export const authRoutes = new Hono()
 
@@ -10,6 +11,10 @@ export const authRoutes = new Hono()
  * Login page
  */
 authRoutes.get('/login', c => {
+  // If in read-only mode, redirect to dashboard
+  if (isReadOnly) {
+    return c.redirect('/dashboard')
+  }
   const content = html`
     <div
       style="max-width: 400px; margin: 4rem auto; background: white; padding: 2rem; border-radius: 0.5rem; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);"
@@ -43,6 +48,11 @@ authRoutes.get('/login', c => {
  * Handle login POST
  */
 authRoutes.post('/login', async c => {
+  // If in read-only mode, redirect to dashboard
+  if (isReadOnly) {
+    return c.redirect('/dashboard')
+  }
+
   const { key } = await c.req.parseBody()
   const apiKey = process.env.DASHBOARD_API_KEY
 

--- a/services/dashboard/src/routes/auth.ts
+++ b/services/dashboard/src/routes/auth.ts
@@ -67,7 +67,7 @@ authRoutes.post('/login', async c => {
 
   if (isValid) {
     setCookie(c, 'dashboard_auth', key as string, {
-      httpOnly: false, // Allow JavaScript access for API calls from the dashboard
+      httpOnly: true, // Prevent client-side script access for security
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'Lax',
       maxAge: 60 * 60 * 24 * 7, // 7 days

--- a/services/dashboard/src/routes/partials/analysis.ts
+++ b/services/dashboard/src/routes/partials/analysis.ts
@@ -189,7 +189,7 @@ function renderIdlePanel(
 ) {
   const defaultPrompt = getAnalysisPromptTemplate()
   const promptId = `prompt-${conversationId}-${branchId}`.replace(/[^a-zA-Z0-9-]/g, '-')
-  const isReadOnly = auth?.isReadOnly && !auth?.isAuthenticated
+  const isReadOnly = !!auth?.isReadOnly
 
   return html`
     <div id="analysis-panel" class="section">
@@ -369,7 +369,7 @@ function renderCompletedPanel(
   analysisResponse: GetAnalysisResponse,
   auth?: { isAuthenticated: boolean; isReadOnly: boolean }
 ) {
-  const isReadOnly = auth?.isReadOnly && !auth?.isAuthenticated
+  const isReadOnly = !!auth?.isReadOnly
   const formatDate = (date: string | Date) => {
     const d = new Date(date)
     return d.toLocaleString('en-US', {
@@ -1029,7 +1029,7 @@ function renderFailedPanel(
   errorMessage?: string | null,
   auth?: { isAuthenticated: boolean; isReadOnly: boolean }
 ) {
-  const isReadOnly = auth?.isReadOnly && !auth?.isAuthenticated
+  const isReadOnly = !!auth?.isReadOnly
   return html`
     <div id="analysis-panel" class="section">
       <div class="section-header" style="display: flex; align-items: center; gap: 0.75rem;">


### PR DESCRIPTION
## Summary

- Adds support for running the dashboard in read-only mode when `DASHBOARD_API_KEY` is not set
- Allows public access to view dashboard data without authentication
- Prevents all write operations through multiple layers of protection

## Motivation

This feature enables users to deploy the dashboard for public viewing without requiring authentication, useful for:
- Demo/showcase purposes
- Public status pages
- Read-only monitoring dashboards

## Implementation Details

### Core Changes

1. **Configuration (`config.ts`)**
   - Added `isReadOnly` flag based on absence of `DASHBOARD_API_KEY`

2. **Authentication Middleware**
   - Updated to allow unauthenticated access in read-only mode
   - Sets auth context with `isReadOnly` flag

3. **Write Protection**
   - Global `app.on()` hook blocks all POST/PUT/DELETE/PATCH methods
   - API client throws `ReadOnlyModeError` before making write requests
   - UI elements (buttons, forms) are disabled with visual indicators

4. **Rate Limiting**
   - Applied only in read-only mode (100 requests/minute per IP)
   - Includes cleanup mechanism to prevent memory leaks

5. **User Experience**
   - Visual banner indicating read-only mode
   - Toast notifications for HTMX requests
   - Disabled buttons with explanatory tooltips

### Security Improvements (from code review)

- Set `httpOnly: true` on auth cookie to prevent XSS attacks
- Improved rate limiter IP detection
- Skip CSRF protection in read-only mode (optimization)
- Simplified read-only logic in UI components

## Testing

- [x] Dashboard loads without `DASHBOARD_API_KEY`
- [x] All write operations are blocked
- [x] Visual indicators work correctly
- [x] Rate limiting functions properly
- [x] Authentication still works when `DASHBOARD_API_KEY` is set

## Breaking Changes

None - this is a backward-compatible feature addition.

## Deployment Notes

To enable read-only mode, simply deploy without setting `DASHBOARD_API_KEY`. The dashboard will automatically run in read-only mode with all protections enabled.

🤖 Generated with [Claude Code](https://claude.ai/code)