### PR TITLE
feat: add system prompt prepend mode for projects

### DIFF
--- a/docs/02-User-Guide/api-reference.md
+++ b/docs/02-User-Guide/api-reference.md
@@ -861,16 +861,18 @@ Updates the system prompt configuration for a project. Requires project membersh
       "text": "You are a helpful assistant specialized in marketing.",
       "cache_control": { "type": "ephemeral" }
     }
-  ]
+  ],
+  "system_prompt_mode": "replace"
 }
 ```
 
 **Request Body Fields:**
 
-| Field                   | Type                                        | Description                                                                 |
-| ----------------------- | ------------------------------------------- | --------------------------------------------------------------------------- |
-| `system_prompt_enabled` | `boolean` (optional)                        | Enable or disable system prompt override. Defaults to `false`.              |
-| `system_prompt`         | `SystemContentBlock[]` or `null` (optional) | Array of content blocks to use as the system prompt, or `null` to clear it. |
+| Field                   | Type                                        | Description                                                                                                                                                                                     |
+| ----------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `system_prompt_enabled` | `boolean` (optional)                        | Enable or disable system prompt override. Defaults to `false`.                                                                                                                                  |
+| `system_prompt`         | `SystemContentBlock[]` or `null` (optional) | Array of content blocks to use as the system prompt, or `null` to clear it.                                                                                                                     |
+| `system_prompt_mode`    | `"replace"` or `"prepend"` (optional)       | How the project system prompt interacts with client requests. `"replace"` (default) replaces the entire system field. `"prepend"` places the project blocks before the original request blocks. |
 
 **`SystemContentBlock` Schema:**
 
@@ -897,14 +899,17 @@ interface SystemContentBlock {
         "text": "You are a helpful assistant specialized in marketing.",
         "cache_control": { "type": "ephemeral" }
       }
-    ]
+    ],
+    "system_prompt_mode": "replace"
   }
 }
 ```
 
 **Behavior:**
 
-- When `system_prompt_enabled` is `true` and a `system_prompt` is configured, the proxy replaces the `system` field of all incoming Claude API requests for that project with the stored system prompt.
+- When `system_prompt_enabled` is `true` and a `system_prompt` is configured:
+  - **Replace mode** (default): The proxy replaces the `system` field of all incoming Claude API requests for that project with the stored system prompt.
+  - **Prepend mode**: The proxy prepends the stored system prompt blocks before the original request's system prompt blocks. If the original system is a string, it is normalized to an array. If the request has no system prompt, the project blocks are used as-is.
 - When `system_prompt_enabled` is `false`, the original `system` field from client requests is passed through unchanged.
 - Sending `"system_prompt": null` clears the stored prompt without affecting `system_prompt_enabled`.
 

--- a/docs/02-User-Guide/dashboard-guide.md
+++ b/docs/02-User-Guide/dashboard-guide.md
@@ -166,9 +166,10 @@ Each project has a settings page accessible from the project detail view. Settin
 
 #### System Prompt Override
 
-The System Prompt section lets project members define a prompt that replaces the `system` field in all incoming requests:
+The System Prompt section lets project members define a prompt that interacts with the `system` field in all incoming requests:
 
 - **Enable/disable toggle**: turn the override on or off without losing the saved prompt
+- **Mode selector**: choose between **Replace** (replaces the entire system prompt) and **Prepend** (places the project prompt before the original request prompt)
 - **JSON editor**: enter the system prompt as a JSON array of content blocks, for example:
 
   ```json
@@ -183,7 +184,12 @@ The System Prompt section lets project members define a prompt that replaces the
 
 - Changes are saved via `PUT /api/projects/:id/system-prompt` and take effect immediately for new requests.
 
-When the override is enabled, the original `system` value sent by clients is silently replaced. When disabled, the client's `system` field is forwarded unchanged.
+When the override is enabled:
+
+- **Replace mode**: the original `system` value sent by clients is replaced with the project's configured prompt.
+- **Prepend mode**: the project prompt blocks are placed before the original request's system prompt blocks.
+
+When disabled, the client's `system` field is forwarded unchanged.
 
 ### Account Management
 

--- a/docs/04-Architecture/ADRs/adr-034-project-system-prompt-override.md
+++ b/docs/04-Architecture/ADRs/adr-034-project-system-prompt-override.md
@@ -48,8 +48,14 @@ Add two columns to the `projects` table and a dedicated override function in the
 ```sql
 ALTER TABLE projects
   ADD COLUMN system_prompt_enabled BOOLEAN NOT NULL DEFAULT false,
