### PR TITLE
feat: add list-analyses script & fix model_used in analysis creation

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -208,6 +208,62 @@ Updates proxy deployment.
 ./scripts/ops/update-proxy.sh
 ```
 
+## AI Analysis Scripts
+
+### list-analyses.ts
+
+Lists recent AI analyses as a formatted table. Shows status, model, token usage, duration, and error details for failed analyses.
+
+```bash
+# Show last 20 analyses (default)
+bun run scripts/list-analyses.ts
+
+# Show last N analyses
+bun run scripts/list-analyses.ts 50
+```
+
+Requires `DATABASE_URL` environment variable.
+
+### check-analysis-jobs.ts
+
+Checks the status of pending, processing, completed, and failed analysis jobs.
+
+```bash
+bun run scripts/check-analysis-jobs.ts
+```
+
+### check-analysis-content.ts
+
+Inspects the content and structured data of a specific analysis.
+
+```bash
+bun run scripts/check-analysis-content.ts <conversation_id>
+```
+
+### process-pending-analyses.ts
+
+Manually triggers processing of pending analysis jobs.
+
+```bash
+bun run scripts/process-pending-analyses.ts
+```
+
+### reset-stuck-analysis-jobs.ts
+
+Resets analysis jobs that have exceeded max retries back to pending.
+
+```bash
+bun run scripts/reset-stuck-analysis-jobs.ts
+```
+
+### fail-exceeded-retry-jobs.ts
+
+Marks analysis jobs that have exceeded max retries as permanently failed.
+
+```bash
+bun run scripts/fail-exceeded-retry-jobs.ts
+```
+
 ## Test Scripts (`test/`)
 
 Testing utilities and scripts for validating proxy functionality.

--- a/scripts/db/migrations/022-update-analysis-model-default.ts
+++ b/scripts/db/migrations/022-update-analysis-model-default.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+
+/**
+ * Migration 022: Update conversation_analyses model_used default
+ *
+ * The original default was 'gemini-2.5-pro' from when the feature used Gemini.
+ * Now that analysis routes through the local proxy with ANTHROPIC_ANALYSIS_MODEL,
+ * the column default should reflect the current code default: 'claude-opus-4-6'.
+ *
+ * Also updates any existing pending rows that still have the stale default.
+ */
+
+import { Pool } from 'pg'
+import { config } from 'dotenv'
+
+config()
+
+async function main() {
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+  })
+
+  try {
+    console.log('Migration 022: Update analysis model_used default\n')
+
+    // Update the column default
+    console.log("1. Updating column default from 'gemini-2.5-pro' to 'claude-opus-4-6'...")
+    await pool.query(`
+      ALTER TABLE conversation_analyses
+      ALTER COLUMN model_used SET DEFAULT 'claude-opus-4-6'
+    `)
+    console.log('   Done.')
+
+    // Fix existing pending/processing rows that have the stale default
+    console.log('2. Updating pending/processing rows with stale model_used...')
+    const result = await pool.query(`
+      UPDATE conversation_analyses
+      SET model_used = 'claude-opus-4-6'
+      WHERE status IN ('pending', 'processing')
+        AND model_used = 'gemini-2.5-pro'
+    `)
+    console.log(`   Updated ${result.rowCount} rows.`)
+
+    console.log('\nMigration 022 complete.')
+  } catch (error) {
+    console.error('Migration failed:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+main()

--- a/scripts/list-analyses.ts
+++ b/scripts/list-analyses.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env bun
+
+/**
+ * List recent AI analyses as a formatted table.
+ *
+ * Usage:
+ *   bun run scripts/list-analyses.ts [count]
+ *
+ * Arguments:
+ *   count  Number of analyses to display (default: 20)
+ *
+ * Environment:
+ *   DATABASE_URL  PostgreSQL connection string (loaded from .env)
+ */
+
+import { Pool } from 'pg'
+import { config } from 'dotenv'
+
+config()
+
+interface AnalysisRow {
+  id: string
+  conversation_id: string
+  branch_id: string
+  status: string
+  model_used: string
+  retry_count: number
+  prompt_tokens: number | null
+  completion_tokens: number | null
+  processing_duration_ms: number | null
+  error_message: string | null
+  created_at: Date
+  completed_at: Date | null
+}
+
+function truncate(str: string, max: number): string {
+  if (str.length <= max) return str
+  return str.slice(0, max - 1) + '…'
+}
+
+function pad(str: string, len: number): string {
+  return str.padEnd(len).slice(0, len)
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '-'
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function formatTokens(prompt: number | null, completion: number | null): string {
+  if (prompt === null && completion === null) return '-'
+  return `${prompt ?? 0}/${completion ?? 0}`
+}
+
+function formatDate(date: Date | null): string {
+  if (!date) return '-'
+  const d = new Date(date)
+  return d.toISOString().replace('T', ' ').slice(0, 19)
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'completed':
+      return 'OK'
+    case 'failed':
+      return 'FAIL'
+    case 'pending':
+      return 'PEND'
+    case 'processing':
+      return 'PROC'
+    default:
+      return status.toUpperCase().slice(0, 4)
+  }
+}
+
+async function main() {
+  const limit = Math.max(1, parseInt(process.argv[2] || '20', 10))
+
+  if (!process.env.DATABASE_URL) {
+    console.error('Error: DATABASE_URL is not set. Ensure .env is configured.')
+    process.exit(1)
+  }
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+
+  try {
+    const { rows } = await pool.query<AnalysisRow>(
+      `
+      SELECT
+        id,
+        conversation_id,
+        branch_id,
+        status,
+        model_used,
+        retry_count,
+        prompt_tokens,
+        completion_tokens,
+        processing_duration_ms,
+        error_message,
+        created_at,
+        completed_at
+      FROM conversation_analyses
+      ORDER BY created_at DESC
+      LIMIT $1
+    `,
+      [limit]
+    )
+
+    if (rows.length === 0) {
+      console.log('No analyses found.')
+      return
+    }
+
+    // Column widths
+    const cols = {
+      id: 5,
+      status: 4,
+      conversation: 12,
+      branch: 8,
+      model: 20,
+      retries: 3,
+      tokens: 13,
+      duration: 7,
+      created: 19,
+    }
+
+    const header = [
+      pad('ID', cols.id),
+      pad('STAT', cols.status),
+      pad('CONVERSATION', cols.conversation),
+      pad('BRANCH', cols.branch),
+      pad('MODEL', cols.model),
+      pad('RTY', cols.retries),
+      pad('TOKENS (P/C)', cols.tokens),
+      pad('DURATIO', cols.duration),
+      pad('CREATED', cols.created),
+    ].join(' | ')
+
+    const separator = header.replace(/[^|]/g, '-').replace(/\|/g, '+')
+
+    console.log(`\nLast ${rows.length} AI Analyses:\n`)
+    console.log(header)
+    console.log(separator)
+
+    const failedRows: AnalysisRow[] = []
+
+    for (const row of rows) {
+      const line = [
+        pad(String(row.id), cols.id),
+        pad(statusIcon(row.status), cols.status),
+        pad(truncate(row.conversation_id, cols.conversation), cols.conversation),
+        pad(truncate(row.branch_id, cols.branch), cols.branch),
+        pad(truncate(row.model_used || '-', cols.model), cols.model),
+        pad(String(row.retry_count), cols.retries),
+        pad(formatTokens(row.prompt_tokens, row.completion_tokens), cols.tokens),
+        pad(formatDuration(row.processing_duration_ms), cols.duration),
+        pad(formatDate(row.created_at), cols.created),
+      ].join(' | ')
+      console.log(line)
+
+      if (row.status === 'failed' && row.error_message) {
+        failedRows.push(row)
+      }
+    }
+
+    // Summary
+    const counts = rows.reduce(
+      (acc, r) => {
+        acc[r.status] = (acc[r.status] || 0) + 1
+        return acc
+      },
+      {} as Record<string, number>
+    )
+
+    console.log(
+      `\nSummary: ${rows.length} total — ` +
+        Object.entries(counts)
+          .map(([s, c]) => `${c} ${s}`)
+          .join(', ')
+    )
+
+    // Failed analyses detail
+    if (failedRows.length > 0) {
+      console.log(`\n=== Failed Analyses (${failedRows.length}) ===\n`)
+      for (const row of failedRows) {
+        console.log(`ID ${row.id} | Conversation: ${row.conversation_id}`)
+        console.log(`  Branch: ${row.branch_id} | Retries: ${row.retry_count}`)
+        console.log(`  Created: ${formatDate(row.created_at)}`)
+        const error =
+          typeof row.error_message === 'string'
+            ? row.error_message
+            : JSON.stringify(row.error_message)
+        console.log(`  Error: ${error}`)
+        console.log()
+      }
+    }
+  } catch (error) {
+    console.error('Error querying analyses:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+main()

--- a/services/proxy/src/routes/analyses.ts
+++ b/services/proxy/src/routes/analyses.ts
@@ -11,6 +11,7 @@ import {
   conversationBranchParamsSchema,
   MSL_PROJECT_ID_HEADER_LOWER,
 } from '@agent-prompttrain/shared'
+import { ANTHROPIC_ANALYSIS_CONFIG } from '@agent-prompttrain/shared/config'
 
 // Request/Response schemas
 const createAnalysisSchema = z.object({
@@ -125,11 +126,17 @@ analysisRoutes.post('/', rateLimitAnalysisCreation(), async c => {
 
     // Create new analysis request
     const insertResult = await pool.query(
-      `INSERT INTO conversation_analyses 
-       (conversation_id, branch_id, status, custom_prompt, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, NOW(), NOW())
+      `INSERT INTO conversation_analyses
+       (conversation_id, branch_id, status, model_used, custom_prompt, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
        RETURNING id`,
