### PR TITLE
fix(proxy): add fallback for missing accountId in wildcard credentials

### DIFF
--- a/docs/02-User-Guide/authentication.md
+++ b/docs/02-User-Guide/authentication.md
@@ -59,7 +59,7 @@ Most common and straightforward method:
 ```json
 {
   "type": "api_key",
-  "accountId": "acc_unique_identifier",
+  "accountId": "production", // Required: Identifies account in dashboard
   "api_key": "sk-ant-api03-...",
   "client_api_key": "cnp_live_..."
 }
@@ -72,7 +72,7 @@ For enhanced security and automatic token management:
 ```json
 {
   "type": "oauth",
-  "accountId": "acc_unique_identifier",
+  "accountId": "staging-team", // Required: Identifies account in dashboard
   "client_api_key": "cnp_live_...",
   "oauth": {
     "accessToken": "...",
@@ -83,6 +83,14 @@ For enhanced security and automatic token management:
   }
 }
 ```
+
+**Important**: The `accountId` field is required and will be displayed in the dashboard to identify which account/team is making requests. Use descriptive names like:
+
+- `production`, `staging`, `development`
+- `team-frontend`, `team-backend`
+- `client-acme`, `client-globex`
+
+If `accountId` is missing, the system will derive one from the filename and log a warning.
 
 ## Setting Up Authentication
 
@@ -100,7 +108,7 @@ For API key authentication:
 cat > credentials/your-domain.com.credentials.json << EOF
 {
   "type": "api_key",
-  "accountId": "acc_$(uuidgen)",
+  "accountId": "your-project-name",
   "api_key": "sk-ant-your-claude-api-key",
   "client_api_key": "$(bun run scripts/generate-api-key.ts)"
 }

--- a/docs/04-Architecture/ADRs/adr-023-wildcard-subdomain-support.md
+++ b/docs/04-Architecture/ADRs/adr-023-wildcard-subdomain-support.md
@@ -102,16 +102,42 @@ Credentials are resolved in order of specificity:
 
 ### Configuration Examples
 
-```
+```json
 # Wildcard for all staging subdomains
-_wildcard.staging.example.com.credentials.json
+# File: _wildcard.staging.example.com.credentials.json
+{
+  "type": "api_key",
+  "apiKey": "sk-...",
+  "accountId": "staging-environment"  // IMPORTANT: Required for dashboard display
+}
 
 # Wildcard for all subdomains of example.com
-_wildcard.example.com.credentials.json
+# File: _wildcard.example.com.credentials.json
+{
+  "type": "oauth",
+  "oauth": { ... },
+  "accountId": "production"  // IMPORTANT: Required for dashboard display
+}
 
-# Exact match (takes precedence)
-api.staging.example.com.credentials.json
+# Exact match (takes precedence over wildcards)
+# File: api.staging.example.com.credentials.json
+{
+  "type": "api_key",
+  "apiKey": "sk-...",
+  "accountId": "api-staging"  // IMPORTANT: Required for dashboard display
+}
 ```
+
+### Account ID Fallback Behavior
+
+When the `accountId` field is missing from a credential file, the system will:
+
+1. Derive an accountId from the credential filename
+2. Log a warning (once per file) recommending to add an explicit accountId
+3. For wildcard files: `_wildcard.example.com.credentials.json` → `accountId: "example.com"`
+4. For exact files: `api.example.com.credentials.json` → `accountId: "api.example.com"`
+
+**Best Practice**: Always include an explicit `accountId` field in credential files to ensure consistent dashboard display and avoid relying on the fallback mechanism.
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the dashboard shows "account: N/A" when using wildcard subdomain credentials that lack an `accountId` field.

## Problem

When using wildcard credentials (e.g., `_wildcard.cla.test.io.credentials.json`) with `ANTHROPIC_BASE_URL=https://alan.cla.test.io`, the authentication works correctly but the dashboard displays "account: N/A" because:
- The `accountId` field is optional in credential files
- Wildcard credentials often omit this field
- The system had no fallback mechanism

## Solution  

Added a fallback mechanism that derives `accountId` from the credential filename when missing:
- For wildcard files: `_wildcard.example.com.credentials.json` → `accountId: "example.com"`
- For exact files: `api.example.com.credentials.json` → `accountId: "api.example.com"`

## Changes

- ✅ Added `deriveAccountIdFromPath` helper to extract domain from filename
- ✅ Added `maybeWarnAccountFallback` to log warnings once per credential file
- ✅ Updated authentication methods to use fallback when accountId is missing
- ✅ Added comprehensive tests for accountId derivation
- ✅ Updated documentation to clarify accountId requirements

## Testing

- All existing tests pass
- Added 4 new test cases for accountId derivation
- Tested with various credential filename patterns

## Backward Compatibility

✅ Fully backward compatible:
- Existing credentials with `accountId` continue working unchanged
- Missing `accountId` now falls back to derived value
- Warning logs help users identify and fix missing fields

## Documentation

Updated:
- ADR-023: Added accountId fallback behavior section
- Authentication guide: Clarified accountId requirements with examples

🤖 Generated with [Claude Code](https://claude.ai/code)