### PR TITLE
refactor: add explicit container lifecycle

### DIFF
--- a/services/proxy/src/__tests__/container.test.ts
+++ b/services/proxy/src/__tests__/container.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { container, initializeContainer, disposeContainer } from '../container.js'
+
+const originalStorageEnabled = process.env.STORAGE_ENABLED
+const originalDatabaseUrl = process.env.DATABASE_URL
+
+describe('Container lifecycle', () => {
+  beforeEach(async () => {
+    await disposeContainer()
+    process.env.STORAGE_ENABLED = 'false'
+    delete process.env.DATABASE_URL
+  })
+
+  afterEach(async () => {
+    await disposeContainer()
+
+    if (originalStorageEnabled === undefined) {
+      delete process.env.STORAGE_ENABLED
+    } else {
+      process.env.STORAGE_ENABLED = originalStorageEnabled
+    }
+
+    if (originalDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL
+    } else {
+      process.env.DATABASE_URL = originalDatabaseUrl
+    }
+  })
+
+  it('throws when accessing services before initialization', () => {
+    expect(() => container.getMetricsService()).toThrow('MetricsService not initialized')
+  })
+
+  it('initializes and cleans up services', async () => {
+    await initializeContainer()
+
+    expect(() => container.getMetricsService()).not.toThrow()
+
+    await disposeContainer()
+
+    expect(() => container.getMetricsService()).toThrow('MetricsService not initialized')
+  })
+})

--- a/services/proxy/src/app.ts
+++ b/services/proxy/src/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
-import { container } from './container.js'
+import { container, initializeContainer } from './container.js'
 import { config, validateConfig } from '@agent-prompttrain/shared/config'
 import { loggingMiddleware, logger } from './middleware/logger.js'
 import { requestIdMiddleware } from './middleware/request-id.js'
@@ -27,6 +27,9 @@ export async function createProxyApp(): Promise<
 > {
   // Validate configuration
   validateConfig()
+
+  // Ensure container dependencies are ready
+  await initializeContainer()
 
   // Initialize external services
   await initializeExternalServices()
@@ -256,7 +259,7 @@ export async function createProxyApp(): Promise<
 
   // Root endpoint
   app.get('/', c => {
-    const endpoints: any = {
+    const endpoints: Record<string, unknown> = {
       api: '/v1/messages',
       health: '/health',
       stats: '/token-stats',


### PR DESCRIPTION
## Summary
- add async init/cleanup lifecycle for proxy container
- ensure bootstrap calls initialization and uses dispose helper on shutdown
- cover lifecycle with a Bun test

## Testing
- bun test services/proxy/src/__tests__/container.test.ts