-  ADD COLUMN system_prompt JSONB DEFAULT NULL;
+  ADD COLUMN system_prompt JSONB DEFAULT NULL,
+  ADD COLUMN system_prompt_mode VARCHAR(10) NOT NULL DEFAULT 'replace';
 ```
+
+The `system_prompt_mode` column controls how the project system prompt interacts with client requests:
+
+- `'replace'` (default): Replaces the entire `system` field
+- `'prepend'`: Prepends the project system prompt blocks before the original request blocks
 
 The `system_prompt` column stores the full Claude API system content blocks array:
 
@@ -74,8 +80,9 @@ This ordering ensures conversation tracking integrity — the system hash reflec
 
 ### Override Behavior
 
-- **Enabled with non-empty array**: Replaces the entire `system` field regardless of original format (string or array)
-- **Enabled with null or empty array `[]`**: No override applied (pass-through)
+- **Replace mode** (default): Replaces the entire `system` field regardless of original format (string or array)
+- **Prepend mode**: Prepends the project's system prompt blocks before the original request blocks. If the original system is a string, it is normalized to a `[{ type: "text", text: "..." }]` array. If the request has no system prompt, the project blocks are used as-is.
+- **Enabled with null or empty array `[]`**: No override applied (pass-through), regardless of mode
 - **Disabled**: No override applied, prompt data preserved in database for re-enablement
 - **Error during lookup**: Gracefully falls back to original request (logged as warning)
 
@@ -106,7 +113,7 @@ Server-side validation via `validateSystemPrompt()`:
 
 - No audit trail of system prompt changes (only `updated_at` timestamp)
 - No versioning or rollback capability
-- System prompt replacement is all-or-nothing (no prepend/append modes)
+- ~~System prompt replacement is all-or-nothing (no prepend/append modes)~~ — resolved: prepend mode added alongside replace mode
 
 ### Risks and Mitigations
 

--- a/docs/06-Reference/changelog.md
+++ b/docs/06-Reference/changelog.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- System prompt prepend mode: projects can now choose to prepend their system prompt before the original request prompt instead of replacing it entirely
+  - New `system_prompt_mode` column (`'replace'` or `'prepend'`, default `'replace'`) on projects table (migration 023)
+  - Mode toggle in the dashboard project settings page
+  - API support via `system_prompt_mode` field on `PUT /api/projects/:id/system-prompt`
+  - In prepend mode, string system prompts are normalized to content block arrays
 - Public token usage status page at `/public/token-usage` (no authentication required)
   - Shows Anthropic OAuth rate limit utilization (5h and 7d windows) per account
   - Compact multi-column layout with progress bars, reset times, and last-checked timestamps

--- a/packages/shared/src/database/queries/project-queries.ts
+++ b/packages/shared/src/database/queries/project-queries.ts
@@ -6,6 +6,7 @@ import type {
   UpdateProjectRequest,
   Credential,
   SlackConfig,
+  SystemPromptMode,
 } from '../../types/credentials'
 import type { SystemContentBlock } from '../../types/claude.js'
 import { toSafeCredential } from './credential-queries-internal'
@@ -201,6 +202,10 @@ export async function updateProject(
     updates.push(`system_prompt = $${paramIndex++}`)
     values.push(request.system_prompt ? JSON.stringify(request.system_prompt) : null)
   }
+  if (request.system_prompt_mode !== undefined) {
+    updates.push(`system_prompt_mode = $${paramIndex++}`)
+    values.push(request.system_prompt_mode)
+  }
 
   if (updates.length === 0) {
     const train = await getProjectById(pool, id)
@@ -331,11 +336,19 @@ export async function getProjectStats(
 export async function getProjectSystemPrompt(
   pool: Pool,
   projectId: string
-): Promise<{ enabled: boolean; system_prompt: SystemContentBlock[] | null } | null> {
+): Promise<{
+  enabled: boolean
+  system_prompt: SystemContentBlock[] | null
+  mode: SystemPromptMode
+} | null> {
   const result = await pool.query<{
     system_prompt_enabled: boolean
     system_prompt: SystemContentBlock[] | null
-  }>(`SELECT system_prompt_enabled, system_prompt FROM projects WHERE project_id = $1`, [projectId])
+    system_prompt_mode: SystemPromptMode
+  }>(
+    `SELECT system_prompt_enabled, system_prompt, system_prompt_mode FROM projects WHERE project_id = $1`,
+    [projectId]
+  )
 
   if (result.rows.length === 0) {
     return null
@@ -345,6 +358,7 @@ export async function getProjectSystemPrompt(
   return {
     enabled: row.system_prompt_enabled,
     system_prompt: row.system_prompt,
+    mode: row.system_prompt_mode,
   }
 }
 

--- a/packages/shared/src/types/credentials.ts
+++ b/packages/shared/src/types/credentials.ts
@@ -5,6 +5,8 @@ import type { SystemContentBlock } from './claude.js'
  * Database models for credential and project management
  */
 
+export type SystemPromptMode = 'replace' | 'prepend'
+
 export type ProviderType = 'anthropic' | 'bedrock'
 
 export interface BaseCredential {
@@ -68,6 +70,7 @@ export interface Project {
   is_private: boolean
   system_prompt_enabled: boolean
   system_prompt: SystemContentBlock[] | null
+  system_prompt_mode: SystemPromptMode
   created_at: Date
   updated_at: Date
 }
@@ -156,6 +159,7 @@ export interface UpdateProjectRequest {
   is_private?: boolean
   system_prompt_enabled?: boolean
   system_prompt?: SystemContentBlock[] | null
+  system_prompt_mode?: SystemPromptMode
 }
 
 export interface CreateApiKeyRequest {

--- a/scripts/db/migrations/023-add-system-prompt-mode.ts
+++ b/scripts/db/migrations/023-add-system-prompt-mode.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+
+/**
+ * Migration: Add system_prompt_mode column to projects table
+ *
+ * Extends the system prompt override feature to support a "prepend" mode
+ * in addition to the existing "replace" mode. In prepend mode, the project's
+ * system prompt blocks are placed before the original request blocks instead
+ * of replacing them entirely.
+ */
+
+import { Pool } from 'pg'
+
+async function up(pool: Pool): Promise<void> {
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    console.log('Adding system_prompt_mode column to projects table...')
+
+    // Add system_prompt_mode column with 'replace' as default (preserves existing behavior)
+    await client.query(`
+      ALTER TABLE projects ADD COLUMN IF NOT EXISTS system_prompt_mode VARCHAR(10) NOT NULL DEFAULT 'replace'
+    `)
+    console.log('✓ Added system_prompt_mode column')
+
+    // Verify column was added
+    const result = await client.query(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = 'projects'
+        AND table_schema = 'public'
+        AND column_name = 'system_prompt_mode'
+    `)
+
+    if (result.rows.length === 0) {
+      throw new Error('Verification failed: system_prompt_mode column not found in projects table')
+    }
+
+    console.log('✓ Verified column exists')
+
+    await client.query('COMMIT')
+    console.log('✅ system_prompt_mode column added to projects table successfully')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('❌ Failed to add system_prompt_mode column:', error)
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+async function down(pool: Pool): Promise<void> {
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    console.log('Removing system_prompt_mode column from projects table...')
+
+    await client.query(`
+      ALTER TABLE projects DROP COLUMN IF EXISTS system_prompt_mode
+    `)
+    console.log('✓ Dropped system_prompt_mode column')
+
+    await client.query('COMMIT')
+    console.log('✅ system_prompt_mode column removed from projects table successfully')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('❌ Failed to remove system_prompt_mode column:', error)
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+// Main execution
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    console.error('❌ DATABASE_URL environment variable is required')
+    process.exit(1)
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl })
+
+  try {
+    const action = process.argv[2] || 'up'
+
+    if (action === 'up') {
+      await up(pool)
+    } else if (action === 'down') {
+      await down(pool)
+    } else {
+      console.error(`❌ Unknown action: ${action}. Use 'up' or 'down'`)
+      process.exit(1)
+    }
+  } catch (error) {
+    console.error('❌ Migration failed:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+// Run if executed directly
+if (import.meta.main) {
+  main()
+}

--- a/services/dashboard/src/routes/projects-ui.ts
+++ b/services/dashboard/src/routes/projects-ui.ts
@@ -601,8 +601,9 @@ trainsUIRoutes.get('/:projectId/view', async c => {
                   System Prompt Override
                 </h3>
                 <p style="font-size: 0.75rem; color: #6b7280; margin-bottom: 1rem;">
-                  When enabled, replaces the system prompt in all Claude API requests routed through
-                  this project. The original system prompt from the request is discarded.
+                  ${train.system_prompt_mode === 'prepend'
+                    ? 'When enabled, prepends the configured system prompt before the original system prompt in all Claude API requests routed through this project.'
+                    : 'When enabled, replaces the system prompt in all Claude API requests routed through this project. The original system prompt from the request is discarded.'}
                 </p>
 
                 <div
@@ -631,6 +632,34 @@ trainsUIRoutes.get('/:projectId/view', async c => {
                         : '#10b981'}; color: white; padding: 0.5rem 1rem; border-radius: 0.25rem; font-weight: 600; border: none; cursor: pointer; font-size: 0.875rem;"
                     >
                       ${train.system_prompt_enabled ? 'Disable' : 'Enable'}
+                    </button>
+                  </form>
+                </div>
+
+                <div
+                  style="background: #f3f4f6; padding: 1rem; border-radius: 0.25rem; margin-bottom: 0.75rem;"
+                >
+                  <form
+                    hx-post="/dashboard/projects/${train.id}/system-prompt-mode"
+                    hx-swap="outerHTML"
+                    hx-target="#system-prompt-settings"
+                    style="display: flex; align-items: center; justify-content: space-between;"
+                  >
+                    <div>
+                      <div style="font-weight: 600; font-size: 0.875rem; margin-bottom: 0.25rem;">
+                        Mode: ${train.system_prompt_mode === 'prepend' ? 'Prepend' : 'Replace'}
+                      </div>
+                      <div style="font-size: 0.75rem; color: #6b7280;">
+                        ${train.system_prompt_mode === 'prepend'
+                          ? 'Project prompt is added before the original request prompt.'
+                          : 'Project prompt fully replaces the original request prompt.'}
+                      </div>
+                    </div>
+                    <button
+                      type="submit"
+                      style="background: #6366f1; color: white; padding: 0.5rem 1rem; border-radius: 0.25rem; font-weight: 600; border: none; cursor: pointer; font-size: 0.875rem;"
+                    >
+                      Switch to ${train.system_prompt_mode === 'prepend' ? 'Replace' : 'Prepend'}
                     </button>
                   </form>
                 </div>
@@ -2179,6 +2208,63 @@ trainsUIRoutes.post('/:projectId/toggle-system-prompt', async c => {
     await updateProject(pool, projectId, { system_prompt_enabled: newEnabled })
 
     // Redirect to reload the page with updated data
+    const updatedProject = await getProjectById(pool, projectId)
+    return c.redirect(`/dashboard/projects/${updatedProject!.project_id}/view`)
+  } catch (error) {
+    return c.html(html`
+      <div style="background: #fee2e2; color: #991b1b; padding: 0.75rem; border-radius: 0.25rem;">
+        Error: ${getErrorMessage(error)}
+      </div>
+    `)
+  }
+})
+
+/**
+ * Toggle system prompt mode between 'replace' and 'prepend'
+ */
+trainsUIRoutes.post('/:projectId/system-prompt-mode', async c => {
+  const projectId = c.req.param('projectId')
+  const pool = container.getPool()
+  const auth = c.get('auth')
+
+  if (!pool) {
+    return c.html(html`
+      <div style="background: #fee2e2; color: #991b1b; padding: 0.75rem; border-radius: 0.25rem;">
+        Database not configured
+      </div>
+    `)
+  }
+
+  if (!auth.isAuthenticated) {
+    return c.html(html`
+      <div style="background: #fee2e2; color: #991b1b; padding: 0.75rem; border-radius: 0.25rem;">
+        <strong>Error:</strong> Unauthorized - please log in
+      </div>
+    `)
+  }
+
+  try {
+    const isMember = await isProjectMember(pool, projectId, auth.principal)
+    if (!isMember) {
+      return c.html(html`
+        <div style="background: #fee2e2; color: #991b1b; padding: 0.75rem; border-radius: 0.25rem;">
+          <strong>Error:</strong> Only project members can change system prompt settings
+        </div>
+      `)
+    }
+
+    const project = await getProjectById(pool, projectId)
+    if (!project) {
+      return c.html(html`
+        <div style="background: #fee2e2; color: #991b1b; padding: 0.75rem; border-radius: 0.25rem;">
+          Project not found
+        </div>
+      `)
+    }
+
+    const newMode = project.system_prompt_mode === 'prepend' ? 'replace' : 'prepend'
+    await updateProject(pool, projectId, { system_prompt_mode: newMode })
+
     const updatedProject = await getProjectById(pool, projectId)
     return c.redirect(`/dashboard/projects/${updatedProject!.project_id}/view`)
   } catch (error) {

--- a/services/dashboard/src/routes/projects.ts
+++ b/services/dashboard/src/routes/projects.ts
@@ -137,6 +137,7 @@ projects.put('/:id/system-prompt', requireProjectMembership, async c => {
       system_prompt_enabled?: boolean
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       system_prompt?: any[] | null
+      system_prompt_mode?: string
     }>()
 
     // Validate system prompt if provided
@@ -147,9 +148,19 @@ projects.put('/:id/system-prompt', requireProjectMembership, async c => {
       }
     }
 
+    // Validate system prompt mode if provided
+    if (
+      body.system_prompt_mode !== undefined &&
+      body.system_prompt_mode !== 'replace' &&
+      body.system_prompt_mode !== 'prepend'
+    ) {
+      return c.json({ error: 'Invalid system_prompt_mode: must be "replace" or "prepend"' }, 400)
+    }
+
     const train = await updateProject(pool, id, {
       system_prompt_enabled: body.system_prompt_enabled,
       system_prompt: body.system_prompt,
+      system_prompt_mode: body.system_prompt_mode as 'replace' | 'prepend' | undefined,
     })
 
     return c.json({ train })

--- a/services/proxy/src/services/__tests__/system-prompt-override.test.ts
+++ b/services/proxy/src/services/__tests__/system-prompt-override.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test'
-import type { ClaudeMessagesRequest, SystemContentBlock } from '@agent-prompttrain/shared'
+import type {
+  ClaudeMessagesRequest,
+  SystemContentBlock,
+  SystemPromptMode,
+} from '@agent-prompttrain/shared'
 
 // ── Mock functions ──────────────────────────────────────────────────────────
 
@@ -7,7 +11,11 @@ const mockGetProjectSystemPrompt = mock<
   (
     pool: any,
     projectId: string
-  ) => Promise<{ enabled: boolean; system_prompt: SystemContentBlock[] | null } | null>
+  ) => Promise<{
+    enabled: boolean
+    system_prompt: SystemContentBlock[] | null
+    mode: SystemPromptMode
+  } | null>
 >(() => Promise.resolve(null))
 
 // ── Module mocks (must run before importing the service) ────────────────────
@@ -57,10 +65,12 @@ describe('applySystemPromptOverride', () => {
     mockGetProjectSystemPrompt.mockImplementation(() => Promise.resolve(null))
   })
 
+  // ── Replace mode tests ───────────────────────────────────────────────────
+
   test('replaces system field when override is enabled with non-empty array', async () => {
     const blocks = makeSystemBlocks('Project system prompt')
     mockGetProjectSystemPrompt.mockImplementation(() =>
-      Promise.resolve({ enabled: true, system_prompt: blocks })
+      Promise.resolve({ enabled: true, system_prompt: blocks, mode: 'replace' })
     )
 
     const request = makeRequest('Original system prompt')
@@ -72,7 +82,7 @@ describe('applySystemPromptOverride', () => {
   test('adds system field when request has none and override is enabled', async () => {
     const blocks = makeSystemBlocks('Injected system prompt')
     mockGetProjectSystemPrompt.mockImplementation(() =>
-      Promise.resolve({ enabled: true, system_prompt: blocks })
+      Promise.resolve({ enabled: true, system_prompt: blocks, mode: 'replace' })
     )
 
     const request = makeRequest()
@@ -86,7 +96,7 @@ describe('applySystemPromptOverride', () => {
   test('does not modify request when override is disabled', async () => {
     const blocks = makeSystemBlocks()
     mockGetProjectSystemPrompt.mockImplementation(() =>
-      Promise.resolve({ enabled: false, system_prompt: blocks })
+      Promise.resolve({ enabled: false, system_prompt: blocks, mode: 'replace' })
     )
 
     const request = makeRequest('Original system')
@@ -97,7 +107,7 @@ describe('applySystemPromptOverride', () => {
 
   test('does not modify request when system_prompt is null', async () => {
     mockGetProjectSystemPrompt.mockImplementation(() =>
-      Promise.resolve({ enabled: true, system_prompt: null })
+      Promise.resolve({ enabled: true, system_prompt: null, mode: 'replace' })
     )
 
     const request = makeRequest('Original system')
@@ -108,7 +118,7 @@ describe('applySystemPromptOverride', () => {
 
   test('does not modify request when system_prompt is empty array', async () => {
     mockGetProjectSystemPrompt.mockImplementation(() =>
-      Promise.resolve({ enabled: true, system_prompt: [] })
+      Promise.resolve({ enabled: true, system_prompt: [], mode: 'replace' })
     )
 
     const request = makeRequest('Original system')
@@ -133,7 +143,7 @@ describe('applySystemPromptOverride', () => {
       { type: 'text', text: 'Override B' },
     ]
     mockGetProjectSystemPrompt.mockImplementation(() =>
-      Promise.resolve({ enabled: true, system_prompt: overrideBlocks })
+      Promise.resolve({ enabled: true, system_prompt: overrideBlocks, mode: 'replace' })
     )
 
     const request = makeRequest(originalBlocks)
@@ -141,5 +151,79 @@ describe('applySystemPromptOverride', () => {
 
     expect(request.system).toEqual(overrideBlocks)
     expect(request.system).not.toEqual(originalBlocks)
+  })
+
+  // ── Prepend mode tests ──────────────────────────────────────────────────
+
+  test('prepends project blocks before original string system prompt', async () => {
+    const projectBlocks = makeSystemBlocks('Project context')
+    mockGetProjectSystemPrompt.mockImplementation(() =>
+      Promise.resolve({ enabled: true, system_prompt: projectBlocks, mode: 'prepend' })
+    )
+
+    const request = makeRequest('Original system prompt')
+    await applySystemPromptOverride(request, 'project-1', fakePool)
+
+    expect(request.system).toEqual([
+      { type: 'text', text: 'Project context' },
+      { type: 'text', text: 'Original system prompt' },
+    ])
+  })
+
+  test('prepends project blocks before original array system prompt', async () => {
+    const projectBlocks: SystemContentBlock[] = [{ type: 'text', text: 'Project context' }]
+    const originalBlocks: SystemContentBlock[] = [
+      { type: 'text', text: 'Original A' },
+      { type: 'text', text: 'Original B' },
+    ]
+    mockGetProjectSystemPrompt.mockImplementation(() =>
+      Promise.resolve({ enabled: true, system_prompt: projectBlocks, mode: 'prepend' })
+    )
+
+    const request = makeRequest(originalBlocks)
+    await applySystemPromptOverride(request, 'project-1', fakePool)
+
+    expect(request.system).toEqual([
+      { type: 'text', text: 'Project context' },
+      { type: 'text', text: 'Original A' },
+      { type: 'text', text: 'Original B' },
+    ])
+  })
+
+  test('prepend applies project blocks when request has no system prompt', async () => {
+    const projectBlocks = makeSystemBlocks('Injected via prepend')
+    mockGetProjectSystemPrompt.mockImplementation(() =>
+      Promise.resolve({ enabled: true, system_prompt: projectBlocks, mode: 'prepend' })
+    )
+
+    const request = makeRequest()
+    expect(request.system).toBeUndefined()
+
+    await applySystemPromptOverride(request, 'project-1', fakePool)
+
+    expect(request.system).toEqual([{ type: 'text', text: 'Injected via prepend' }])
+  })
+
+  test('prepend does not modify when override is disabled', async () => {
+    const projectBlocks = makeSystemBlocks('Project context')
+    mockGetProjectSystemPrompt.mockImplementation(() =>
+      Promise.resolve({ enabled: false, system_prompt: projectBlocks, mode: 'prepend' })
+    )
+
+    const request = makeRequest('Original system')
+    await applySystemPromptOverride(request, 'project-1', fakePool)
+
+    expect(request.system).toBe('Original system')
+  })
+
+  test('prepend does not modify when system_prompt is empty', async () => {
+    mockGetProjectSystemPrompt.mockImplementation(() =>
+      Promise.resolve({ enabled: true, system_prompt: [], mode: 'prepend' })
+    )
+
+    const request = makeRequest('Original system')
+    await applySystemPromptOverride(request, 'project-1', fakePool)
+
+    expect(request.system).toBe('Original system')
   })
 })

--- a/services/proxy/src/services/system-prompt-override.ts
+++ b/services/proxy/src/services/system-prompt-override.ts
@@ -1,13 +1,31 @@
 import type { Pool } from 'pg'
-import type { ClaudeMessagesRequest } from '@agent-prompttrain/shared'
+import type { ClaudeMessagesRequest, SystemContentBlock } from '@agent-prompttrain/shared'
 import { getProjectSystemPrompt } from '@agent-prompttrain/shared/database/queries'
 import { logger } from '../middleware/logger'
+
+/**
+ * Normalize the request's system field to an array of SystemContentBlock.
+ * Claude API accepts both a string and an array of content blocks for the system field.
+ */
+function normalizeSystemToBlocks(system: ClaudeMessagesRequest['system']): SystemContentBlock[] {
+  if (!system) {
+    return []
+  }
+  if (typeof system === 'string') {
+    return [{ type: 'text', text: system }]
+  }
+  return system as SystemContentBlock[]
+}
 
 /**
  * Apply project-level system prompt override to a request.
  * Mutates rawRequest.system if the project has an enabled, non-empty system prompt.
  * Must be called AFTER conversation tracking (which needs the original system)
  * and BEFORE forwarding to Claude API.
+ *
+ * Supports two modes:
+ * - "replace": Replaces the entire system field with the project's system prompt (default)
+ * - "prepend": Prepends the project's system prompt blocks before the original request blocks
  *
  * @returns true if a system prompt override was applied, false otherwise
  */
@@ -25,15 +43,24 @@ export async function applySystemPromptOverride(
       return false
     }
 
+    const mode = config.mode || 'replace'
+
     logger.debug('Applying project system prompt override', {
       projectId,
       metadata: {
+        mode,
         blockCount: config.system_prompt.length,
         hadOriginalSystem: !!rawRequest.system,
       },
     })
 
-    rawRequest.system = config.system_prompt
+    if (mode === 'prepend') {
+      const originalBlocks = normalizeSystemToBlocks(rawRequest.system)
+      rawRequest.system = [...config.system_prompt, ...originalBlocks]
+    } else {
+      rawRequest.system = config.system_prompt
+    }
+
     return true
   } catch (error) {
     logger.warn('Failed to apply system prompt override, using original', {


### PR DESCRIPTION
## Summary

- Adds a new `system_prompt_mode` column to the projects table (`'replace'` | `'prepend'`, default `'replace'`)
- In **prepend** mode, the project's system prompt blocks are placed **before** the original request blocks instead of replacing them entirely
- In **replace** mode (default), existing behavior is unchanged — the project prompt replaces the entire `system` field

## Changes

### Database
- New migration `023-add-system-prompt-mode.ts` adds `system_prompt_mode VARCHAR(10) NOT NULL DEFAULT 'replace'` to the `projects` table

### Shared Package
- Added `SystemPromptMode` type (`'replace' | 'prepend'`) to `credentials.ts`
- Updated `Project` and `UpdateProjectRequest` interfaces with `system_prompt_mode` field
- Updated `getProjectSystemPrompt()` query to return the `mode` field
- Updated `updateProject()` to handle `system_prompt_mode` updates

### Proxy Service
- Updated `applySystemPromptOverride()` to support prepend mode
- Added `normalizeSystemToBlocks()` helper to convert string system prompts to content block arrays
- 5 new test cases for prepend mode behavior (12 total tests, all passing)

### Dashboard
- Added mode toggle button (Replace/Prepend) in the project system prompt settings
- New `POST /:projectId/system-prompt-mode` endpoint to toggle mode
- Updated API endpoint to accept and validate `system_prompt_mode` field
- Dynamic description text updates based on selected mode

### Documentation
- Updated ADR-034 with prepend mode schema, behavior, and resolved the "all-or-nothing" negative consequence
- Updated API Reference with new `system_prompt_mode` field documentation
- Updated Dashboard Guide with mode selector description
- Added changelog entry

## Test plan

- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] All 12 system prompt override tests pass (7 replace + 5 prepend)
- [x] Full test suite: no new failures introduced (18 pre-existing failures in Docker/CLI integration tests)
- [ ] Manual: verify mode toggle in dashboard UI
- [ ] Manual: verify prepend mode correctly combines prompts in proxy
- [ ] Run migration 023 on staging database

🤖 Generated with [Claude Code](https://claude.com/claude-code)