### PR TITLE
feat: display XML tags in dashboard conversation view

### DIFF
--- a/docs/06-Reference/changelog.md
+++ b/docs/06-Reference/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Display of XML tags in dashboard conversation view (e.g., `<system-reminder>`, `<command>`) instead of filtering them
 - Conversation branching visualization in dashboard
 - Message count tracking at database level for performance
 - Branch-specific statistics in conversation view


### PR DESCRIPTION
## Summary
- Changed dashboard conversation view to display XML tags instead of filtering them
- XML tags like `<system-reminder>`, `<command>` are now visible as text
- Maintains security through proper HTML escaping

## Implementation Details
The implementation uses a targeted escaping approach:
1. Parse markdown with `marked` (which passes XML tags through as HTML)
2. Escape disallowed tags using `escapeDisallowedTags()` function
3. Sanitize the HTML as usual

This ensures XML tags display as text while preserving markdown formatting and security.

## Changes Made
- Added `escapeDisallowedTags()` helper function to escape non-allowed HTML tags
- Removed all `stripSystemReminder()` imports and usage
- Applied escaping between markdown parsing and HTML sanitization
- Updated changelog documentation

## Test Plan
- [x] Build passes with `bun run build`
- [x] TypeScript check passes with `bun run typecheck`
- [x] Tested escaping pipeline manually - XML tags display correctly
- [ ] Manual testing in dashboard UI

🤖 Generated with [Claude Code](https://claude.ai/code)