-      [conversationId, branchId, ConversationAnalysisStatus.PENDING, customPrompt || null]
+      [
+        conversationId,
+        branchId,
+        ConversationAnalysisStatus.PENDING,
+        ANTHROPIC_ANALYSIS_CONFIG.MODEL_NAME,
+        customPrompt || null,
+      ]
     )
 
     const analysisId = insertResult.rows[0].id
@@ -334,19 +341,30 @@ analysisRoutes.post(
         // Update existing analysis to pending
         analysisId = existingResult.rows[0].id
         await pool.query(
-          `UPDATE conversation_analyses 
-         SET status = $1, updated_at = NOW(), retry_count = retry_count + 1, custom_prompt = $3
+          `UPDATE conversation_analyses
+         SET status = $1, model_used = $3, updated_at = NOW(), retry_count = retry_count + 1, custom_prompt = $4
          WHERE id = $2`,
-          [ConversationAnalysisStatus.PENDING, analysisId, customPrompt || null]
+          [
+            ConversationAnalysisStatus.PENDING,
+            analysisId,
+            ANTHROPIC_ANALYSIS_CONFIG.MODEL_NAME,
+            customPrompt || null,
+          ]
         )
       } else {
         // Create new analysis
         const insertResult = await pool.query(
-          `INSERT INTO conversation_analyses 
-         (conversation_id, branch_id, status, custom_prompt, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, NOW(), NOW())
+          `INSERT INTO conversation_analyses
+         (conversation_id, branch_id, status, model_used, custom_prompt, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
          RETURNING id`,
-          [conversationId, branchId, ConversationAnalysisStatus.PENDING, customPrompt || null]
+          [
+            conversationId,
+            branchId,
+            ConversationAnalysisStatus.PENDING,
+            ANTHROPIC_ANALYSIS_CONFIG.MODEL_NAME,
+            customPrompt || null,
+          ]
         )
         analysisId = insertResult.rows[0].id
       }


