### PR TITLE
fix: handle modern Claude content blocks for Claude Code traffic

### DIFF
--- a/docs/06-Reference/api-schemas.md
+++ b/docs/06-Reference/api-schemas.md
@@ -26,9 +26,36 @@ interface Message {
 }
 
 interface ContentBlock {
-  type: 'text' | 'image'
+  type:
+    | 'text'
+    | 'image'
+    | 'tool_use'
+    | 'tool_result'
+    // Extended thinking blocks (Claude 4.x adaptive thinking). The
+    // `signature` field must be round-tripped unchanged when echoing
+    // assistant messages back to the API.
+    | 'thinking'
+    | 'redacted_thinking'
+    // Anthropic-hosted server tools (web_search, code_execution, MCP
+    // connector). `server_tool_use` is the call; the matching
+    // `*_tool_result` block is the response.
+    | 'server_tool_use'
+    | 'web_search_tool_result'
+    | 'code_execution_tool_result'
   text?: string // For text blocks
   source?: ImageSource // For image blocks
+  // tool_use / server_tool_use fields
+  id?: string
+  name?: string
+  input?: unknown
+  // tool_result / *_tool_result fields
+  tool_use_id?: string
+  content?: string | ContentBlock[] | unknown
+  // thinking-block fields
+  thinking?: string
+  signature?: string
+  // redacted_thinking field
+  data?: string
 }
 
 interface ImageSource {
@@ -51,7 +78,19 @@ interface MessagesResponse {
   role: 'assistant'
   content: ContentBlock[]
   model: string
-  stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence'
+  stop_reason:
+    | 'end_turn'
+    | 'max_tokens'
+    | 'stop_sequence'
+    | 'tool_use'
+    // Server-tool sequence paused; clients must continue with the same
+    // container id.
+    | 'pause_turn'
+    // Streaming-classifier safety refusal. Conversation context should
+    // be reset before retrying.
+    | 'refusal'
+    // Generation hit the context window (Claude 4.5+ behaviour).
+    | 'model_context_window_exceeded'
   stop_sequence?: string
   usage: TokenUsage
 }
@@ -61,6 +100,13 @@ interface TokenUsage {
   output_tokens: number
   cache_creation_input_tokens?: number
   cache_read_input_tokens?: number
+  // Per-TTL-tier breakdown for prompt caching. The sum equals
+  // `cache_creation_input_tokens`. Captured verbatim in the proxy's
+  // `usage_data` JSONB column.
+  cache_creation?: {
+    ephemeral_5m_input_tokens?: number
+    ephemeral_1h_input_tokens?: number
+  }
 }
 ```
 
@@ -98,15 +144,29 @@ interface MessageStartEvent {
 interface ContentBlockDeltaEvent {
   type: 'content_block_delta'
   index: number
-  delta: {
-    type: 'text_delta'
-    text: string
-  }
+  delta:
+    | { type: 'text_delta'; text: string }
+    | { type: 'input_json_delta'; partial_json: string }
+    // Extended-thinking deltas. `thinking_delta` carries the streamed
+    // thinking text; `signature_delta` is emitted once when the block
+    // closes and must be preserved by the client.
+    | { type: 'thinking_delta'; thinking: string }
+    | { type: 'signature_delta'; signature: string }
+    // Web-search citation deltas (forwarded verbatim by the proxy; not
+    // currently parsed for metrics).
+    | { type: 'citations_delta'; citation: unknown }
 }
 
 interface MessageStopEvent {
   type: 'message_stop'
-  stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence'
+  stop_reason:
+    | 'end_turn'
+    | 'max_tokens'
+    | 'stop_sequence'
+    | 'tool_use'
+    | 'pause_turn'
+    | 'refusal'
+    | 'model_context_window_exceeded'
   stop_sequence?: string
   usage?: TokenUsage // Final token counts
 }

--- a/docs/06-Reference/changelog.md
+++ b/docs/06-Reference/changelog.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Conversation tracking for modern Claude API traffic (Claude 4.x adaptive thinking, server tools): `ConversationLinker` previously hashed every unknown content block to the literal `[N]<type>:unknown`, so all `thinking`, `redacted_thinking`, and `server_tool_use` blocks collapsed to the same hash. Parent-message lookup could match wrong conversations when Claude Code or any other client produced extended-thinking turns. Distinct serializers are now used for `thinking` (keyed on `signature`), `redacted_thinking`, `server_tool_use`, `web_search_tool_result`, and `code_execution_tool_result` blocks.
+- `ProxyResponse` now counts `server_tool_use` blocks in `toolCallCount` and exposes them via `toolCalls` (previously only `tool_use` was counted, undercounting any turn that used web_search / code_execution).
+- Streaming `thinking_delta` and `signature_delta` events are now captured into new `thinkingContent` and `thinkingSignatures` getters instead of being dropped. Visible `content` is no longer polluted with thinking text. Unknown delta types (e.g. `citations_delta`) are forwarded but ignored for metrics.
+
 ### Changed
 
+- TypeScript types in `@agent-prompttrain/shared` updated to reflect 2026 Anthropic API surface: `ClaudeContent.type` union extended with `thinking`, `redacted_thinking`, `server_tool_use`, `web_search_tool_result`, `code_execution_tool_result`; `stop_reason` extended with `pause_turn`, `refusal`, `model_context_window_exceeded`; `ClaudeStreamEvent.delta.type` extended with `thinking_delta`, `signature_delta`, `citations_delta`.
 - Token Usage overview: projects with zero tokens are now hidden from the project list
 - Token Usage overview: project list now shows 2-line format with percentage of 5-hour and 7-day windows including date ranges
 - API `/api/token-usage/accounts` now returns `outputTokens7d` and `requests7d` per project for 7-day window usage

--- a/packages/shared/src/types/claude.ts
+++ b/packages/shared/src/types/claude.ts
@@ -9,7 +9,22 @@ export interface ClaudeMessage {
 }
 
 export interface ClaudeContent {
-  type: 'text' | 'image' | 'tool_use' | 'tool_result'
+  type:
+    | 'text'
+    | 'image'
+    | 'tool_use'
+    | 'tool_result'
+    // Extended thinking — emitted by Claude 4.x adaptive-thinking turns
+    // and echoed back into the next request. Carries `thinking` text and
+    // a `signature` that the API uses to verify continuity.
+    | 'thinking'
+    | 'redacted_thinking'
+    // Anthropic-hosted server tools (web_search, code_execution, MCP
+    // connector, container runtime). `server_tool_use` is the request,
+    // the matching `*_tool_result` block is the response.
+    | 'server_tool_use'
+    | 'web_search_tool_result'
+    | 'code_execution_tool_result'
   text?: string
   source?: {
     type: 'base64'
@@ -20,7 +35,13 @@ export interface ClaudeContent {
   name?: string
   input?: any
   tool_use_id?: string
-  content?: string | ClaudeContent[]
+  content?: string | ClaudeContent[] | any
+  // Extended-thinking fields. `thinking` is the natural-language trace;
+  // `signature` is opaque and must be round-tripped untouched. `data` is
+  // the encrypted payload for `redacted_thinking` blocks.
+  thinking?: string
+  signature?: string
+  data?: string
 }
 
 export interface ClaudeTool {
@@ -75,7 +96,22 @@ export interface ClaudeMessagesResponse {
   role: 'assistant'
   content: ClaudeContent[]
   model: string
-  stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | null
+  stop_reason:
+    | 'end_turn'
+    | 'max_tokens'
+    | 'stop_sequence'
+    | 'tool_use'
+    // Returned when a server-tool sequence (e.g. heavy web_search) needs
+    // to be continued with a follow-up request that carries the same
+    // container id. Clients must re-issue rather than treat the turn as
+    // finished.
+    | 'pause_turn'
+    // Streaming-classifier safety refusal (Claude 4 models). The
+    // conversation context should be reset/rephrased before continuing.
+    | 'refusal'
+    // The model hit the context window mid-generation (Claude 4.5+).
+    | 'model_context_window_exceeded'
+    | null
   stop_sequence: string | null
   usage: {
     input_tokens: number
@@ -100,9 +136,21 @@ export interface ClaudeStreamEvent {
   index?: number
   content_block?: ClaudeContent
   delta?: {
-    type?: 'text_delta' | 'input_json_delta'
+    // `thinking_delta` carries extended-thinking text, `signature_delta`
+    // the signature for the just-closed thinking block, and
+    // `citations_delta` web-search citations. Older clients can ignore
+    // the new variants — the proxy forwards them verbatim.
+    type?:
+      | 'text_delta'
+      | 'input_json_delta'
+      | 'thinking_delta'
+      | 'signature_delta'
+      | 'citations_delta'
     text?: string
     partial_json?: string
+    thinking?: string
+    signature?: string
+    citation?: any
     stop_reason?: string
     stop_sequence?: string
   }

--- a/packages/shared/src/utils/__tests__/conversation-linker.test.ts
+++ b/packages/shared/src/utils/__tests__/conversation-linker.test.ts
@@ -849,6 +849,148 @@ describe('Dual Hash System - Message and System Hashing', () => {
       const hash2 = hashMessagesOnly(messagesWithoutDuplicates)
       expect(hash1).toBe(hash2)
     })
+
+    describe('modern content block types (B1 regression)', () => {
+      // Background: prior to this fix, the default branch in
+      // ConversationLinker.serializeContentItem returned `[N]<type>:unknown`
+      // for every unrecognized type. That meant every `thinking`,
+      // `server_tool_use`, etc. block in every conversation hashed to the
+      // same string, causing wrong parent matches when Claude Code uses
+      // adaptive thinking or server-side tools.
+
+      test('different thinking content produces different hashes', () => {
+        const base = (thinking: string, signature: string): ClaudeMessage[] => [
+          { role: 'user', content: 'tell me a story' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking, signature } as any,
+              { type: 'text', text: 'Here is a story...' },
+            ],
+          },
+        ]
+
+        const hash1 = hashMessagesOnly(base('Plot involves a cat.', 'sig-aaa'))
+        const hash2 = hashMessagesOnly(base('Plot involves a dog.', 'sig-bbb'))
+        expect(hash1).not.toBe(hash2)
+      })
+
+      test('thinking signature alone differentiates blocks', () => {
+        // Anthropic guarantees signature is deterministic for identical input,
+        // so the same signature must produce the same hash even if the
+        // thinking text is later truncated/redacted.
+        const base = (signature: string): ClaudeMessage[] => [
+          { role: 'user', content: 'tell me a story' },
+          {
+            role: 'assistant',
+            content: [{ type: 'thinking', thinking: '', signature } as any],
+          },
+        ]
+
+        const h1 = hashMessagesOnly(base('signature-1'))
+        const h2 = hashMessagesOnly(base('signature-2'))
+        expect(h1).not.toBe(h2)
+      })
+
+      test('different redacted_thinking blocks produce different hashes', () => {
+        const make = (data: string): ClaudeMessage[] => [
+          { role: 'user', content: 'sensitive question' },
+          {
+            role: 'assistant',
+            content: [{ type: 'redacted_thinking', data } as any],
+          },
+        ]
+
+        const h1 = hashMessagesOnly(make('encrypted-payload-1'))
+        const h2 = hashMessagesOnly(make('encrypted-payload-2'))
+        expect(h1).not.toBe(h2)
+      })
+
+      test('different server_tool_use blocks produce different hashes', () => {
+        const make = (name: string, input: unknown): ClaudeMessage[] => [
+          { role: 'user', content: 'do research' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'server_tool_use',
+                id: 'srv_1',
+                name,
+                input,
+              } as any,
+            ],
+          },
+        ]
+
+        const h1 = hashMessagesOnly(make('web_search', { query: 'cats' }))
+        const h2 = hashMessagesOnly(make('web_search', { query: 'dogs' }))
+        const h3 = hashMessagesOnly(make('code_execution', { code: 'print(1)' }))
+        expect(h1).not.toBe(h2)
+        expect(h1).not.toBe(h3)
+        expect(h2).not.toBe(h3)
+      })
+
+      test('different web_search_tool_result blocks produce different hashes', () => {
+        const make = (content: unknown): ClaudeMessage[] => [
+          { role: 'user', content: 'search' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'web_search_tool_result',
+                tool_use_id: 'srv_1',
+                content,
+              } as any,
+            ],
+          },
+        ]
+
+        const h1 = hashMessagesOnly(make([{ url: 'https://a.com', title: 'A' }]))
+        const h2 = hashMessagesOnly(make([{ url: 'https://b.com', title: 'B' }]))
+        expect(h1).not.toBe(h2)
+      })
+
+      test('different code_execution_tool_result blocks produce different hashes', () => {
+        const make = (content: unknown): ClaudeMessage[] => [
+          { role: 'user', content: 'compute' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'code_execution_tool_result',
+                tool_use_id: 'srv_1',
+                content,
+              } as any,
+            ],
+          },
+        ]
+
+        const h1 = hashMessagesOnly(make({ stdout: '42' }))
+        const h2 = hashMessagesOnly(make({ stdout: '43' }))
+        expect(h1).not.toBe(h2)
+      })
+
+      test('identical modern blocks produce identical hashes', () => {
+        // Sanity check: serialization must still be deterministic.
+        const messages: ClaudeMessage[] = [
+          { role: 'user', content: 'q' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'deep thoughts', signature: 'sig-x' } as any,
+              {
+                type: 'server_tool_use',
+                id: 'srv_1',
+                name: 'web_search',
+                input: { query: 'q' },
+              } as any,
+            ],
+          },
+        ]
+
+        expect(hashMessagesOnly(messages)).toBe(hashMessagesOnly(messages))
+      })
+    })
   })
 
   describe('hashSystemPrompt', () => {

--- a/packages/shared/src/utils/conversation-linker.ts
+++ b/packages/shared/src/utils/conversation-linker.ts
@@ -757,9 +757,61 @@ export class ConversationLinker {
         return this.serializeToolUseItem(item, index)
       case 'tool_result':
         return this.serializeToolResultItem(item, index)
+      case 'thinking':
+        return this.serializeThinkingItem(item, index)
+      case 'redacted_thinking':
+        return this.serializeRedactedThinkingItem(item, index)
+      case 'server_tool_use':
+        return this.serializeServerToolUseItem(item, index)
+      case 'web_search_tool_result':
+      case 'code_execution_tool_result':
+        return this.serializeServerToolResultItem(item, index)
       default:
-        return `[${index}]${item.type}:unknown`
+        // Hash the full item so unknown future block types contribute
+        // their content to the hash instead of collapsing to a single
+        // sentinel string. JSON.stringify iterates own keys in insertion
+        // order, which is stable for objects parsed from the same JSON.
+        return `[${index}]${item.type}:${JSON.stringify(item)}`
     }
+  }
+
+  private serializeThinkingItem(item: ClaudeContent, index: number): string {
+    // The signature is the canonical, deterministic identifier of a
+    // thinking block (Anthropic returns the same signature for identical
+    // inputs and the client echoes it back verbatim on later turns). When
+    // absent (e.g. mid-stream before signature_delta arrives) we fall
+    // back to hashing the thinking text so identical text still hashes
+    // identically.
+    const signature = (item as any).signature as string | undefined
+    if (signature) {
+      return `[${index}]thinking:sig:${signature}`
+    }
+    const thinking = (item as any).thinking as string | undefined
+    const digest = createHash('sha256')
+      .update(thinking || '')
+      .digest('hex')
+    return `[${index}]thinking:text:${digest}`
+  }
+
+  private serializeRedactedThinkingItem(item: ClaudeContent, index: number): string {
+    const data = (item as any).data as string | undefined
+    const digest = createHash('sha256')
+      .update(data || '')
+      .digest('hex')
+    return `[${index}]redacted_thinking:${digest}`
+  }
+
+  private serializeServerToolUseItem(item: ClaudeContent, index: number): string {
+    return `[${index}]server_tool_use:${item.name}:${item.id}:${JSON.stringify(item.input)}`
+  }
+
+  private serializeServerToolResultItem(item: ClaudeContent, index: number): string {
+    // content is provider-defined (e.g. search results array, code output
+    // object); JSON.stringify keeps it bounded since the proxy already
+    // limits request size upstream.
+    const contentStr =
+      typeof item.content === 'string' ? item.content : JSON.stringify(item.content ?? '')
+    return `[${index}]${item.type}:${item.tool_use_id}:${contentStr}`
   }
 
   private serializeTextItem(item: ClaudeContent, index: number): string {

--- a/services/proxy/src/domain/entities/ProxyResponse.ts
+++ b/services/proxy/src/domain/entities/ProxyResponse.ts
@@ -1,5 +1,16 @@
-import { ClaudeMessagesResponse, ClaudeStreamEvent, hasToolUse } from '@agent-prompttrain/shared'
+import { ClaudeMessagesResponse, ClaudeStreamEvent } from '@agent-prompttrain/shared'
 import { logger } from '../../middleware/logger'
+
+// Content block types that represent a model-initiated tool invocation.
+// `tool_use` is the standard client-side tool; `server_tool_use` is an
+// Anthropic-hosted tool (web_search, code_execution, etc.) that the API
+// runs server-side. Both should be counted as tool calls for tracking
+// purposes; the `*_tool_result` blocks are responses, not calls.
+const TOOL_USE_BLOCK_TYPES = new Set(['tool_use', 'server_tool_use'])
+
+function isToolUseBlock(c: { type?: string } | undefined): boolean {
+  return !!c && typeof c.type === 'string' && TOOL_USE_BLOCK_TYPES.has(c.type)
+}
 
 /**
  * Domain entity representing a proxy response
@@ -12,6 +23,8 @@ export class ProxyResponse {
   private _cacheReadInputTokens: number = 0
   private _toolCallCount: number = 0
   private _content: string = ''
+  private _thinkingContent: string = ''
+  private _thinkingSignatures: string[] = []
   private _fullUsageData: any = null
   private _toolCalls: Array<{ name: string; id?: string; input?: any }> = []
   private _currentToolIndex: number = -1
@@ -58,6 +71,14 @@ export class ProxyResponse {
     return this._fullUsageData
   }
 
+  get thinkingContent(): string {
+    return this._thinkingContent
+  }
+
+  get thinkingSignatures(): string[] {
+    return this._thinkingSignatures
+  }
+
   /**
    * Process a non-streaming response
    */
@@ -79,9 +100,11 @@ export class ProxyResponse {
       },
     })
 
-    // Count tool calls and extract tool info
-    if (response.content && hasToolUse(response.content)) {
-      const toolUses = response.content.filter(c => c.type === 'tool_use')
+    // Count tool calls (both client-side `tool_use` and server-hosted
+    // `server_tool_use` blocks). `*_tool_result` blocks are responses,
+    // not calls, and are intentionally excluded.
+    if (response.content) {
+      const toolUses = response.content.filter(isToolUseBlock)
       this._toolCallCount = toolUses.length
       this._toolCalls = toolUses.map(tool => ({
         name: tool.name || 'unknown',
@@ -96,6 +119,23 @@ export class ProxyResponse {
         ?.filter(c => c.type === 'text')
         .map(c => c.text)
         .join('\n') || ''
+
+    // Capture thinking blocks separately so they're available for
+    // observability without polluting the human-visible `content` field.
+    if (response.content) {
+      for (const block of response.content) {
+        if (block.type === 'thinking') {
+          const thinking = (block as any).thinking as string | undefined
+          const signature = (block as any).signature as string | undefined
+          if (thinking) {
+            this._thinkingContent += thinking
+          }
+          if (signature) {
+            this._thinkingSignatures.push(signature)
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -174,26 +214,41 @@ export class ProxyResponse {
         break
 
       case 'content_block_start':
-        if (event.content_block?.type === 'tool_use') {
+        if (isToolUseBlock(event.content_block)) {
           this._toolCallCount++
           this._currentToolIndex = this._toolCalls.length
           this._toolInputAccumulator = ''
           this._toolCalls.push({
-            name: event.content_block.name || 'unknown',
-            id: event.content_block.id,
-            input: event.content_block.input || {},
+            name: event.content_block?.name || 'unknown',
+            id: event.content_block?.id,
+            input: event.content_block?.input || {},
           })
         }
         break
 
-      case 'content_block_delta':
-        if (event.delta?.type === 'text_delta' && event.delta.text) {
+      case 'content_block_delta': {
+        const deltaType = event.delta?.type
+        if (deltaType === 'text_delta' && event.delta?.text) {
           this._content += event.delta.text
-        } else if (event.delta?.type === 'input_json_delta' && event.delta.partial_json) {
+        } else if (deltaType === 'input_json_delta' && event.delta?.partial_json) {
           // Accumulate tool input JSON
           this._toolInputAccumulator += event.delta.partial_json
+        } else if (deltaType === 'thinking_delta') {
+          const t = (event.delta as any)?.thinking
+          if (typeof t === 'string') {
+            this._thinkingContent += t
+          }
+        } else if (deltaType === 'signature_delta') {
+          const sig = (event.delta as any)?.signature
+          if (typeof sig === 'string' && sig.length > 0) {
+            this._thinkingSignatures.push(sig)
+          }
         }
+        // Unknown delta types (e.g. `citations_delta`) are intentionally
+        // ignored here — the raw SSE line is still forwarded verbatim to
+        // the client by the streaming pipeline.
         break
+      }
 
       case 'content_block_stop':
         // Parse accumulated tool input when block stops

--- a/services/proxy/src/domain/entities/__tests__/ProxyResponse.test.ts
+++ b/services/proxy/src/domain/entities/__tests__/ProxyResponse.test.ts
@@ -1,0 +1,214 @@
+import { describe, test, expect, mock } from 'bun:test'
+
+// The middleware logger reads from request context; stub it out so the
+// entity can be constructed without a real Hono request.
+mock.module('../../../middleware/logger', () => ({
+  logger: {
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  },
+}))
+
+import { ProxyResponse } from '../ProxyResponse'
+import type { ClaudeMessagesResponse, ClaudeStreamEvent } from '@agent-prompttrain/shared'
+
+const baseResponse = (overrides: Partial<ClaudeMessagesResponse> = {}): ClaudeMessagesResponse => ({
+  id: 'msg_1',
+  type: 'message',
+  role: 'assistant',
+  model: 'claude-opus-4-7',
+  stop_reason: 'end_turn',
+  stop_sequence: null,
+  content: [],
+  usage: { input_tokens: 10, output_tokens: 5 },
+  ...overrides,
+})
+
+describe('ProxyResponse — modern Claude content blocks', () => {
+  describe('B2: server_tool_use counted as a tool call', () => {
+    test('non-streaming response includes server_tool_use in tool list', () => {
+      const r = new ProxyResponse('req_1', false)
+      r.processResponse(
+        baseResponse({
+          content: [
+            { type: 'text', text: 'Let me search.' },
+            {
+              type: 'server_tool_use',
+              id: 'srv_1',
+              name: 'web_search',
+              input: { query: 'cats' },
+            } as any,
+            {
+              type: 'web_search_tool_result',
+              tool_use_id: 'srv_1',
+              content: [{ url: 'https://example.com', title: 'cats' }],
+            } as any,
+            { type: 'tool_use', id: 'cli_1', name: 'calculator', input: { a: 1 } } as any,
+          ],
+        })
+      )
+
+      // server_tool_use + tool_use = 2; results are not calls
+      expect(r.toolCallCount).toBe(2)
+      const names = r.toolCalls.map(t => t.name)
+      expect(names).toContain('web_search')
+      expect(names).toContain('calculator')
+    })
+
+    test('streaming response counts server_tool_use blocks', () => {
+      const r = new ProxyResponse('req_2', true)
+
+      const events: ClaudeStreamEvent[] = [
+        {
+          type: 'message_start',
+          message: baseResponse({ usage: { input_tokens: 7, output_tokens: 0 } }),
+        },
+        {
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'server_tool_use',
+            id: 'srv_1',
+            name: 'web_search',
+            input: {},
+          } as any,
+        },
+        {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"query":"cats"}' } as any,
+        },
+        { type: 'content_block_stop', index: 0 } as any,
+        { type: 'message_stop' },
+      ]
+
+      events.forEach(e => r.processStreamEvent(e))
+
+      expect(r.toolCallCount).toBe(1)
+      expect(r.toolCalls[0].name).toBe('web_search')
+      // input_json_delta payload should be parsed into the tool call
+      expect(r.toolCalls[0].input).toEqual({ query: 'cats' })
+    })
+
+    test('streaming response does NOT count *_tool_result blocks as calls', () => {
+      const r = new ProxyResponse('req_3', true)
+
+      const events: ClaudeStreamEvent[] = [
+        {
+          type: 'message_start',
+          message: baseResponse({ usage: { input_tokens: 1, output_tokens: 0 } }),
+        },
+        {
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srv_1',
+            content: [],
+          } as any,
+        },
+        { type: 'content_block_stop', index: 0 } as any,
+        { type: 'message_stop' },
+      ]
+      events.forEach(e => r.processStreamEvent(e))
+
+      expect(r.toolCallCount).toBe(0)
+    })
+  })
+
+  describe('B3: thinking deltas captured', () => {
+    test('thinking_delta and signature_delta accumulate without polluting _content', () => {
+      const r = new ProxyResponse('req_4', true)
+
+      const events: ClaudeStreamEvent[] = [
+        {
+          type: 'message_start',
+          message: baseResponse({ usage: { input_tokens: 1, output_tokens: 0 } }),
+        },
+        {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'thinking', thinking: '', signature: '' } as any,
+        },
+        {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'thinking_delta', thinking: 'Let me ' } as any,
+        },
+        {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'thinking_delta', thinking: 'reason...' } as any,
+        },
+        {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'signature_delta', signature: 'sig-aaa' } as any,
+        },
+        { type: 'content_block_stop', index: 0 } as any,
+        {
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'text', text: '' } as any,
+        },
+        {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'text_delta', text: 'The answer is 42.' } as any,
+        },
+        { type: 'content_block_stop', index: 1 } as any,
+        { type: 'message_stop' },
+      ]
+
+      events.forEach(e => r.processStreamEvent(e))
+
+      // Visible content must NOT include the thinking text
+      expect(r.content).toBe('The answer is 42.')
+      // Thinking text is captured separately
+      expect(r.thinkingContent).toBe('Let me reason...')
+      // Signature(s) are captured for downstream verification
+      expect(r.thinkingSignatures).toEqual(['sig-aaa'])
+    })
+
+    test('non-streaming thinking blocks are captured', () => {
+      const r = new ProxyResponse('req_5', false)
+      r.processResponse(
+        baseResponse({
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'Deep thoughts',
+              signature: 'sig-1',
+            } as any,
+            { type: 'text', text: 'Hello.' },
+          ],
+        })
+      )
+
+      expect(r.content).toBe('Hello.')
+      expect(r.thinkingContent).toBe('Deep thoughts')
+      expect(r.thinkingSignatures).toEqual(['sig-1'])
+    })
+
+    test('unknown content_block_delta types do not throw', () => {
+      const r = new ProxyResponse('req_6', true)
+
+      const events: ClaudeStreamEvent[] = [
+        {
+          type: 'message_start',
+          message: baseResponse({ usage: { input_tokens: 1, output_tokens: 0 } }),
+        },
+        {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'citations_delta', citation: { url: 'https://x' } } as any,
+        },
+        { type: 'message_stop' },
+      ]
+
+      expect(() => events.forEach(e => r.processStreamEvent(e))).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes three regressions affecting Claude Code traffic through the proxy on Claude 4.6 / 4.7 (adaptive thinking + server tools).

- **B1 — Conversation hashing collapsed unknown content types.** `ConversationLinker.serializeContentItem` returned `[N]<type>:unknown` for every block type it didn't recognise, so every `thinking`, `redacted_thinking`, and `server_tool_use` block produced an identical hash contribution. Result: parent-message lookup could match the wrong prior request, producing incorrect branches and sub-task links for any client using extended thinking or server-hosted tools. Adds explicit serializers keyed on the canonical fields (`signature` for thinking, data hash for redacted_thinking, `name+id+input` for server_tool_use, `tool_use_id+content` for server-tool results).
- **B2 — `server_tool_use` blocks not counted as tool calls.** `ProxyResponse.processResponse` and `processStreamEvent` both filtered on `type === 'tool_use'`, undercounting `tool_call_count` and producing empty `toolCalls` arrays for any turn that used `web_search` / `code_execution` / MCP / container tools.
- **B3 — Streaming `thinking_delta` / `signature_delta` events dropped.** The streaming switch only handled `text_delta` and `input_json_delta`, so thinking text never made it into the proxy's stored content. Adds `thinkingContent` and `thinkingSignatures` getters that capture this separately. Visible `content` is no longer polluted with thinking text. Unknown delta types (e.g. `citations_delta`) are forwarded but skipped for metrics.

Also extends the shared TypeScript types to reflect the 2026 Anthropic API surface so future code is forced to handle the new shapes:

- `ClaudeContent.type` gains `thinking`, `redacted_thinking`, `server_tool_use`, `web_search_tool_result`, `code_execution_tool_result`
- `stop_reason` gains `pause_turn`, `refusal`, `model_context_window_exceeded`
- `ClaudeStreamEvent.delta.type` gains `thinking_delta`, `signature_delta`, `citations_delta`

## Out of scope

This PR fixes things that are already broken. Forward-looking additions (1h-TTL cache breakdown columns, `service_tier`, `mcp_servers`, `context_management` request schema, `claude-opus-4-7` in `model-limits.ts`) are deliberately deferred — they affect observability of new features, not correctness of existing ones.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test packages/shared/src/utils/__tests__/conversation-linker.test.ts` — 40 pass (6 new tests for modern content blocks).
- [x] `bun test services/proxy/src/domain/entities/__tests__/ProxyResponse.test.ts` — 6 pass (new file, covers B2 + B3 streaming and non-streaming paths).
- [x] Full `bun test` — same 18 pre-existing failures as `main` (Playwright `.spec.ts` files, docker/DB-dependent tests). No new failures.
- [x] `bun run lint` — 0 errors, 131 pre-existing warnings (none in changed files).
- [ ] Manual: send a streaming request through the proxy with `thinking: { type: 'enabled', budget_tokens: 4096 }` on `claude-opus-4-7` and verify the dashboard shows non-zero `thinkingContent` and that conversation tree links across turns.
- [ ] Manual: send a request that triggers `web_search` and verify `tool_call_count` reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)