### PR TITLE
E2E: Verify page rendering and console errors for all dashboard pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,26 @@ bun run ai:reset-stuck         # Reset jobs with high retry counts
 
 See [DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines.
 
+### E2E Testing (Playwright)
+
+Playwright tests live under `/e2e` and validate dashboard pages render without console errors.
+
+```bash
+# One-time: install Playwright browsers
+npx playwright install --with-deps
+
+# Run all Playwright tests (auto-starts dashboard on :3001)
+npm run test:playwright
+
+# UI mode
+npm run test:playwright:ui
+
+# Run a single spec
+npx playwright test e2e/pages-render.test.ts --project=chromium
+```
+
+Requirements: a PostgreSQL instance and `.env` configured for the dashboard (DATABASE*URL or DB*\*). The Playwright config launches `bun run dev:dashboard` at `http://localhost:3001`.
+
 ## Deployment
 
 ### Environments (MoonsongLabs Internal)

--- a/docs/01-Getting-Started/development.md
+++ b/docs/01-Getting-Started/development.md
@@ -124,11 +124,32 @@ bun run build:shared
 
 ### Testing
 
-Run tests:
+Run unit/integration tests:
 
 ```bash
 bun test
 ```
+
+E2E testing (Playwright):
+
+```bash
+# One-time: install browsers
+npx playwright install --with-deps
+
+# Run all e2e tests (auto-starts dashboard on :3001)
+npm run test:playwright
+
+# UI mode for debugging
+npm run test:playwright:ui
+
+# Run a single spec
+npx playwright test e2e/pages-render.test.ts --project=chromium
+```
+
+Requirements:
+
+- PostgreSQL accessible and `.env` configured (DATABASE*URL or DB*\* variables)
+- Playwright config launches `bun run dev:dashboard` with base URL `http://localhost:3001`
 
 Test specific functionality:
 

--- a/e2e/pages-render.test.ts
+++ b/e2e/pages-render.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+// List of dashboard pages to verify
+const routes: { path: string; expectSelector?: string }[] = [
+  { path: '/dashboard', expectSelector: 'nav' },
+  { path: '/dashboard/requests', expectSelector: 'body' },
+  { path: '/dashboard/token-usage', expectSelector: 'body' },
+  { path: '/dashboard/usage', expectSelector: 'body' },
+  { path: '/dashboard/prompts', expectSelector: 'body' },
+  // In read-only mode, login may redirect to /dashboard, but still ensure no errors
+  { path: '/dashboard/login', expectSelector: 'body' },
+]
+
+test.describe('Page rendering and console errors', () => {
+  for (const { path, expectSelector } of routes) {
+    test(`renders ${path} without console errors`, async ({ page, baseURL }) => {
+      const errors: string[] = []
+
+      page.on('console', msg => {
+        if (msg.type() === 'error') {
+          errors.push(`[console.error] ${msg.text()}`)
+        }
+      })
+
+      page.on('pageerror', err => {
+        errors.push(`[pageerror] ${String(err)}`)
+      })
+
+      const response = await page.goto(path, { waitUntil: 'domcontentloaded' })
+
+      // Ensure navigation succeeded (allow 2xx/3xx)
+      expect(response, `No response for ${path}`).not.toBeNull()
+      const status = response!.status()
+      expect(status, `Unexpected HTTP status ${status} for ${path}`).toBeLessThan(400)
+
+      // If redirected, ensure final URL still on the same origin
+      if (baseURL) {
+        const base = new URL(baseURL)
+        const current = new URL(page.url())
+        expect(current.origin).toBe(base.origin)
+      }
+
+      if (expectSelector) {
+        await expect(page.locator(expectSelector)).toBeVisible()
+      }
+
+      // Wait for network to settle a bit for client-side fetches
+      await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {})
+
+      // Assert no console errors or page errors captured
+      expect(
+        errors,
+        errors.length ? `Errors on ${path}:\n${errors.join('\n')}` : 'no errors'
+      ).toHaveLength(0)
+    })
+  }
+})
+

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,7 +59,6 @@ export default defineConfig({
   webServer: {
     command: 'bun run dev:dashboard',
     url: 'http://localhost:3001',
-    port: 3001,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },

--- a/services/dashboard/README.md
+++ b/services/dashboard/README.md
@@ -22,7 +22,7 @@ The dashboard service provides a web UI for monitoring and analyzing Claude API 
 
 ## Development
 
-```bash
+````bash
 # Install dependencies
 cd services/dashboard
 bun install
@@ -35,6 +35,27 @@ bun run build
 
 # Run tests
 bun test
+
+### E2E (Playwright)
+
+Repository-level Playwright tests exercise the dashboard UI end-to-end.
+
+```bash
+# One-time: install Playwright browsers
+npx playwright install --with-deps
+
+# From repo root: run e2e tests (auto-starts dashboard on :3001)
+npm run test:playwright
+
+# UI mode
+npm run test:playwright:ui
+````
+
+Requirements:
+
+- A PostgreSQL instance and `.env` configured (DATABASE*URL or DB*\* vars)
+- The dashboard will be launched by Playwright via `bun run dev:dashboard`
+
 ```
 
 ## Configuration
@@ -73,3 +94,4 @@ The service provides read-only access to the database:
 - Dashboard routes with HTMX for dynamic updates
 - SSE for real-time monitoring
 - Chart.js for data visualization
+```


### PR DESCRIPTION
This PR adds a Playwright test that navigates core dashboard routes (/dashboard, /dashboard/requests, /dashboard/token-usage, /dashboard/usage, /dashboard/prompts, /dashboard/login) and asserts successful rendering with zero console or page errors. It also corrects the Playwright webServer config to use only URL as required by Playwright 1.53.\n\nNotes:\n- Uses existing dev server command (bun run dev:dashboard).\n- Keeps retries only on CI.\n- Safe to extend by adding more routes when new pages are added.