### PR TITLE
feat: include private projects in token usage dashboard

### DIFF
--- a/docs/04-Architecture/ADRs/adr-029-project-privacy-model.md
+++ b/docs/04-Architecture/ADRs/adr-029-project-privacy-model.md
@@ -22,7 +22,12 @@ We implement a **selective privacy model** focused on protecting conversation co
    - Only project members can view conversations, requests, and message content
    - Non-members receive empty results when querying private project data
 
-3. **Member lists and API keys are visible** to all authenticated users
+3. **Token usage statistics include all projects** (public and private)
+   - Rationale: Aggregate usage stats (token counts, request counts) provide operational value without exposing conversation content
+   - Private projects appear with a privacy indicator in the token usage dashboard
+   - Linked projects from the `project_accounts` junction table are included even without recent activity
+
+4. **Member lists and API keys are visible** to all authenticated users
    - Rationale: This is an internal company dashboard where team composition transparency is valued
    - Partial API key visibility helps with debugging and audit trails
 

--- a/services/dashboard/src/routes/partials/analytics.ts
+++ b/services/dashboard/src/routes/partials/analytics.ts
@@ -190,10 +190,11 @@ analyticsPartialRoutes.get('/partials/analytics', async c => {
                               .slice(0, 3)
                               .map(
                                 d => `
-                              <div style="font-size: 11px; color: #6b7280; background: #f3f4f6; padding: 2px 6px; border-radius: 3px;">
-                                <span style="color: #374151;">${escapeHtml(d.projectId)}:</span>
+                              <div style="font-size: 11px; color: #6b7280; background: ${d.isPrivate ? '#fef3c7' : '#f3f4f6'}; padding: 2px 6px; border-radius: 3px; ${d.outputTokens === 0 ? 'opacity: 0.6;' : ''}">
+                                ${d.isPrivate ? '<span title="Private project">&#128274;</span> ' : ''}
+                                <span style="color: #374151;">${escapeHtml(d.projectName || d.projectId)}:</span>
                                 ${formatNumber(d.outputTokens)} tokens
-                                (${((d.outputTokens / account.outputTokens) * 100).toFixed(0)}%)
+                                ${account.outputTokens > 0 ? `(${((d.outputTokens / account.outputTokens) * 100).toFixed(0)}%)` : ''}
                               </div>
                             `
                               )

--- a/services/dashboard/src/routes/token-usage.ts
+++ b/services/dashboard/src/routes/token-usage.ts
@@ -420,10 +420,11 @@ tokenUsageRoutes.get('/token-usage', async c => {
                               ${account.trainIds
                                 .map(
                                   projectId => `
-                                <div style="font-size: 12px; color: #6b7280; background: #f3f4f6; padding: 4px 8px; border-radius: 4px;">
-                                  <span style="color: #374151; font-weight: 500;">${escapeHtml(projectId.projectId)}:</span>
+                                <div style="font-size: 12px; color: #6b7280; background: ${projectId.isPrivate ? '#fef3c7' : '#f3f4f6'}; padding: 4px 8px; border-radius: 4px; ${projectId.outputTokens === 0 ? 'opacity: 0.6;' : ''}">
+                                  ${projectId.isPrivate ? '<span title="Private project">&#128274;</span> ' : ''}
+                                  <span style="color: #374151; font-weight: 500;">${escapeHtml(projectId.projectName || projectId.projectId)}:</span>
                                   ${formatNumber(projectId.outputTokens)} tokens
-                                  (${((projectId.outputTokens / account.outputTokens) * 100).toFixed(0)}%)
+                                  ${account.outputTokens > 0 ? `(${((projectId.outputTokens / account.outputTokens) * 100).toFixed(0)}%)` : ''}
                                 </div>
                               `
                                 )

--- a/services/dashboard/src/services/api-client.ts
+++ b/services/dashboard/src/services/api-client.ts
@@ -556,6 +556,8 @@ export class ProxyApiClient {
       percentageUsed: number
       trainIds: Array<{
         projectId: string
+        projectName: string | null
+        isPrivate: boolean
         outputTokens: number
         requests: number
       }>
@@ -588,6 +590,8 @@ export class ProxyApiClient {
         percentageUsed: account.percentageUsed,
         trainIds: (account.trainIds || []).map((item: any) => ({
           projectId: item.projectId,
+          projectName: item.projectName || null,
+          isPrivate: item.isPrivate || false,
           outputTokens: item.outputTokens,
           requests: item.requests,
         })),

--- a/services/proxy/src/domain/entities/ProxyRequest.ts
+++ b/services/proxy/src/domain/entities/ProxyRequest.ts
@@ -8,6 +8,7 @@ export type RequestType = 'query_evaluation' | 'inference' | 'quota' | 'internal
  */
 export class ProxyRequest {
   private _requestType: RequestType | null = null
+  private _hasCustomSystemPrompt = false
 
   constructor(
     public readonly raw: ClaudeMessagesRequest,
@@ -15,6 +16,11 @@ export class ProxyRequest {
     public readonly requestId: string,
     public readonly apiKey?: string
   ) {}
+
+  /** Whether this request had a project-level system prompt override applied */
+  get hasCustomSystemPrompt(): boolean {
+    return this._hasCustomSystemPrompt
+  }
 
   get isStreaming(): boolean {
     return this.raw.stream === true
@@ -29,6 +35,18 @@ export class ProxyRequest {
       this._requestType = this.determineRequestType()
     }
     return this._requestType
+  }
+
+  /**
+   * Upgrade request type to 'inference' if it was classified as non-storable.
+   * Used when a project has a custom system prompt override configured,
+   * meaning the request is meaningful regardless of the original system message count.
+   */
+  upgradeToInference(): void {
+    this._hasCustomSystemPrompt = true
+    if (this._requestType === 'query_evaluation') {
+      this._requestType = 'inference'
+    }
   }
 
   get systemMessageCount(): number {

--- a/services/proxy/src/routes/api.ts
+++ b/services/proxy/src/routes/api.ts
@@ -1186,7 +1186,9 @@ apiRoutes.get('/token-usage/accounts', async c => {
   }
 
   try {
-    // Get all accounts from credentials table, with usage data from the last 5 hours
+    // Get all accounts from credentials table, with usage data from the last 5 hours.
+    // Also includes linked projects from project_accounts + projects tables so that
+    // all projects (including private ones) appear even without recent api_requests data.
     const accountsQuery = `
       WITH account_usage AS (
         SELECT
@@ -1210,6 +1212,42 @@ apiRoutes.get('/token-usage/accounts', async c => {
         WHERE account_id IS NOT NULL
           AND timestamp >= NOW() - INTERVAL '5 hours'
         GROUP BY account_id, project_id
+      ),
+      linked_projects AS (
+        SELECT DISTINCT
+          cr.account_id,
+          p.project_id as project_string_id,
+          p.name as project_name,
+          p.is_private
+        FROM credentials cr
+        JOIN project_accounts pa ON cr.id = pa.credential_id
+        JOIN projects p ON pa.project_id = p.id
+      ),
+      default_projects AS (
+        SELECT DISTINCT
+          cr.account_id,
+          p.project_id as project_string_id,
+          p.name as project_name,
+          p.is_private
+        FROM credentials cr
+        JOIN projects p ON p.default_account_id = cr.id
+      ),
+      all_linked AS (
+        SELECT * FROM linked_projects
+        UNION
+        SELECT * FROM default_projects
+      ),
+      combined_projects AS (
+        SELECT
+          COALESCE(tu.account_id, lp.account_id) as account_id,
+          COALESCE(tu.project_id, lp.project_string_id) as project_id,
+          COALESCE(lp.project_name, tu.project_id) as project_name,
+          COALESCE(lp.is_private, false) as is_private,
+          COALESCE(tu.train_output_tokens, 0) as output_tokens,
+          COALESCE(tu.train_requests, 0) as requests
+        FROM train_usage tu
+        FULL OUTER JOIN all_linked lp
+          ON tu.account_id = lp.account_id AND tu.project_id = lp.project_string_id
       )
       SELECT
         c.account_id,
@@ -1220,16 +1258,18 @@ apiRoutes.get('/token-usage/accounts', async c => {
         COALESCE(
           json_agg(
             json_build_object(
-              'projectId', tu.project_id,
-              'outputTokens', tu.train_output_tokens,
-              'requests', tu.train_requests
-            ) ORDER BY tu.train_output_tokens DESC
-          ) FILTER (WHERE tu.project_id IS NOT NULL),
+              'projectId', cp.project_id,
+              'projectName', cp.project_name,
+              'isPrivate', cp.is_private,
+              'outputTokens', cp.output_tokens,
+              'requests', cp.requests
+            ) ORDER BY cp.output_tokens DESC
+          ) FILTER (WHERE cp.project_id IS NOT NULL),
           '[]'::json
         ) as train_ids
       FROM credentials c
       LEFT JOIN account_usage au ON c.account_id = au.account_id
-      LEFT JOIN train_usage tu ON c.account_id = tu.account_id
+      LEFT JOIN combined_projects cp ON c.account_id = cp.account_id
       GROUP BY c.account_id, au.total_output_tokens, au.total_input_tokens,
                au.request_count, au.last_request_time
       ORDER BY COALESCE(au.total_output_tokens, 0) DESC

--- a/services/proxy/src/services/MetricsService.ts
+++ b/services/proxy/src/services/MetricsService.ts
@@ -410,7 +410,10 @@ export class MetricsService {
     }
 
     // Skip storing internal Claude Code helper requests
-    if (this.isInternalClaudeCodeRequest(request.raw)) {
+    // But not when a project-level system prompt override was applied,
+    // since the overridden system prompt replaces the original and
+    // should not be matched against internal helper prefixes.
+    if (!request.hasCustomSystemPrompt && this.isInternalClaudeCodeRequest(request.raw)) {
       logger.debug('Skipping storage for internal Claude Code request', {
         requestId: context.requestId,
       })

--- a/services/proxy/src/services/ProxyService.ts
+++ b/services/proxy/src/services/ProxyService.ts
@@ -152,7 +152,15 @@ export class ProxyService {
     // Apply project system prompt override (after conversation tracking, before forwarding)
     if (this.storageAdapter) {
       const pool = this.storageAdapter.getPool()
-      await applySystemPromptOverride(rawRequest, context.projectId, pool)
+      const overrideApplied = await applySystemPromptOverride(rawRequest, context.projectId, pool)
+
+      // If a custom system prompt was applied, ensure the request is stored.
+      // Without this, requests with few original system blocks (e.g. from simple clients)
+      // would be classified as 'query_evaluation' and skipped from storage,
+      // even though the project has meaningful configuration.
+      if (overrideApplied) {
+        request.upgradeToInference()
+      }
     }
 
     try {

--- a/services/proxy/src/services/system-prompt-override.ts
+++ b/services/proxy/src/services/system-prompt-override.ts
@@ -8,19 +8,21 @@ import { logger } from '../middleware/logger'
  * Mutates rawRequest.system if the project has an enabled, non-empty system prompt.
  * Must be called AFTER conversation tracking (which needs the original system)
  * and BEFORE forwarding to Claude API.
+ *
+ * @returns true if a system prompt override was applied, false otherwise
  */
 export async function applySystemPromptOverride(
   rawRequest: ClaudeMessagesRequest,
   projectId: string,
   pool: Pool
-): Promise<void> {
+): Promise<boolean> {
   try {
     const config = await getProjectSystemPrompt(pool, projectId)
     if (!config || !config.enabled) {
-      return
+      return false
     }
     if (!config.system_prompt || config.system_prompt.length === 0) {
-      return
+      return false
     }
 
     logger.debug('Applying project system prompt override', {
@@ -32,6 +34,7 @@ export async function applySystemPromptOverride(
     })
 
     rawRequest.system = config.system_prompt
+    return true
   } catch (error) {
     logger.warn('Failed to apply system prompt override, using original', {
       projectId,
@@ -39,5 +42,6 @@ export async function applySystemPromptOverride(
         error: error instanceof Error ? error.message : String(error),
       },
     })
+    return false
   }
 }


### PR DESCRIPTION
## Summary
- Enriches the token usage API (`/api/token-usage/accounts`) to include all projects linked to each account via `project_accounts` junction table and `default_account_id`, not just projects found in recent `api_requests` data. This ensures private projects appear in the dashboard even without recent tracking data.
- Shows project names and privacy indicators (lock icon, amber background) in the token usage tags on both the Token Usage page and the Analytics panel.
- Fixes a bug where requests from projects with custom system prompts (configured in database) were incorrectly classified as `query_evaluation` and skipped from storage — now upgrades request type to `inference` when a system prompt override is applied.
- Skips the `isInternalClaudeCodeRequest` check when a custom system prompt is active, preventing false positive filtering.
- Updates ADR-029 to document that token usage statistics include all projects regardless of privacy.

## Test plan
- [ ] Verify token usage page shows private projects with lock icon and amber background
- [ ] Verify projects linked via `project_accounts` appear even without recent api_requests
- [ ] Verify projects with custom system prompts are now stored in api_requests
- [ ] Run `bun run typecheck` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)