### PR TITLE
[codex] Speed up dashboard overview loading

### DIFF
--- a/services/dashboard/src/layout/index.ts
+++ b/services/dashboard/src/layout/index.ts
@@ -3,6 +3,13 @@ import { dashboardStyles } from './styles.js'
 import { Context } from 'hono'
 import { nexusLogo } from '../components/logo.js'
 
+type LayoutOptions = {
+  assets?: {
+    htmx?: boolean
+    codeViewer?: boolean
+  }
+}
+
 /**
  * Dashboard HTML layout template
  */
@@ -10,8 +17,12 @@ export const layout = (
   title: string,
   content: any,
   additionalScripts: string = '',
-  context?: Context
+  context?: Context,
+  options?: LayoutOptions
 ) => {
+  const includeHtmx = options?.assets?.htmx ?? true
+  const includeCodeViewer = options?.assets?.codeViewer ?? true
+
   // Get CSRF token if context is provided
   const csrfToken = context?.get('csrfToken') || ''
   // Get auth state if context is provided
@@ -30,10 +41,9 @@ export const layout = (
         <title>${title} - Agent Prompt Train Dashboard</title>
         ${csrfToken ? html`<meta name="csrf-token" content="${csrfToken}" />` : ''}
         <style>
-          ${raw(
-            dashboardStyles
-          )}
-        
+          ${raw(dashboardStyles)}
+          ${includeCodeViewer
+            ? raw(`
         /* Ultra-dense JSON viewer styles injected globally */
         andypf-json-viewer::part(json-viewer) {
             font-size: 10px !important;
@@ -52,132 +62,139 @@ export const layout = (
             line-height: 1.1 !important;
             padding: 0 !important;
           }
+        `)
+            : ''}
         </style>
-        <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css"
-          id="hljs-light-theme"
-        />
-        <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css"
-          id="hljs-dark-theme"
-          disabled
-        />
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/@andypf/json-viewer@2.1.10/dist/iife/index.js"></script>
-        <style>
-          /* JSON Viewer styling - Ultra Dense */
-          andypf-json-viewer {
-            display: block;
-            padding: 0.5rem;
-            border-radius: 0.25rem;
-            overflow: auto;
-            margin-bottom: 0.125rem;
-            font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
-            font-size: 10px;
-            line-height: 1.2;
-            letter-spacing: -0.03em;
-            --json-viewer-indent: 12px;
-            --json-viewer-key-color: #1e40af;
-            --json-viewer-value-string-color: #059669;
-            --json-viewer-value-number-color: #dc2626;
-            --json-viewer-value-boolean-color: #7c3aed;
-            --json-viewer-value-null-color: #6b7280;
-            --json-viewer-property-color: #1e40af;
-            --json-viewer-bracket-color: #6b7280;
-            --json-viewer-comma-color: #6b7280;
-          }
+        ${includeCodeViewer
+          ? html`
+              <link
+                rel="stylesheet"
+                href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css"
+                id="hljs-light-theme"
+              />
+              <link
+                rel="stylesheet"
+                href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css"
+                id="hljs-dark-theme"
+                disabled
+              />
+              <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+              <script src="https://cdn.jsdelivr.net/npm/@andypf/json-viewer@2.1.10/dist/iife/index.js"></script>
+              <style>
+                /* JSON Viewer styling - Ultra Dense */
+                andypf-json-viewer {
+                  display: block;
+                  padding: 0.5rem;
+                  border-radius: 0.25rem;
+                  overflow: auto;
+                  margin-bottom: 0.125rem;
+                  font-family:
+                    'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+                  font-size: 10px;
+                  line-height: 1.2;
+                  letter-spacing: -0.03em;
+                  --json-viewer-indent: 12px;
+                  --json-viewer-key-color: #1e40af;
+                  --json-viewer-value-string-color: #059669;
+                  --json-viewer-value-number-color: #dc2626;
+                  --json-viewer-value-boolean-color: #7c3aed;
+                  --json-viewer-value-null-color: #6b7280;
+                  --json-viewer-property-color: #1e40af;
+                  --json-viewer-bracket-color: #6b7280;
+                  --json-viewer-comma-color: #6b7280;
+                }
 
-          /* Dark mode JSON viewer colors */
-          [data-theme='dark'] andypf-json-viewer {
-            --json-viewer-key-color: #60a5fa;
-            --json-viewer-value-string-color: #34d399;
-            --json-viewer-value-number-color: #f87171;
-            --json-viewer-value-boolean-color: #a78bfa;
-            --json-viewer-value-null-color: #94a3b8;
-            --json-viewer-property-color: #60a5fa;
-            --json-viewer-bracket-color: #94a3b8;
-            --json-viewer-comma-color: #94a3b8;
-          }
+                /* Dark mode JSON viewer colors */
+                [data-theme='dark'] andypf-json-viewer {
+                  --json-viewer-key-color: #60a5fa;
+                  --json-viewer-value-string-color: #34d399;
+                  --json-viewer-value-number-color: #f87171;
+                  --json-viewer-value-boolean-color: #a78bfa;
+                  --json-viewer-value-null-color: #94a3b8;
+                  --json-viewer-property-color: #60a5fa;
+                  --json-viewer-bracket-color: #94a3b8;
+                  --json-viewer-comma-color: #94a3b8;
+                }
 
-          /* Compact view - reduce padding on containers */
-          #request-json-container andypf-json-viewer,
-          #response-json-container andypf-json-viewer {
-            padding: 0.25rem;
-            margin-bottom: 0;
-          }
+                /* Compact view - reduce padding on containers */
+                #request-json-container andypf-json-viewer,
+                #response-json-container andypf-json-viewer {
+                  padding: 0.25rem;
+                  margin-bottom: 0;
+                }
 
-          /* Make the overall section more compact */
-          #raw-view .section-content {
-            padding: 0.25rem;
-          }
+                /* Make the overall section more compact */
+                #raw-view .section-content {
+                  padding: 0.25rem;
+                }
 
-          /* Reduce spacing between sections */
-          .section {
-            margin-bottom: 0.5rem;
-          }
+                /* Reduce spacing between sections */
+                .section {
+                  margin-bottom: 0.5rem;
+                }
 
-          .section-header {
-            padding: 0.375rem 0.5rem;
-            font-size: 0.875rem;
-          }
+                .section-header {
+                  padding: 0.375rem 0.5rem;
+                  font-size: 0.875rem;
+                }
 
-          .section-content {
-            padding: 0.375rem;
-          }
+                .section-content {
+                  padding: 0.375rem;
+                }
 
-          /* Dense view toggle buttons */
-          .view-toggle {
-            margin: 0.5rem 0;
-          }
+                /* Dense view toggle buttons */
+                .view-toggle {
+                  margin: 0.5rem 0;
+                }
 
-          .view-toggle button {
-            padding: 0.25rem 0.75rem;
-            font-size: 0.8125rem;
-          }
+                .view-toggle button {
+                  padding: 0.25rem 0.75rem;
+                  font-size: 0.8125rem;
+                }
 
-          /* Ensure code blocks in these containers have light backgrounds */
-          .hljs {
-            background: transparent !important;
-            color: #1f2937 !important;
-          }
+                /* Ensure code blocks in these containers have light backgrounds */
+                .hljs {
+                  background: transparent !important;
+                  color: #1f2937 !important;
+                }
 
-          /* Chunk containers */
-          #chunks-container > div > div {
-            background-color: white !important;
-          }
+                /* Chunk containers */
+                #chunks-container > div > div {
+                  background-color: white !important;
+                }
 
-          /* Tool use and conversation code blocks */
-          .message-content pre,
-          .message-content code,
-          .conversation-container pre,
-          .conversation-container code {
-            background-color: #f9fafb !important;
-            color: #1f2937 !important;
-            border: 1px solid #e5e7eb;
-          }
+                /* Tool use and conversation code blocks */
+                .message-content pre,
+                .message-content code,
+                .conversation-container pre,
+                .conversation-container code {
+                  background-color: #f9fafb !important;
+                  color: #1f2937 !important;
+                  border: 1px solid #e5e7eb;
+                }
 
-          .message-content pre code,
-          .conversation-container pre code {
-            background-color: transparent !important;
-            border: none;
-          }
+                .message-content pre code,
+                .conversation-container pre code {
+                  background-color: transparent !important;
+                  border: none;
+                }
 
-          /* Specific language code blocks */
-          .language-json,
-          .language-javascript,
-          .language-python,
-          .language-bash,
-          .language-shell,
-          pre.hljs,
-          code.hljs {
-            background-color: #f9fafb !important;
-            color: #1f2937 !important;
-          }
-        </style>
-        <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-        ${csrfToken
+                /* Specific language code blocks */
+                .language-json,
+                .language-javascript,
+                .language-python,
+                .language-bash,
+                .language-shell,
+                pre.hljs,
+                code.hljs {
+                  background-color: #f9fafb !important;
+                  color: #1f2937 !important;
+                }
+              </style>
+            `
+          : ''}
+        ${includeHtmx ? html`<script src="https://unpkg.com/htmx.org@1.9.10"></script>` : ''}
+        ${includeHtmx && csrfToken
           ? raw(`
       <script>
         // Add CSRF token to all HTMX requests
@@ -308,6 +325,9 @@ export const layout = (
             }
 
             function updateHighlightTheme(theme) {
+              if (!hljsLightTheme || !hljsDarkTheme) {
+                return
+              }
               if (theme === 'dark') {
                 hljsLightTheme.disabled = true
                 hljsDarkTheme.disabled = false

--- a/services/dashboard/src/routes/__tests__/dark-mode.integration.test.ts
+++ b/services/dashboard/src/routes/__tests__/dark-mode.integration.test.ts
@@ -36,6 +36,26 @@ describe('Dark Mode Integration', () => {
     expect(html).toContain('disabled')
   })
 
+  it('can omit optional third-party assets for lightweight pages', async () => {
+    app.get('/lite', c => {
+      return c.html(
+        layout('Lite Page', '<div>Lite Content</div>', '', c, {
+          assets: {
+            htmx: false,
+            codeViewer: false,
+          },
+        })
+      )
+    })
+
+    const res = await app.request('/lite')
+    const html = await res.text()
+
+    expect(html).not.toContain('highlight.min.js')
+    expect(html).not.toContain('@andypf/json-viewer')
+    expect(html).not.toContain('htmx.org@1.9.10')
+  })
+
   it('should set data-theme attribute based on localStorage', async () => {
     const res = await app.request('/test')
     const html = await res.text()

--- a/services/dashboard/src/routes/overview.ts
+++ b/services/dashboard/src/routes/overview.ts
@@ -12,6 +12,40 @@ import {
 import { layout } from '../layout/index.js'
 import { container } from '../container.js'
 
+const PROJECT_CACHE_TTL_MS = 30_000
+
+let cachedProjects: Awaited<ReturnType<typeof listProjects>> | null = null
+let cachedProjectsExpiresAt = 0
+let cachedProjectsPromise: Promise<Awaited<ReturnType<typeof listProjects>>> | null = null
+
+async function getCachedProjects() {
+  const now = Date.now()
+  if (cachedProjects && cachedProjectsExpiresAt > now) {
+    return cachedProjects
+  }
+
+  if (cachedProjectsPromise) {
+    return cachedProjectsPromise
+  }
+
+  const pool = container.getPool()
+  if (!pool) {
+    return []
+  }
+
+  cachedProjectsPromise = listProjects(pool)
+    .then(projects => {
+      cachedProjects = projects
+      cachedProjectsExpiresAt = Date.now() + PROJECT_CACHE_TTL_MS
+      return projects
+    })
+    .finally(() => {
+      cachedProjectsPromise = null
+    })
+
+  return cachedProjectsPromise
+}
+
 export const overviewRoutes = new Hono<{
   Variables: {
     apiClient?: ProxyApiClient
@@ -20,6 +54,22 @@ export const overviewRoutes = new Hono<{
   }
 }>()
 
+overviewRoutes.get('/partials/weekly-conversations', async c => {
+  const apiClient = c.get('apiClient')
+  const projectId = c.req.query('projectId')
+
+  if (!apiClient) {
+    return c.json({ error: 'Chart unavailable', weeks: [] }, 503)
+  }
+
+  try {
+    const weeklyResult = await apiClient.getWeeklyConversations({ days: 30, projectId })
+    return c.json(weeklyResult)
+  } catch (error) {
+    return c.json({ error: getErrorMessage(error), weeks: [] }, 500)
+  }
+})
+
 /**
  * Main dashboard page - Shows conversations overview with branches
  */
@@ -27,7 +77,8 @@ overviewRoutes.get('/', async c => {
   const projectId = c.req.query('projectId')
   const page = parseInt(c.req.query('page') || '1')
   const perPage = parseInt(c.req.query('per_page') || '50')
-  const searchQuery = c.req.query('search')?.toLowerCase()
+  const rawSearchQuery = c.req.query('search') || ''
+  const searchQuery = rawSearchQuery.toLowerCase()
 
   // Validate pagination params
   const currentPage = Math.max(1, page)
@@ -45,7 +96,15 @@ overviewRoutes.get('/', async c => {
           <div class="error-banner">
             <strong>Error:</strong> API client not configured. Please check your configuration.
           </div>
-        `
+        `,
+        '',
+        c,
+        {
+          assets: {
+            htmx: false,
+            codeViewer: false,
+          },
+        }
       )
     )
   }
@@ -54,20 +113,17 @@ overviewRoutes.get('/', async c => {
     // Calculate offset for pagination
     const offset = (currentPage - 1) * itemsPerPage
 
-    // Get database pool for fetching project privacy info
-    const pool = container.getPool()
-
-    // Fetch dashboard stats, conversations, weekly trend, and projects in parallel
-    const [statsResult, conversationsResult, weeklyResult, projects] = await Promise.all([
+    // Fetch dashboard stats, conversations, and projects in parallel.
+    // The weekly chart is loaded after first paint to avoid blocking the main response.
+    const [statsResult, conversationsResult, projects] = await Promise.all([
       apiClient.getDashboardStats({ projectId }),
       apiClient.getConversations({
         projectId,
         limit: itemsPerPage,
-        offset: searchQuery ? 0 : offset, // For search, get all and filter client-side for now
+        offset: searchQuery ? 0 : offset, // Search still filters the loaded page client-side
         userEmail: auth?.principal, // Pass the authenticated user for privacy filtering
       }),
-      apiClient.getWeeklyConversations({ days: 30, projectId }),
-      pool ? listProjects(pool) : Promise.resolve([]),
+      getCachedProjects(),
     ])
 
     const apiConversations = conversationsResult.conversations
@@ -142,9 +198,6 @@ overviewRoutes.get('/', async c => {
         )
       })
     }
-
-    // Sort by last message time
-    filteredBranches.sort((a, b) => b.lastMessage.getTime() - a.lastMessage.getTime())
 
     // No longer filter subtasks - display all conversations at the same level
     const groupedConversations = filteredBranches
@@ -255,127 +308,151 @@ overviewRoutes.get('/', async c => {
         </div>
       </div>
 
-      <!-- Weekly Conversations Chart -->
-      ${weeklyResult.weeks.length > 0
-        ? html`
-            <div class="section" style="margin-bottom: 1.5rem;">
-              <div class="section-header">Conversations Per Week</div>
-              <div class="section-content">
-                <canvas
-                  id="weekly-conversations-chart"
-                  width="800"
-                  height="250"
-                  style="width: 100%; height: 250px;"
-                  data-testid="weekly-conversations-chart"
-                ></canvas>
-                <script>
-                  ;(function () {
-                    const canvas = document.getElementById('weekly-conversations-chart')
-                    if (!canvas) return
-                    const ctx = canvas.getContext('2d')
-                    if (!ctx) return
+      <div class="section" style="margin-bottom: 1.5rem;" id="weekly-conversations-panel">
+        <div class="section-header">Conversations Per Week</div>
+        <div class="section-content">
+          <p class="text-gray-500">Loading chart...</p>
+        </div>
+      </div>
+      <script>
+        ;(() => {
+          const panel = document.getElementById('weekly-conversations-panel')
+          if (!panel) return
 
-                    const dpr = window.devicePixelRatio || 1
-                    const rect = canvas.getBoundingClientRect()
-                    canvas.width = rect.width * dpr
-                    canvas.height = rect.height * dpr
-                    ctx.scale(dpr, dpr)
+          const renderChart = weeks => {
+            if (!Array.isArray(weeks) || weeks.length === 0) {
+              panel.style.display = 'none'
+              return
+            }
 
-                    const width = rect.width
-                    const height = rect.height
+            const content = panel.querySelector('.section-content')
+            if (!content) return
 
-                    const data = ${raw(
-                      JSON.stringify(
-                        weeklyResult.weeks.map(w => ({
-                          label: w.weekStart,
-                          value: w.conversationCount,
-                        }))
-                      )
-                    )}
+            content.innerHTML =
+              '<canvas id="weekly-conversations-chart" width="800" height="250" style="width: 100%; height: 250px;" data-testid="weekly-conversations-chart"></canvas>'
 
-                    if (data.length === 0) return
+            const canvas = document.getElementById('weekly-conversations-chart')
+            if (!canvas) return
+            const ctx = canvas.getContext('2d')
+            if (!ctx) return
 
-                    const padding = { top: 20, right: 20, bottom: 50, left: 50 }
-                    const chartWidth = width - padding.left - padding.right
-                    const chartHeight = height - padding.top - padding.bottom
+            const dpr = window.devicePixelRatio || 1
+            const rect = canvas.getBoundingClientRect()
+            canvas.width = rect.width * dpr
+            canvas.height = rect.height * dpr
+            ctx.scale(dpr, dpr)
 
-                    const maxValue = Math.max(...data.map(d => d.value), 1)
-                    const barWidth = Math.max((chartWidth / data.length) * 0.7, 4)
-                    const barGap = chartWidth / data.length - barWidth
+            const width = rect.width
+            const height = rect.height
+            const data = weeks.map(week => ({
+              label: week.weekStart,
+              value: week.conversationCount,
+            }))
 
-                    // Detect dark mode
-                    const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
-                    const textColor = isDark ? '#9ca3af' : '#6b7280'
-                    const gridColor = isDark ? '#374151' : '#e5e7eb'
-                    const barColor = isDark ? '#60a5fa' : '#3b82f6'
-                    const barHoverColor = isDark ? '#93c5fd' : '#2563eb'
+            const padding = { top: 20, right: 20, bottom: 50, left: 50 }
+            const chartWidth = width - padding.left - padding.right
+            const chartHeight = height - padding.top - padding.bottom
 
-                    // Draw grid lines
-                    ctx.strokeStyle = gridColor
-                    ctx.lineWidth = 0.5
-                    const gridLines = 5
-                    for (let i = 0; i <= gridLines; i++) {
-                      const y = padding.top + (chartHeight / gridLines) * i
-                      ctx.beginPath()
-                      ctx.moveTo(padding.left, y)
-                      ctx.lineTo(width - padding.right, y)
-                      ctx.stroke()
+            const maxValue = Math.max(...data.map(d => d.value), 1)
+            const barWidth = Math.max((chartWidth / data.length) * 0.7, 4)
+            const barGap = chartWidth / data.length - barWidth
 
-                      // Y-axis labels
-                      const val = Math.round(maxValue - (maxValue / gridLines) * i)
-                      ctx.fillStyle = textColor
-                      ctx.font = '11px system-ui, sans-serif'
-                      ctx.textAlign = 'right'
-                      ctx.fillText(val.toString(), padding.left - 8, y + 4)
-                    }
+            const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
+            const textColor = isDark ? '#9ca3af' : '#6b7280'
+            const gridColor = isDark ? '#374151' : '#e5e7eb'
+            const barColor = isDark ? '#60a5fa' : '#3b82f6'
 
-                    // Draw bars
-                    data.forEach((d, i) => {
-                      const x = padding.left + i * (barWidth + barGap) + barGap / 2
-                      const barHeight = (d.value / maxValue) * chartHeight
-                      const y = padding.top + chartHeight - barHeight
+            ctx.strokeStyle = gridColor
+            ctx.lineWidth = 0.5
+            const gridLines = 5
+            for (let i = 0; i <= gridLines; i++) {
+              const y = padding.top + (chartHeight / gridLines) * i
+              ctx.beginPath()
+              ctx.moveTo(padding.left, y)
+              ctx.lineTo(width - padding.right, y)
+              ctx.stroke()
 
-                      // Bar fill
-                      ctx.fillStyle = barColor
-                      ctx.beginPath()
-                      const radius = Math.min(3, barWidth / 4)
-                      ctx.moveTo(x + radius, y)
-                      ctx.lineTo(x + barWidth - radius, y)
-                      ctx.quadraticCurveTo(x + barWidth, y, x + barWidth, y + radius)
-                      ctx.lineTo(x + barWidth, y + barHeight)
-                      ctx.lineTo(x, y + barHeight)
-                      ctx.lineTo(x, y + radius)
-                      ctx.quadraticCurveTo(x, y, x + radius, y)
-                      ctx.fill()
+              const val = Math.round(maxValue - (maxValue / gridLines) * i)
+              ctx.fillStyle = textColor
+              ctx.font = '11px system-ui, sans-serif'
+              ctx.textAlign = 'right'
+              ctx.fillText(val.toString(), padding.left - 8, y + 4)
+            }
 
-                      // Value label on top of bar
-                      if (d.value > 0) {
-                        ctx.fillStyle = textColor
-                        ctx.font = '10px system-ui, sans-serif'
-                        ctx.textAlign = 'center'
-                        ctx.fillText(d.value.toString(), x + barWidth / 2, y - 5)
-                      }
+            data.forEach((d, i) => {
+              const x = padding.left + i * (barWidth + barGap) + barGap / 2
+              const barHeight = (d.value / maxValue) * chartHeight
+              const y = padding.top + chartHeight - barHeight
 
-                      // X-axis label (week start date)
-                      ctx.fillStyle = textColor
-                      ctx.font = '10px system-ui, sans-serif'
-                      ctx.textAlign = 'center'
-                      ctx.save()
-                      ctx.translate(x + barWidth / 2, padding.top + chartHeight + 14)
-                      ctx.rotate(-Math.PI / 6)
-                      const dateLabel = new Date(d.label).toLocaleDateString('en-US', {
-                        month: 'short',
-                        day: 'numeric',
-                      })
-                      ctx.fillText(dateLabel, 0, 0)
-                      ctx.restore()
-                    })
-                  })()
-                </script>
-              </div>
-            </div>
-          `
-        : ''}
+              ctx.fillStyle = barColor
+              ctx.beginPath()
+              const radius = Math.min(3, barWidth / 4)
+              ctx.moveTo(x + radius, y)
+              ctx.lineTo(x + barWidth - radius, y)
+              ctx.quadraticCurveTo(x + barWidth, y, x + barWidth, y + radius)
+              ctx.lineTo(x + barWidth, y + barHeight)
+              ctx.lineTo(x, y + barHeight)
+              ctx.lineTo(x, y + radius)
+              ctx.quadraticCurveTo(x, y, x + radius, y)
+              ctx.fill()
+
+              if (d.value > 0) {
+                ctx.fillStyle = textColor
+                ctx.font = '10px system-ui, sans-serif'
+                ctx.textAlign = 'center'
+                ctx.fillText(d.value.toString(), x + barWidth / 2, y - 5)
+              }
+
+              ctx.fillStyle = textColor
+              ctx.font = '10px system-ui, sans-serif'
+              ctx.textAlign = 'center'
+              ctx.save()
+              ctx.translate(x + barWidth / 2, padding.top + chartHeight + 14)
+              ctx.rotate(-Math.PI / 6)
+              const dateLabel = new Date(d.label).toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+              })
+              ctx.fillText(dateLabel, 0, 0)
+              ctx.restore()
+            })
+          }
+
+          const loadPanel = async () => {
+            try {
+              const response = await fetch(
+                '/dashboard/partials/weekly-conversations${projectId
+                  ? `?projectId=${encodeURIComponent(projectId)}`
+                  : ''}'
+              )
+              if (!response.ok) {
+                throw new Error('Failed to load weekly conversations chart')
+              }
+
+              const result = await response.json()
+              renderChart(result.weeks || [])
+            } catch (_error) {
+              const content = panel.querySelector('.section-content')
+              if (content) {
+                content.innerHTML = '<p class="text-gray-500">Unable to load chart right now.</p>'
+              }
+            }
+          }
+
+          if ('requestIdleCallback' in window) {
+            window.requestIdleCallback(
+              () => {
+                void loadPanel()
+              },
+              { timeout: 1000 }
+            )
+          } else {
+            window.setTimeout(() => {
+              void loadPanel()
+            }, 0)
+          }
+        })()
+      </script>
 
       <!-- Conversations Table -->
       <div class="section">
@@ -626,7 +703,14 @@ overviewRoutes.get('/', async c => {
       </div>
     `
 
-    return c.html(layout('Dashboard', content, '', c))
+    return c.html(
+      layout('Dashboard', content, '', c, {
+        assets: {
+          htmx: false,
+          codeViewer: false,
+        },
+      })
+    )
   } catch (error) {
     return c.html(
       layout(
@@ -637,7 +721,13 @@ overviewRoutes.get('/', async c => {
           </div>
         `,
         '',
-        c
+        c,
+        {
+          assets: {
+            htmx: false,
+            codeViewer: false,
+          },
+        }
       )
     )
   }

--- a/services/proxy/src/routes/api.ts
+++ b/services/proxy/src/routes/api.ts
@@ -708,13 +708,13 @@ apiRoutes.get('/conversations', async c => {
       },
     })
 
+    const normalizedUserEmail = userEmail?.trim().toLowerCase()
     const conditions: string[] = []
     const values: any[] = []
     let paramCount = 0
 
-    // If userEmail is provided, it's always the first parameter
-    if (userEmail) {
-      values.push(userEmail)
+    if (normalizedUserEmail) {
+      values.push(normalizedUserEmail)
       paramCount++
     }
 
@@ -738,210 +738,164 @@ apiRoutes.get('/conversations', async c => {
       values.push(params.dateTo)
     }
 
-    // For non-privacy queries, remove the 'ar.' prefix from conditions
-    const whereClauseNoPrefix =
-      conditions.length > 0
-        ? `WHERE ${conditions.map(c => c.replace('ar.', '')).join(' AND ')}`
-        : ''
-    const whereConditions = conditions.length > 0 ? conditions.join(' AND ') : '' // With ar. prefix for privacy filtering
-
-    // Get conversations grouped by conversation_id with account info and subtask status
-    // Optimized query using "limit first, aggregate second" approach
-    let conversationsQuery: string
-
-    // For early pages without date filters, add a time bound to avoid full table scan
-    // (600K+ rows → ~5K rows). Falls back to full scan for deep pagination or date-filtered queries.
     const needsRows = params.offset + params.limit
-    const useTimeBound = !userEmail && !params.dateFrom && !params.dateTo && needsRows <= 200
-    const timeBoundClause = useTimeBound
-      ? `${whereClauseNoPrefix ? 'AND' : 'WHERE'} timestamp >= NOW() - INTERVAL '7 days'`
+    const useTimeBound =
+      !normalizedUserEmail && !params.dateFrom && !params.dateTo && needsRows <= 200
+    const baseFilters = ['ar.conversation_id IS NOT NULL', ...conditions]
+    if (useTimeBound) {
+      baseFilters.push(`ar.timestamp >= NOW() - INTERVAL '7 days'`)
+    }
+    const whereClause = `WHERE ${baseFilters.join(' AND ')}`
+
+    const privacyCte = normalizedUserEmail
+      ? `
+      accessible_projects AS (
+        SELECT DISTINCT p.project_id
+        FROM projects p
+        LEFT JOIN project_members pm
+          ON p.id = pm.project_id
+          AND LOWER(pm.user_email) = $1
+        WHERE (p.is_private = false OR pm.user_email IS NOT NULL)
+      ),
+    `
+      : ''
+    const privacyJoin = normalizedUserEmail
+      ? 'JOIN accessible_projects ap ON ar.project_id = ap.project_id'
       : ''
 
-    if (userEmail) {
-      // With privacy filtering
-      conversationsQuery = `
-      -- STEP 1 (WITH PRIVACY): Get only the conversation IDs we need for this page with privacy filtering
-      WITH filtered_requests AS (
-        SELECT ar.*
-        FROM api_requests ar
-        JOIN projects p ON ar.project_id = p.project_id
-        LEFT JOIN project_members pm ON p.id = pm.project_id AND LOWER(pm.user_email) = LOWER($1)
-        WHERE (p.is_private = false OR pm.user_email IS NOT NULL)
-          ${whereConditions ? 'AND (' + whereConditions + ')' : ''}
-      ),
-      paginated_conversations AS (
-        SELECT DISTINCT
-          conversation_id,
-          MAX(timestamp) as last_message_time
-        FROM filtered_requests
-        WHERE conversation_id IS NOT NULL
-        GROUP BY conversation_id
-        ORDER BY last_message_time DESC
-        LIMIT $${++paramCount}
-        OFFSET $${++paramCount}
-      ),
-      -- STEP 2: Get all request data ONLY for those paginated conversations
-      relevant_requests AS (
-        SELECT
-          r.request_id,
-          r.conversation_id,
-          r.project_id,
-          r.account_id,
-          r.timestamp,
-          r.input_tokens,
-          r.output_tokens,
-          r.branch_id,
-          r.model,
-          r.is_subtask,
-          r.parent_task_request_id,
-          r.response_body,
-          ROW_NUMBER() OVER (PARTITION BY r.conversation_id ORDER BY r.timestamp DESC, r.request_id DESC) as rn,
-          ROW_NUMBER() OVER (PARTITION BY r.conversation_id, r.is_subtask ORDER BY r.timestamp ASC, r.request_id ASC) as subtask_rn
-        FROM filtered_requests r
-        INNER JOIN paginated_conversations pc ON r.conversation_id = pc.conversation_id
-      ),
-      -- STEP 3: Aggregate data only for the paginated conversations
-      conversation_summary AS (
-        SELECT
-          conversation_id,
-          ARRAY_AGG(DISTINCT project_id) FILTER (WHERE project_id IS NOT NULL) as train_ids,
-          ARRAY_AGG(DISTINCT account_id) FILTER (WHERE account_id IS NOT NULL) as account_ids,
-          MIN(timestamp) as first_message_time,
-          MAX(timestamp) as last_message_time,
-          COUNT(*) as message_count,
-          SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) as total_tokens,
-          COUNT(DISTINCT branch_id) as branch_count,
-          -- Add branch type counts for the new feature
-          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id LIKE 'subtask_%') as subtask_branch_count,
-          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id LIKE 'compact_%') as compact_branch_count,
-          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id IS NOT NULL AND branch_id NOT LIKE 'subtask_%' AND branch_id NOT LIKE 'compact_%' AND branch_id != 'main') as user_branch_count,
-          ARRAY_AGG(DISTINCT model) FILTER (WHERE model IS NOT NULL) as models_used,
-          (array_agg(request_id ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_request_id,
-          (array_agg(model ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_model,
-          (array_agg(response_body ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_response_body,
-          BOOL_OR(is_subtask) as is_subtask,
-          -- Get the parent_task_request_id from the first subtask in the conversation
-          (array_agg(parent_task_request_id ORDER BY subtask_rn) FILTER (WHERE is_subtask = true AND subtask_rn = 1))[1] as parent_task_request_id,
-          COUNT(CASE WHEN is_subtask THEN 1 END) as subtask_message_count
-        FROM relevant_requests
-        GROUP BY conversation_id
-      )
-      -- STEP 4: Final select with parent conversation lookup and preserve order
-      SELECT 
-        cs.*,
-        parent_req.conversation_id as parent_conversation_id
-      FROM conversation_summary cs
-      LEFT JOIN api_requests parent_req ON cs.parent_task_request_id = parent_req.request_id
-      -- Join with paginated_conversations to preserve the original sort order
-      INNER JOIN paginated_conversations pc ON cs.conversation_id = pc.conversation_id
-      ORDER BY pc.last_message_time DESC
-    `
-    } else {
-      // Without privacy filtering
-      conversationsQuery = `
-      -- STEP 1 (NO PRIVACY): Get only the conversation IDs we need for this page
-      WITH paginated_conversations AS (
-        SELECT DISTINCT
-          conversation_id,
-          MAX(timestamp) as last_message_time
-        FROM api_requests
-        ${whereClauseNoPrefix}
-        ${whereClauseNoPrefix ? 'AND' : 'WHERE'} conversation_id IS NOT NULL
-        ${timeBoundClause}
-        GROUP BY conversation_id
-        ORDER BY last_message_time DESC
-        LIMIT $${++paramCount}
-        OFFSET $${++paramCount}
-      ),
-      -- STEP 2: Get all request data ONLY for those paginated conversations
-      relevant_requests AS (
-        SELECT
-          r.request_id,
-          r.conversation_id,
-          r.project_id,
-          r.account_id,
-          r.timestamp,
-          r.input_tokens,
-          r.output_tokens,
-          r.branch_id,
-          r.model,
-          r.is_subtask,
-          r.parent_task_request_id,
-          r.response_body,
-          ROW_NUMBER() OVER (PARTITION BY r.conversation_id ORDER BY r.timestamp DESC, r.request_id DESC) as rn,
-          ROW_NUMBER() OVER (PARTITION BY r.conversation_id, r.is_subtask ORDER BY r.timestamp ASC, r.request_id ASC) as subtask_rn
-        FROM api_requests r
-        INNER JOIN paginated_conversations pc ON r.conversation_id = pc.conversation_id
-      ),
-      -- STEP 3: Aggregate data only for the paginated conversations
-      conversation_summary AS (
-        SELECT
-          conversation_id,
-          ARRAY_AGG(DISTINCT project_id) FILTER (WHERE project_id IS NOT NULL) as train_ids,
-          ARRAY_AGG(DISTINCT account_id) FILTER (WHERE account_id IS NOT NULL) as account_ids,
-          MIN(timestamp) as first_message_time,
-          MAX(timestamp) as last_message_time,
-          COUNT(*) as message_count,
-          SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) as total_tokens,
-          COUNT(DISTINCT branch_id) as branch_count,
-          -- Add branch type counts for the new feature
-          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id LIKE 'subtask_%') as subtask_branch_count,
-          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id LIKE 'compact_%') as compact_branch_count,
-          COUNT(DISTINCT branch_id) FILTER (WHERE branch_id IS NOT NULL AND branch_id NOT LIKE 'subtask_%' AND branch_id NOT LIKE 'compact_%' AND branch_id != 'main') as user_branch_count,
-          ARRAY_AGG(DISTINCT model) FILTER (WHERE model IS NOT NULL) as models_used,
-          (array_agg(request_id ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_request_id,
-          (array_agg(model ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_model,
-          (array_agg(response_body ORDER BY rn) FILTER (WHERE rn = 1))[1] as latest_response_body,
-          BOOL_OR(is_subtask) as is_subtask,
-          -- Get the parent_task_request_id from the first subtask in the conversation
-          (array_agg(parent_task_request_id ORDER BY subtask_rn) FILTER (WHERE is_subtask = true AND subtask_rn = 1))[1] as parent_task_request_id,
-          COUNT(CASE WHEN is_subtask THEN 1 END) as subtask_message_count
-        FROM relevant_requests
-        GROUP BY conversation_id
-      )
-      -- STEP 4: Final select with parent conversation lookup and preserve order
-      SELECT
-        cs.*,
-        parent_req.conversation_id as parent_conversation_id
-      FROM conversation_summary cs
-      LEFT JOIN api_requests parent_req ON cs.parent_task_request_id = parent_req.request_id
-      -- Join with paginated_conversations to preserve the original sort order
-      INNER JOIN paginated_conversations pc ON cs.conversation_id = pc.conversation_id
-      ORDER BY pc.last_message_time DESC
-    `
+    const cacheKey = [
+      'conversations',
+      normalizedUserEmail || 'public',
+      params.projectId || '',
+      params.accountId || '',
+      params.dateFrom || '',
+      params.dateTo || '',
+      params.limit,
+      params.offset,
+      useTimeBound ? 'recent' : 'full',
+    ].join(':')
+
+    const cachedResponse = apiResponseCache.get<{
+      conversations: Array<Record<string, unknown>>
+      pagination: {
+        total: number
+        limit: number
+        offset: number
+        hasMore: boolean
+        page: number
+        totalPages: number
+      }
+    }>(cacheKey)
+    if (cachedResponse) {
+      return c.json(cachedResponse)
     }
 
-    // Add limit and offset parameters
+    const conversationsQuery = `
+      WITH
+      ${privacyCte}
+      paginated_conversations AS (
+        SELECT
+          ar.conversation_id,
+          MAX(ar.timestamp) AS last_message_time
+        FROM api_requests ar
+        ${privacyJoin}
+        ${whereClause}
+        GROUP BY ar.conversation_id
+        ORDER BY last_message_time DESC
+        LIMIT $${++paramCount}
+        OFFSET $${++paramCount}
+      ),
+      conversation_rollups AS (
+        SELECT
+          ar.conversation_id,
+          ARRAY_AGG(DISTINCT ar.project_id) FILTER (WHERE ar.project_id IS NOT NULL) AS train_ids,
+          ARRAY_AGG(DISTINCT ar.account_id) FILTER (WHERE ar.account_id IS NOT NULL) AS account_ids,
+          MIN(ar.timestamp) AS first_message_time,
+          MAX(ar.timestamp) AS last_message_time,
+          COUNT(*) AS message_count,
+          SUM(COALESCE(ar.input_tokens, 0) + COALESCE(ar.output_tokens, 0)) AS total_tokens,
+          COUNT(DISTINCT ar.branch_id) AS branch_count,
+          COUNT(DISTINCT ar.branch_id) FILTER (WHERE ar.branch_id LIKE 'subtask_%') AS subtask_branch_count,
+          COUNT(DISTINCT ar.branch_id) FILTER (WHERE ar.branch_id LIKE 'compact_%') AS compact_branch_count,
+          COUNT(DISTINCT ar.branch_id) FILTER (
+            WHERE ar.branch_id IS NOT NULL
+              AND ar.branch_id NOT LIKE 'subtask_%'
+              AND ar.branch_id NOT LIKE 'compact_%'
+              AND ar.branch_id != 'main'
+          ) AS user_branch_count,
+          ARRAY_AGG(DISTINCT ar.model) FILTER (WHERE ar.model IS NOT NULL) AS models_used,
+          BOOL_OR(ar.is_subtask) AS is_subtask,
+          COUNT(*) FILTER (WHERE ar.is_subtask) AS subtask_message_count
+        FROM api_requests ar
+        ${privacyJoin}
+        INNER JOIN paginated_conversations pc ON ar.conversation_id = pc.conversation_id
+        ${whereClause}
+        GROUP BY ar.conversation_id
+      ),
+      latest_requests AS (
+        SELECT DISTINCT ON (ar.conversation_id)
+          ar.conversation_id,
+          ar.request_id AS latest_request_id,
+          ar.model AS latest_model,
+          ar.response_body AS latest_response_body
+        FROM api_requests ar
+        ${privacyJoin}
+        INNER JOIN paginated_conversations pc ON ar.conversation_id = pc.conversation_id
+        ${whereClause}
+        ORDER BY ar.conversation_id, ar.timestamp DESC, ar.request_id DESC
+      ),
+      first_subtasks AS (
+        SELECT DISTINCT ON (ar.conversation_id)
+          ar.conversation_id,
+          ar.parent_task_request_id
+        FROM api_requests ar
+        ${privacyJoin}
+        INNER JOIN paginated_conversations pc ON ar.conversation_id = pc.conversation_id
+        ${whereClause}
+          AND ar.is_subtask = true
+        ORDER BY ar.conversation_id, ar.timestamp ASC, ar.request_id ASC
+      )
+      SELECT
+        cr.*,
+        lr.latest_request_id,
+        lr.latest_model,
+        lr.latest_response_body,
+        fs.parent_task_request_id,
+        parent_req.conversation_id AS parent_conversation_id
+      FROM conversation_rollups cr
+      INNER JOIN paginated_conversations pc ON cr.conversation_id = pc.conversation_id
+      LEFT JOIN latest_requests lr ON lr.conversation_id = cr.conversation_id
+      LEFT JOIN first_subtasks fs ON fs.conversation_id = cr.conversation_id
+      LEFT JOIN api_requests parent_req ON fs.parent_task_request_id = parent_req.request_id
+      ORDER BY pc.last_message_time DESC
+    `
+
     values.push(params.limit)
     values.push(params.offset)
 
-    // Get total count for pagination with privacy filtering
-    const countQuery = userEmail
+    const countQuery = normalizedUserEmail
       ? `
-      WITH filtered_requests AS (
-        SELECT ar.conversation_id
-        FROM api_requests ar
-        JOIN projects p ON ar.project_id = p.project_id
-        LEFT JOIN project_members pm ON p.id = pm.project_id AND LOWER(pm.user_email) = LOWER($1)
+      WITH
+      accessible_projects AS (
+        SELECT DISTINCT p.project_id
+        FROM projects p
+        LEFT JOIN project_members pm
+          ON p.id = pm.project_id
+          AND LOWER(pm.user_email) = $1
         WHERE (p.is_private = false OR pm.user_email IS NOT NULL)
-          ${whereConditions ? 'AND (' + whereConditions + ')' : ''}
-          AND conversation_id IS NOT NULL
       )
-      SELECT COUNT(DISTINCT conversation_id) as total
-      FROM filtered_requests
+      SELECT COUNT(DISTINCT ar.conversation_id) AS total
+      FROM api_requests ar
+      JOIN accessible_projects ap ON ar.project_id = ap.project_id
+      ${whereClause}
     `
       : `
-      SELECT COUNT(DISTINCT conversation_id) as total
-      FROM api_requests
-      ${whereClauseNoPrefix}
-      ${whereClauseNoPrefix ? 'AND' : 'WHERE'} conversation_id IS NOT NULL
-      ${timeBoundClause}
+      SELECT COUNT(DISTINCT ar.conversation_id) AS total
+      FROM api_requests ar
+      ${whereClause}
     `
 
-    // Execute both queries in parallel
-    // For count query, exclude the last two values (limit and offset)
     const countValues = values.slice(0, values.length - 2)
-
     const [conversationsResult, countResult] = await Promise.all([
       pool.query(conversationsQuery, values),
       pool.query(countQuery, countValues),
@@ -950,46 +904,44 @@ apiRoutes.get('/conversations', async c => {
     const totalCount = parseInt(countResult.rows[0]?.total || 0)
     const hasMore = params.offset + params.limit < totalCount
 
-    const conversations = conversationsResult.rows.map(row => {
-      // Calculate context tokens from the latest response
-      let latestContextTokens = 0
-      if (row.latest_response_body?.usage) {
-        const usage = row.latest_response_body.usage
-        latestContextTokens =
-          (usage.input_tokens || 0) +
-          (usage.cache_read_input_tokens || 0) +
-          (usage.cache_creation_input_tokens || 0)
-      }
+    const responseData = {
+      conversations: conversationsResult.rows.map(row => {
+        // Calculate context tokens from the latest response
+        let latestContextTokens = 0
+        if (row.latest_response_body?.usage) {
+          const usage = row.latest_response_body.usage
+          latestContextTokens =
+            (usage.input_tokens || 0) +
+            (usage.cache_read_input_tokens || 0) +
+            (usage.cache_creation_input_tokens || 0)
+        }
 
-      return {
-        conversationId: row.conversation_id,
-        trainIds: row.train_ids || [],
-        accountIds: row.account_ids || [],
-        // Keep backward compatibility with single projectId/accountId (use first one)
-        projectId: (row.train_ids && row.train_ids[0]) || '',
-        accountId: (row.account_ids && row.account_ids[0]) || null,
-        firstMessageTime: row.first_message_time,
-        lastMessageTime: row.last_message_time,
-        messageCount: parseInt(row.message_count),
-        totalTokens: parseInt(row.total_tokens),
-        branchCount: parseInt(row.branch_count),
-        // Add new branch type counts
-        subtaskBranchCount: parseInt(row.subtask_branch_count || 0),
-        compactBranchCount: parseInt(row.compact_branch_count || 0),
-        userBranchCount: parseInt(row.user_branch_count || 0),
-        modelsUsed: row.models_used,
-        latestRequestId: row.latest_request_id,
-        latestModel: row.latest_model,
-        latestContextTokens,
-        isSubtask: row.is_subtask,
-        parentTaskRequestId: row.parent_task_request_id,
-        parentConversationId: row.parent_conversation_id,
-        subtaskMessageCount: parseInt(row.subtask_message_count || 0),
-      }
-    })
-
-    return c.json({
-      conversations,
+        return {
+          conversationId: row.conversation_id,
+          trainIds: row.train_ids || [],
+          accountIds: row.account_ids || [],
+          // Keep backward compatibility with single projectId/accountId (use first one)
+          projectId: (row.train_ids && row.train_ids[0]) || '',
+          accountId: (row.account_ids && row.account_ids[0]) || null,
+          firstMessageTime: row.first_message_time,
+          lastMessageTime: row.last_message_time,
+          messageCount: parseInt(row.message_count),
+          totalTokens: parseInt(row.total_tokens),
+          branchCount: parseInt(row.branch_count),
+          // Add new branch type counts
+          subtaskBranchCount: parseInt(row.subtask_branch_count || 0),
+          compactBranchCount: parseInt(row.compact_branch_count || 0),
+          userBranchCount: parseInt(row.user_branch_count || 0),
+          modelsUsed: row.models_used,
+          latestRequestId: row.latest_request_id,
+          latestModel: row.latest_model,
+          latestContextTokens,
+          isSubtask: row.is_subtask,
+          parentTaskRequestId: row.parent_task_request_id,
+          parentConversationId: row.parent_conversation_id,
+          subtaskMessageCount: parseInt(row.subtask_message_count || 0),
+        }
+      }),
       pagination: {
         total: totalCount,
         limit: params.limit,
@@ -998,7 +950,10 @@ apiRoutes.get('/conversations', async c => {
         page: Math.floor(params.offset / params.limit) + 1,
         totalPages: Math.ceil(totalCount / params.limit),
       },
-    })
+    }
+
+    apiResponseCache.set(cacheKey, responseData, 15)
+    return c.json(responseData)
   } catch (error) {
     if (error instanceof z.ZodError) {
       return c.json({ error: 'Invalid parameters', details: error.errors }, 400)


### PR DESCRIPTION
## What changed

- reduced dashboard main-page blocking work by deferring the weekly chart request until after first paint
- stopped the overview layout from loading HTMX, highlight.js, and the JSON viewer on pages that do not use them
- rewrote the proxy /api/conversations query to page conversation ids first, aggregate only the selected conversations, and fetch latest response bodies separately instead of carrying wide rows through the whole pipeline
- added a short response cache for /api/conversations to speed up repeated dashboard refreshes

## Why

- the dashboard overview was dominated by the conversations query and unnecessary upfront asset loading
- the previous SQL materialized very wide intermediate rows and spilled to temp files before pagination

## Impact

- live timing against the configured database improved the dashboard main page from roughly 10.2s cold / 4.3s overlapping warm to about 7.3s cold and about 2.0s once the first optimized query completed and caches were warm
- the deferred weekly panel is no longer part of the initial HTML critical path

## Validation

- bun run typecheck
- bun test services/dashboard/src/routes/__tests__/dark-mode.integration.test.ts services/dashboard/src/layout/__tests__/theme.test.ts services/proxy/src/routes/__tests__
