### PR TITLE
feat: make Docker Compose automatically create network

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -146,4 +146,3 @@ volumes:
 networks:
   default:
     name: claude-nexus-network
-    external: true

--- a/scripts/ops/update-proxy.sh
+++ b/scripts/ops/update-proxy.sh
@@ -6,6 +6,11 @@
 #   ./update-proxy.sh v8          # Updates both containers
 #   ./update-proxy.sh v8 proxy    # Updates only proxy
 #   ./update-proxy.sh v8 dashboard # Updates only dashboard
+#
+# IMPORTANT: This script uses 'docker run' to redeploy services.
+# Any configuration changes made to the 'proxy' or 'dashboard' services
+# in 'docker/docker-compose.yml' (e.g., environment variables, volumes)
+# MUST be manually duplicated here to avoid configuration drift.
 
 VERSION=$1
 SERVICE=$2
@@ -78,10 +83,11 @@ update_dashboard() {
     fi
 }
 
-# Check if network exists, create if it doesn't
-if ! docker network ls | grep -q claude-nexus-network; then
-    echo "Creating Docker network claude-nexus-network..."
-    docker network create claude-nexus-network
+# Check that the network managed by Docker Compose exists.
+if ! docker network ls | grep -q "claude-nexus-network"; then
+    echo "Error: Docker network 'claude-nexus-network' not found."
+    echo "The environment must be initialized first. Please run './docker-up.sh up -d' from the project root."
+    exit 1
 fi
 
 # Update based on service parameter


### PR DESCRIPTION
## Summary

- Removes `external: true` from docker-compose.yml network configuration
- Docker Compose now automatically creates and manages the network lifecycle
- Simplifies setup and ensures proper cleanup

## Changes

1. **docker/docker-compose.yml**: Removed `external: true` from the network configuration, allowing Docker Compose to manage the network
2. **scripts/ops/update-proxy.sh**: 
   - Added guard clause to check network exists before updating containers
   - Added warning comment about configuration drift between this script and docker-compose.yml

## Benefits

- 🚀 **Simplified Setup**: No need for manual `docker network create` step
- 🧹 **Automatic Cleanup**: Network is removed on `docker compose down`
- 🔧 **Better CI/CD**: Single command deployment without prerequisites
- 👥 **Easier Onboarding**: New developers can start with just `./docker-up.sh up -d`

## Migration Guide for Existing Users

Your current setup will continue to work without changes. However, for a cleaner environment and to let Docker Compose fully manage the network, we recommend a one-time migration:

```bash
# Stop services
./docker-up.sh down

# Remove the manually created network
docker network rm claude-nexus-network

# Start services (network will be auto-created)
./docker-up.sh up -d
```

## Test Plan

- [x] Verified network is automatically created on `docker-up.sh up -d`
- [x] Confirmed network is managed by Compose (via `docker network inspect`)
- [x] Verified network is removed on `docker-up.sh down`
- [x] Tested update-proxy.sh fails gracefully when network doesn't exist
- [x] Checked documentation and CI/CD for network creation references (none found)

🤖 Generated with [Claude Code](https://claude.ai/code)