### PR TITLE
feat: change dashboard tool result colors from green to purple

### DIFF
--- a/services/dashboard/src/layout/__tests__/styles.test.ts
+++ b/services/dashboard/src/layout/__tests__/styles.test.ts
@@ -131,12 +131,12 @@ describe('Dark Mode CSS Variables', () => {
     expect(lightVars['--msg-user-bg']).toBe('#eff6ff')
     expect(lightVars['--msg-assistant-bg']).toBe('#ffffff')
     expect(lightVars['--msg-tool-use-bg']).toBe('#fef3c7')
-    expect(lightVars['--msg-tool-result-bg']).toBe('#dcfce7')
+    expect(lightVars['--msg-tool-result-bg']).toBe('#f3e8ff')
 
     // Dark theme message colors
     expect(darkVars['--msg-user-bg']).toBe('#1e3a8a')
     expect(darkVars['--msg-assistant-bg']).toBe('#1e293b')
     expect(darkVars['--msg-tool-use-bg']).toBe('#78350f')
-    expect(darkVars['--msg-tool-result-bg']).toBe('#14532d')
+    expect(darkVars['--msg-tool-result-bg']).toBe('#4c1d95')
   })
 })

--- a/services/dashboard/src/layout/styles.ts
+++ b/services/dashboard/src/layout/styles.ts
@@ -56,8 +56,8 @@ export const dashboardStyles = `
     --msg-system-border: #9ca3af;
     --msg-tool-use-bg: #fef3c7;
     --msg-tool-use-border: #f59e0b;
-    --msg-tool-result-bg: #dcfce7;
-    --msg-tool-result-border: #22c55e;
+    --msg-tool-result-bg: #f3e8ff;
+    --msg-tool-result-border: #9333ea;
     
     /* Code block colors */
     --code-bg: #1e293b;
@@ -117,8 +117,8 @@ export const dashboardStyles = `
     --msg-system-border: #6b7280;
     --msg-tool-use-bg: #78350f;
     --msg-tool-use-border: #f59e0b;
-    --msg-tool-result-bg: #14532d;
-    --msg-tool-result-border: #22c55e;
+    --msg-tool-result-bg: #4c1d95;
+    --msg-tool-result-border: #9333ea;
     
     /* Code block colors */
     --code-bg: #0f172a;


### PR DESCRIPTION
## Summary
- Changed tool result colors in the dashboard from green to purple
- Affects the request details page where tool results are displayed
- Maintains consistency across light and dark themes

## Changes
- Updated CSS variables in `services/dashboard/src/layout/styles.ts`:
  - Light theme: `--msg-tool-result-bg: #f3e8ff` and `--msg-tool-result-border: #9333ea`
  - Dark theme: `--msg-tool-result-bg: #4c1d95` and `--msg-tool-result-border: #9333ea`
- Updated test expectations in `services/dashboard/src/layout/__tests__/styles.test.ts`

## Testing
- ✅ All tests pass (`bun test`)
- ✅ TypeScript checks pass (`bun run typecheck`)
- ✅ WCAG AA accessibility compliant (contrast ratios: 13.14:1 light, 10.41:1 dark)

## Visual Impact
Tool results in the dashboard will now display with purple backgrounds and borders instead of green, providing a fresh visual distinction while maintaining excellent readability.

🤖 Generated with [Claude Code](https://claude.ai/code)