### PR DESCRIPTION
## Summary
- Adds `scripts/list-analyses.ts` — lists the last N AI analyses as a formatted table (default 20)
- **Fixes bug**: analysis INSERT queries did not set `model_used`, falling back to stale DB default `gemini-2.5-pro` instead of the configured model
- Now sets `model_used` from `ANTHROPIC_ANALYSIS_CONFIG.MODEL_NAME` at creation and regeneration time
- Adds migration 022 to update DB column default and fix existing pending rows
- Documents all AI analysis scripts in `scripts/README.md`

## Changes
### New: `scripts/list-analyses.ts`
```bash
bun run scripts/list-analyses.ts      # last 20
bun run scripts/list-analyses.ts 50   # last 50
```
Shows status, model, token usage, duration, and error details for failed analyses.

### Fix: `services/proxy/src/routes/analyses.ts`
- All 3 query paths (create, regenerate-update, regenerate-insert) now explicitly set `model_used`
- Import `ANTHROPIC_ANALYSIS_CONFIG` from shared config

### Migration: `scripts/db/migrations/022-update-analysis-model-default.ts`
- Updates column default from `gemini-2.5-pro` to `claude-opus-4-6`
- Fixes existing pending/processing rows with stale model value

## Test plan
- [x] Typecheck passes
- [x] Script runs successfully against database
- [x] Migration tested locally (updated 3 stale rows)
- [x] Verified pending analyses now show correct model
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)