### PR TITLE
feat: enhance token usage display with 7-day sliding window chart

### DIFF
--- a/services/dashboard/src/routes/token-usage.ts
+++ b/services/dashboard/src/routes/token-usage.ts
@@ -123,13 +123,13 @@ tokenUsageRoutes.get('/token-usage', async c => {
                   `
 
                           return `
-                    <div style="height: 100px; border: 1px solid #e5e7eb; border-radius: 0.5rem; padding: 10px; background: white;">
+                    <div style="height: 120px; border: 1px solid #e5e7eb; border-radius: 0.5rem; padding: 15px; background: white;">
                       <a href="/dashboard/token-usage?accountId=${encodeURIComponent(account.accountId)}" style="text-decoration: none; color: inherit; display: block;">
-                        <div style="display: flex; align-items: flex-start; gap: 15px; height: 100%;">
+                        <div style="display: flex; align-items: flex-start; gap: 20px; height: 100%;">
                           <div style="flex: 1; min-width: 0;">
-                            <div style="display: flex; align-items: baseline; gap: 10px; margin-bottom: 5px;">
-                              <strong style="font-size: 14px; color: #1f2937;">${escapeHtml(account.accountId)}</strong>
-                              <span style="font-size: 12px; color: ${
+                            <div style="display: flex; align-items: baseline; gap: 10px; margin-bottom: 8px;">
+                              <strong style="font-size: 16px; color: #1f2937;">${escapeHtml(account.accountId)}</strong>
+                              <span style="font-size: 14px; color: ${
                                 account.percentageUsed > 90
                                   ? '#ef4444'
                                   : account.percentageUsed > 70
@@ -140,12 +140,12 @@ tokenUsageRoutes.get('/token-usage', async c => {
                                 (${account.percentageUsed.toFixed(1)}% used)
                               </span>
                             </div>
-                            <div style="display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px;">
+                            <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px;">
                               ${account.domains
                                 .map(
                                   domain => `
-                                <div style="font-size: 11px; color: #6b7280; background: #f3f4f6; padding: 2px 6px; border-radius: 3px;">
-                                  <span style="color: #374151;">${escapeHtml(domain.domain)}:</span>
+                                <div style="font-size: 12px; color: #6b7280; background: #f3f4f6; padding: 4px 8px; border-radius: 4px;">
+                                  <span style="color: #374151; font-weight: 500;">${escapeHtml(domain.domain)}:</span>
                                   ${formatNumber(domain.outputTokens)} tokens
                                   (${((domain.outputTokens / account.outputTokens) * 100).toFixed(0)}%)
                                 </div>
@@ -154,7 +154,7 @@ tokenUsageRoutes.get('/token-usage', async c => {
                                 .join('')}
                             </div>
                           </div>
-                          <div style="width: 200px; height: 60px; flex-shrink: 0;">
+                          <div style="width: 300px; height: 80px; flex-shrink: 0;">
                             <canvas id="${chartId}" style="width: 100%; height: 100%;"></canvas>
                           </div>
                         </div>
@@ -193,19 +193,27 @@ tokenUsageRoutes.get('/token-usage', async c => {
 
   try {
     // Fetch all data in parallel
-    const [tokenUsageWindow, dailyUsageResult, rateLimitsResult, timeSeriesResult] =
-      await Promise.allSettled([
-        apiClient.getTokenUsageWindow({ accountId, domain, window: 300 }), // 5 hour window
-        apiClient.getDailyTokenUsage({ accountId, domain, days: 30, aggregate: true }),
-        apiClient.getRateLimitConfigs({ accountId }),
-        apiClient.getTokenUsageTimeSeries({ accountId, window: 5, interval: 5 }), // 5-hour window, 5-minute intervals
-      ])
+    const [
+      tokenUsageWindow,
+      dailyUsageResult,
+      rateLimitsResult,
+      timeSeriesResult,
+      slidingWindowResult,
+    ] = await Promise.allSettled([
+      apiClient.getTokenUsageWindow({ accountId, domain, window: 300 }), // 5 hour window
+      apiClient.getDailyTokenUsage({ accountId, domain, days: 30, aggregate: true }),
+      apiClient.getRateLimitConfigs({ accountId }),
+      apiClient.getTokenUsageTimeSeries({ accountId, window: 5, interval: 5 }), // 5-hour window, 5-minute intervals
+      apiClient.getSlidingWindowUsage({ accountId, days: 7, bucketMinutes: 10, windowHours: 5 }), // 7-day sliding window
+    ])
 
     // Handle results
     const tokenUsage = tokenUsageWindow.status === 'fulfilled' ? tokenUsageWindow.value : null
     const dailyUsage = dailyUsageResult.status === 'fulfilled' ? dailyUsageResult.value.usage : []
     const rateLimits = rateLimitsResult.status === 'fulfilled' ? rateLimitsResult.value.configs : []
     const timeSeries = timeSeriesResult.status === 'fulfilled' ? timeSeriesResult.value : null
+    const slidingWindow =
+      slidingWindowResult.status === 'fulfilled' ? slidingWindowResult.value : null
 
     // Find the primary rate limit for this account
     const primaryLimit =
@@ -481,6 +489,213 @@ tokenUsageRoutes.get('/token-usage', async c => {
                 `
               })()
             : html` <p class="text-gray-500">No time series data available.</p> `}
+        </div>
+      </div>
+
+      <!-- 7-Day Sliding Window Chart -->
+      <div class="section">
+        <div class="section-header">7-Day Token Usage (5-Hour Sliding Windows)</div>
+        <div class="section-content">
+          ${slidingWindow && slidingWindow.data.length > 0
+            ? (() => {
+                const chartId = 'slidingWindowChart'
+                const chartScript = `
+              // Prepare sliding window chart data
+              const slidingData = ${JSON.stringify(
+                slidingWindow.data.map(point => ({
+                  time: new Date(point.time_bucket).toLocaleString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  }),
+                  tokens: point.sliding_window_tokens,
+                  hasWarning: point.rate_limit_warning_in_window,
+                }))
+              )};
+              
+              const tokenLimit = 140000; // 5-hour sliding window limit
+              
+              // Wait for canvas to be ready
+              setTimeout(() => {
+                const canvas = document.getElementById('${chartId}');
+                if (!canvas) return;
+                
+                const ctx = canvas.getContext('2d');
+                const rect = canvas.getBoundingClientRect();
+                canvas.width = rect.width * window.devicePixelRatio;
+                canvas.height = rect.height * window.devicePixelRatio;
+                ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+                
+                const padding = { top: 20, right: 20, bottom: 100, left: 80 };
+                const chartWidth = rect.width - padding.left - padding.right;
+                const chartHeight = rect.height - padding.top - padding.bottom;
+                
+                // Clear canvas
+                ctx.fillStyle = '#ffffff';
+                ctx.fillRect(0, 0, rect.width, rect.height);
+                
+                // Draw axes
+                ctx.strokeStyle = '#e5e7eb';
+                ctx.lineWidth = 1;
+                ctx.beginPath();
+                ctx.moveTo(padding.left, padding.top);
+                ctx.lineTo(padding.left, padding.top + chartHeight);
+                ctx.lineTo(padding.left + chartWidth, padding.top + chartHeight);
+                ctx.stroke();
+                
+                // Draw horizontal grid lines and Y-axis labels
+                ctx.fillStyle = '#6b7280';
+                ctx.font = '12px sans-serif';
+                ctx.textAlign = 'right';
+                
+                const ySteps = 5;
+                for (let i = 0; i <= ySteps; i++) {
+                  const y = padding.top + (chartHeight * i / ySteps);
+                  const value = tokenLimit * (1 - i / ySteps);
+                  
+                  // Grid line
+                  ctx.strokeStyle = '#f3f4f6';
+                  ctx.beginPath();
+                  ctx.moveTo(padding.left, y);
+                  ctx.lineTo(padding.left + chartWidth, y);
+                  ctx.stroke();
+                  
+                  // Label
+                  ctx.fillStyle = '#6b7280';
+                  ctx.fillText(formatNumber(value), padding.left - 10, y + 4);
+                }
+                
+                // Draw X-axis labels (show every nth label to avoid crowding)
+                ctx.save();
+                ctx.textAlign = 'right';
+                ctx.translate(0, padding.top + chartHeight + 20);
+                const labelInterval = Math.ceil(slidingData.length / 15);
+                slidingData.forEach((point, index) => {
+                  if (index % labelInterval === 0 || index === slidingData.length - 1) {
+                    const x = padding.left + (index / (slidingData.length - 1)) * chartWidth;
+                    ctx.save();
+                    ctx.translate(x, 0);
+                    ctx.rotate(-Math.PI / 4);
+                    ctx.fillText(point.time, 0, 0);
+                    ctx.restore();
+                  }
+                });
+                ctx.restore();
+                
+                // Determine if we have any warnings
+                const hasAnyWarning = slidingData.some(p => p.hasWarning);
+                const currentHasWarning = slidingData[slidingData.length - 1]?.hasWarning || false;
+                
+                // Draw the usage line with segments
+                ctx.lineWidth = 2;
+                let lastWarningState = slidingData[0]?.hasWarning || false;
+                let segmentStart = 0;
+                
+                // Function to draw a line segment
+                const drawSegment = (startIdx, endIdx, hasWarning) => {
+                  ctx.beginPath();
+                  for (let i = startIdx; i <= endIdx; i++) {
+                    const x = padding.left + (i / (slidingData.length - 1)) * chartWidth;
+                    const y = padding.top + (1 - slidingData[i].tokens / tokenLimit) * chartHeight;
+                    
+                    if (i === startIdx) {
+                      ctx.moveTo(x, y);
+                    } else {
+                      ctx.lineTo(x, y);
+                    }
+                  }
+                  ctx.strokeStyle = hasWarning ? '#ef4444' : '#10b981';
+                  ctx.stroke();
+                };
+                
+                // Draw segments based on warning state changes
+                for (let i = 1; i < slidingData.length; i++) {
+                  if (slidingData[i].hasWarning !== lastWarningState) {
+                    drawSegment(segmentStart, i - 1, lastWarningState);
+                    segmentStart = i - 1; // Overlap by one point for continuity
+                    lastWarningState = slidingData[i].hasWarning;
+                  }
+                }
+                // Draw the final segment
+                drawSegment(segmentStart, slidingData.length - 1, lastWarningState);
+                
+                // Draw warning indicators as dots
+                ctx.fillStyle = '#ef4444';
+                slidingData.forEach((point, index) => {
+                  if (point.hasWarning) {
+                    const x = padding.left + (index / (slidingData.length - 1)) * chartWidth;
+                    const y = padding.top + (1 - point.tokens / tokenLimit) * chartHeight;
+                    ctx.beginPath();
+                    ctx.arc(x, y, 3, 0, Math.PI * 2);
+                    ctx.fill();
+                  }
+                });
+                
+                // Draw current point
+                const lastPoint = slidingData[slidingData.length - 1];
+                const lastX = padding.left + chartWidth;
+                const lastY = padding.top + (1 - lastPoint.tokens / tokenLimit) * chartHeight;
+                
+                ctx.fillStyle = currentHasWarning ? '#ef4444' : '#10b981';
+                ctx.beginPath();
+                ctx.arc(lastX, lastY, 5, 0, Math.PI * 2);
+                ctx.fill();
+                
+                // Draw current value label
+                ctx.fillStyle = '#1f2937';
+                ctx.font = '14px sans-serif';
+                ctx.textAlign = 'right';
+                ctx.fillText(
+                  formatNumber(lastPoint.tokens) + ' tokens',
+                  lastX - 10,
+                  lastY - 10
+                );
+                
+                // Add axis labels
+                ctx.fillStyle = '#374151';
+                ctx.font = '14px sans-serif';
+                ctx.textAlign = 'center';
+                ctx.fillText('Time (7 Days)', padding.left + chartWidth / 2, rect.height - 10);
+                
+                ctx.save();
+                ctx.translate(15, padding.top + chartHeight / 2);
+                ctx.rotate(-Math.PI / 2);
+                ctx.fillText('Output Tokens (5-Hour Window)', 0, 0);
+                ctx.restore();
+                
+                // Add legend
+                const legendY = padding.top - 10;
+                ctx.font = '12px sans-serif';
+                
+                // Normal usage
+                ctx.fillStyle = '#10b981';
+                ctx.fillRect(padding.left + chartWidth - 200, legendY, 12, 12);
+                ctx.fillStyle = '#374151';
+                ctx.textAlign = 'left';
+                ctx.fillText('Normal', padding.left + chartWidth - 185, legendY + 10);
+                
+                // Rate limited
+                ctx.fillStyle = '#ef4444';
+                ctx.fillRect(padding.left + chartWidth - 120, legendY, 12, 12);
+                ctx.fillStyle = '#374151';
+                ctx.fillText('Rate Limited', padding.left + chartWidth - 105, legendY + 10);
+                
+                // Helper function
+                function formatNumber(num) {
+                  return num.toLocaleString();
+                }
+              }, 100);
+            `
+
+                return html`
+                  <div style="width: 100%; height: 500px; position: relative;">
+                    <canvas id="${chartId}" style="width: 100%; height: 100%;"></canvas>
+                  </div>
+                  ${raw(`<script>${chartScript}</script>`)}
+                `
+              })()
+            : html` <p class="text-gray-500">No sliding window data available.</p> `}
         </div>
       </div>
 

--- a/services/dashboard/src/services/api-client.ts
+++ b/services/dashboard/src/services/api-client.ts
@@ -417,6 +417,69 @@ export class ProxyApiClient {
   }
 
   /**
+   * Get sliding window token usage with rate limit status
+   */
+  async getSlidingWindowUsage(params: {
+    accountId: string
+    days?: number
+    bucketMinutes?: number
+    windowHours?: number
+  }): Promise<{
+    accountId: string
+    params: {
+      days: number
+      bucketMinutes: number
+      windowHours: number
+    }
+    data: Array<{
+      time_bucket: string
+      sliding_window_tokens: number
+      rate_limit_warning_in_window: boolean
+    }>
+  }> {
+    try {
+      const url = new URL('/api/analytics/token-usage/sliding-window', this.baseUrl)
+      url.searchParams.set('accountId', params.accountId)
+      if (params.days) {
+        url.searchParams.set('days', params.days.toString())
+      }
+      if (params.bucketMinutes) {
+        url.searchParams.set('bucketMinutes', params.bucketMinutes.toString())
+      }
+      if (params.windowHours) {
+        url.searchParams.set('windowHours', params.windowHours.toString())
+      }
+
+      const response = await fetch(url.toString(), {
+        headers: this.getHeaders(),
+      })
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status} ${response.statusText}`)
+      }
+
+      return (await response.json()) as {
+        accountId: string
+        params: {
+          days: number
+          bucketMinutes: number
+          windowHours: number
+        }
+        data: Array<{
+          time_bucket: string
+          sliding_window_tokens: number
+          rate_limit_warning_in_window: boolean
+        }>
+      }
+    } catch (error) {
+      logger.error('Failed to fetch sliding window usage from proxy API', {
+        error: getErrorMessage(error),
+        params,
+      })
+      throw error
+    }
+  }
+
+  /**
    * Get all accounts with their token usage
    */
   async getAccountsTokenUsage(): Promise<{


### PR DESCRIPTION
## Summary
- Added 7-day sliding window token usage chart with 5-hour sliding windows
- Implemented rate limit detection using `anthropic-ratelimit-unified-status` header
- Enhanced UI with bigger token usage boxes and dynamic color coding

## Key Changes
1. **New getSlidingWindowUsage method** in TokenUsageService:
   - Calculates cumulative 5-hour sliding windows over a configurable period
   - Uses 10-minute bucket aggregation for performance
   - Detects rate limit warnings from response headers

2. **New API endpoint** `/api/analytics/token-usage/sliding-window`:
   - Configurable parameters: days (1-30), bucketMinutes (1-60), windowHours (1-24)
   - Includes NaN validation for all parameters
   - Returns time-bucketed data with rate limit status

3. **Enhanced Dashboard UI**:
   - Token usage boxes now 120px height with 300px chart width
   - New 7-day sliding window chart (500px height)
   - Red/green line segments based on rate limit status (not token threshold)
   - Red dots indicate data points with rate limit warnings
   - Rotated X-axis labels for better readability
   - Legend showing color meanings

## Security & Performance
- Fixed SQL injection vulnerability with parameterized queries
- Fixed column ambiguity error in SQL query
- 10-minute bucket aggregation reduces data points from 10,080 to 1,008 for 7 days
- GIN index on response_body already exists for efficient JSONB searches

## Test plan
- [x] Verify 7-day sliding window chart displays correctly
- [x] Confirm rate limit detection works with `allowed_warning` status
- [x] Test parameter validation (days, bucketMinutes, windowHours)
- [x] Verify SQL query performance with large datasets
- [x] Check chart color changes based on rate limit status
- [ ] Test with accounts that have experienced rate limiting
- [ ] Verify chart responsiveness on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)