### PR TITLE
feat: add nexus logo to dashboard header

### DIFF
--- a/services/dashboard/src/components/logo.ts
+++ b/services/dashboard/src/components/logo.ts
@@ -1,0 +1,36 @@
+/**
+ * Nexus logo component - A simple SVG representing interconnected nodes
+ * Uses currentColor to automatically adapt to light/dark themes
+ */
+export const nexusLogo = (): string => {
+  return `
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="1.2em"
+      height="1.2em"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      style="display: inline-block; vertical-align: middle;"
+    >
+      <!-- Central node -->
+      <circle cx="12" cy="12" r="3"/>
+      
+      <!-- Outer nodes -->
+      <circle cx="12" cy="4" r="2"/>
+      <circle cx="20" cy="12" r="2"/>
+      <circle cx="12" cy="20" r="2"/>
+      <circle cx="4" cy="12" r="2"/>
+      
+      <!-- Connections -->
+      <path d="M12 9 L12 7"/>
+      <path d="M15 12 L18 12"/>
+      <path d="M12 15 L12 18"/>
+      <path d="M9 12 L6 12"/>
+    </svg>
+  `
+}

--- a/services/dashboard/src/layout/index.ts
+++ b/services/dashboard/src/layout/index.ts
@@ -1,6 +1,7 @@
 import { html, raw } from 'hono/html'
 import { dashboardStyles } from './styles.js'
 import { Context } from 'hono'
+import { nexusLogo } from '../components/logo.js'
 
 /**
  * Dashboard HTML layout template
@@ -203,7 +204,10 @@ export const layout = (
         }
         <nav>
           <div class="container">
-            <h1>Claude Nexus Dashboard</h1>
+            <h1 style="display: flex; align-items: center; gap: 0.5rem;">
+              ${raw(nexusLogo())}
+              <span>Claude Nexus Dashboard</span>
+            </h1>
             <div class="space-x-4" style="display: flex; align-items: center;">
               <a href="/dashboard" class="text-sm text-blue-600">Dashboard</a>
               <a href="/dashboard/requests" class="text-sm text-blue-600">Requests</a>


### PR DESCRIPTION
## Summary
- Added a simple SVG logo next to the dashboard title
- Logo represents a nexus with interconnected nodes
- Automatically adapts to light/dark theme using currentColor
- Scales proportionally with text for better accessibility

## Changes
- Created new logo component at `services/dashboard/src/components/logo.ts`
- Modified dashboard layout to include the logo next to the title
- Used flexbox for proper alignment
- Logo uses relative units (em) for responsive scaling

## Visual
The logo shows a central node connected to 4 outer nodes, representing the nexus concept.