### PR TITLE
chore: remove references to public demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Agent Prompt Train empowers development teams to maximize their Claude AI usage 
 - 📈 **Historical Analytics**: Comprehensive activity history enabling usage monitoring, pattern identification, and continuous improvement
 - 🤖 **Intelligent Insights**: AI-powered conversation analysis providing actionable prompt optimization suggestions and best practice recommendations
 
+## 🚀 Demo
+
+![Image](https://github.com/user-attachments/assets/d7200534-3be0-4225-8f9f-ac96b9bf3978)
+
+<img src="https://github.com/user-attachments/assets/aebffb8c-9535-4073-aa76-be31ee05a402" alt="Agent Prompt Train Dashboard" width="800">
+
 ## ✨ Features
 
 - 🚀 **High-Performance Proxy** - Built with Bun and Hono for minimal latency

--- a/README.md
+++ b/README.md
@@ -35,18 +35,6 @@ Agent Prompt Train empowers development teams to maximize their Claude AI usage 
 - 📈 **Historical Analytics**: Comprehensive activity history enabling usage monitoring, pattern identification, and continuous improvement
 - 🤖 **Intelligent Insights**: AI-powered conversation analysis providing actionable prompt optimization suggestions and best practice recommendations
 
-## 🚀 Demo
-
-![Image](https://github.com/user-attachments/assets/d7200534-3be0-4225-8f9f-ac96b9bf3978)
-
-Experience Agent Prompt Train in action with our live demo:
-
-👉 **[https://prompttrain-demo.moonsonglabs.dev](https://prompttrain-demo.moonsonglabs.dev)**
-
-_Note: This is a read-only demo showcasing real usage data from our development team._
-
-<img src="https://github.com/user-attachments/assets/aebffb8c-9535-4073-aa76-be31ee05a402" alt="Agent Prompt Train Dashboard" width="800">
-
 ## ✨ Features
 
 - 🚀 **High-Performance Proxy** - Built with Bun and Hono for minimal latency


### PR DESCRIPTION
## Summary

- Remove the link to the (now disabled) public demo at `https://prompttrain-demo.moonsonglabs.dev` and its surrounding description from the `## 🚀 Demo` section in the README
- Keep both dashboard images and the section heading intact

## Test plan

- [x] Verify no remaining references to `prompttrain-demo` or `moonsonglabs.dev` in the repo
- [x] README still renders the Demo section with both images
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)