### PR TITLE
feat: add support for new Claude models (Fable 5, Opus 4.7/4.8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,7 +149,7 @@ AI_ANALYSIS_REQUEST_TIMEOUT_MS=60000
 # AI Analysis routing (via local proxy)
 # Create a dedicated project and link an account with Claude API access
 AI_ANALYSIS_PROJECT_ID=your-analysis-project-id
-ANTHROPIC_ANALYSIS_MODEL=claude-opus-4-6
+ANTHROPIC_ANALYSIS_MODEL=claude-opus-4-8
 # Optional: API key for the analysis project (needed when ENABLE_CLIENT_AUTH=true)
 # AI_ANALYSIS_API_KEY=your-project-api-key
 

--- a/docs/02-User-Guide/ai-analysis.md
+++ b/docs/02-User-Guide/ai-analysis.md
@@ -60,7 +60,7 @@ AI_ANALYSIS_REQUEST_TIMEOUT_MS=60000       # API timeout (60 seconds)
 
 # Analysis routing (via local proxy)
 AI_ANALYSIS_PROJECT_ID=your-analysis-project-id  # REQUIRED: Project ID from step 2
-ANTHROPIC_ANALYSIS_MODEL=claude-opus-4-6          # Claude model to use
+ANTHROPIC_ANALYSIS_MODEL=claude-opus-4-8          # Claude model to use
 
 # Optional: API key for the analysis project (only needed when ENABLE_CLIENT_AUTH=true)
 # AI_ANALYSIS_API_KEY=your-project-api-key
@@ -89,7 +89,7 @@ Check the logs for:
 ```
 AI Analysis:
   - Enabled: Yes
-  - Model: claude-opus-4-6
+  - Model: claude-opus-4-8
   - Project: your-analysis-project-id
   - Routing: Via local proxy
 ✓ AI Analysis Worker started

--- a/docs/03-Operations/ai-analysis-security.md
+++ b/docs/03-Operations/ai-analysis-security.md
@@ -148,7 +148,7 @@ AI_ANALYSIS_MAX_RETRIES=2                   # Retry failed requests
 
 # Analysis routing (via local proxy)
 AI_ANALYSIS_PROJECT_ID=your-project-id      # Required
-ANTHROPIC_ANALYSIS_MODEL=claude-opus-4-6    # Model selection
+ANTHROPIC_ANALYSIS_MODEL=claude-opus-4-8    # Model selection
 ```
 
 ### Disabling Features

--- a/docs/03-Operations/monitoring.md
+++ b/docs/03-Operations/monitoring.md
@@ -443,23 +443,25 @@ LIMIT 10;
 
 ### Token Cost Calculation
 
-Track costs by model:
+Track costs by model using the shared pricing registry
+(`@agent-prompttrain/shared`):
 
 ```javascript
-const tokenCosts = {
-  'claude-3-opus-20240229': { input: 15, output: 75 }, // per million tokens
-  'claude-3-sonnet-20240229': { input: 3, output: 15 },
-  'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
-}
+import { getModelPricing, calculateRequestCost } from '@agent-prompttrain/shared'
 
-function calculateCost(model, inputTokens, outputTokens) {
-  const costs = tokenCosts[model]
-  return {
-    input: (inputTokens / 1_000_000) * costs.input,
-    output: (outputTokens / 1_000_000) * costs.output,
-    total: (inputTokens / 1_000_000) * costs.input + (outputTokens / 1_000_000) * costs.output,
-  }
-}
+// Pattern-based pricing per million tokens, e.g.:
+// claude-fable-5:    { input: 10, output: 50 }
+// claude-opus-4-8:   { input: 5,  output: 25 }
+// claude-sonnet-4-6: { input: 3,  output: 15 }
+// claude-haiku-4-5:  { input: 1,  output: 5 }
+const { pricing } = getModelPricing('claude-opus-4-8')
+
+const totalCost = calculateRequestCost('claude-opus-4-8', {
+  inputTokens,
+  outputTokens,
+  cacheReadTokens,
+  cacheCreationTokens,
+})
 ```
 
 ### Budget Alerts
@@ -471,9 +473,9 @@ Set up cost alerts:
 WITH daily_costs AS (
   SELECT
     date_trunc('day', created_at) as day,
-    SUM(input_tokens * 0.000015 + output_tokens * 0.000075) as cost
+    SUM(input_tokens * 0.000005 + output_tokens * 0.000025) as cost
   FROM api_requests
-  WHERE model = 'claude-3-opus-20240229'
+  WHERE model = 'claude-opus-4-8'
   GROUP BY day
 )
 SELECT

--- a/docs/06-Reference/changelog.md
+++ b/docs/06-Reference/changelog.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for new Claude models: Fable 5 (`claude-fable-5`) and Opus 4.7/4.8 (`claude-opus-4-7`, `claude-opus-4-8`)
+  - 1M context window rules for Fable 5 and Opus 4.6/4.7/4.8
+  - Centralized model pricing registry in `@agent-prompttrain/shared` (`getModelPricing`, `calculateRequestCost`)
+  - AWS Bedrock cost report pricing entries for Fable 5, Opus 4.6-4.8 and Sonnet 4.6
+
 ### Changed
 
+- Dashboard conversation analytics now estimates costs from the shared pricing registry instead of outdated hardcoded Claude 3 rates
+- Default AI analysis model bumped from `claude-opus-4-6` to `claude-opus-4-8` (override with `ANTHROPIC_ANALYSIS_MODEL`)
 - Token Usage overview: projects with zero tokens are now hidden from the project list
 - Token Usage overview: project list now shows 2-line format with percentage of 5-hour and 7-day windows including date ranges
 - API `/api/token-usage/accounts` now returns `outputTokens7d` and `requests7d` per project for 7-day window usage

--- a/docs/06-Reference/environment-vars.md
+++ b/docs/06-Reference/environment-vars.md
@@ -157,7 +157,7 @@ SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 | Variable                   | Description                                                    | Default                   |
 | -------------------------- | -------------------------------------------------------------- | ------------------------- |
 | `AI_ANALYSIS_PROJECT_ID`   | Dedicated project ID for analysis (routes through local proxy) | -                         |
-| `ANTHROPIC_ANALYSIS_MODEL` | Claude model to use for analysis                               | `claude-opus-4-6`         |
+| `ANTHROPIC_ANALYSIS_MODEL` | Claude model to use for analysis                               | `claude-opus-4-8`         |
 | `AI_ANALYSIS_API_KEY`      | Project API key (only needed when `ENABLE_CLIENT_AUTH=true`)   | -                         |
 | `AI_ANALYSIS_PROXY_URL`    | Override proxy URL for analysis requests                       | `http://localhost:{PORT}` |
 
@@ -274,7 +274,7 @@ AI_WORKER_MAX_CONCURRENT_JOBS=3
 AI_WORKER_JOB_TIMEOUT_MINUTES=5
 AI_ANALYSIS_MAX_RETRIES=3
 AI_ANALYSIS_PROJECT_ID=your-analysis-project-id
-ANTHROPIC_ANALYSIS_MODEL=claude-opus-4-6
+ANTHROPIC_ANALYSIS_MODEL=claude-opus-4-8
 
 # Directories
 CREDENTIALS_DIR=./credentials

--- a/packages/shared/src/config/ai-analysis.ts
+++ b/packages/shared/src/config/ai-analysis.ts
@@ -39,7 +39,7 @@ export const ANALYSIS_PROMPT_CONFIG = {
 // Requests are routed through the local proxy using a dedicated project
 export const ANTHROPIC_ANALYSIS_CONFIG = {
   get MODEL_NAME() {
-    return process.env.ANTHROPIC_ANALYSIS_MODEL || 'claude-opus-4-6'
+    return process.env.ANTHROPIC_ANALYSIS_MODEL || 'claude-opus-4-8'
   },
   get PROJECT_ID() {
     return process.env.AI_ANALYSIS_PROJECT_ID || ''

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -280,7 +280,7 @@ export const config = {
   // Requests are routed through the local proxy using a dedicated project
   aiAnalysis: {
     get modelName() {
-      return env.string('ANTHROPIC_ANALYSIS_MODEL', 'claude-opus-4-6')
+      return env.string('ANTHROPIC_ANALYSIS_MODEL', 'claude-opus-4-8')
     },
     get projectId() {
       return env.string('AI_ANALYSIS_PROJECT_ID', '')

--- a/packages/shared/src/config/model-mapping.ts
+++ b/packages/shared/src/config/model-mapping.ts
@@ -11,6 +11,12 @@ export interface BedrockModelConfig {
 /**
  * Map of Anthropic model names to Bedrock model IDs
  * Updated as of November 2025
+ *
+ * Note: Newer models (Claude Fable 5, Opus 4.6/4.7/4.8, Sonnet 4.6) are not
+ * served through this legacy ARN-versioned Bedrock integration and have no
+ * verified `{region}.anthropic.{model}-vN:0` IDs. They intentionally have no
+ * entry here: `mapToBedrockModel()` passes unknown model IDs through
+ * unchanged, so first-party requests for these models are unaffected.
  */
 export const MODEL_MAPPING: Record<string, string> = {
   // Claude 4.5 Opus (Latest - November 2025)

--- a/packages/shared/src/constants/__tests__/model-limits.test.ts
+++ b/packages/shared/src/constants/__tests__/model-limits.test.ts
@@ -8,9 +8,25 @@ import {
 
 describe('Model Context Limits', () => {
   describe('getModelContextLimit', () => {
-    // Test 1M context models - Claude 4.6 (Opus & Sonnet)
+    // Test 1M context models - Claude Fable 5
+    it('should return 1M for Claude Fable 5', () => {
+      const result = getModelContextLimit('claude-fable-5')
+      expect(result).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
+    // Test 1M context models - Claude Opus 4.6 / 4.7 / 4.8
     it('should return 1M for Claude Opus 4.6', () => {
       const result = getModelContextLimit('claude-opus-4-6')
+      expect(result).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
+    it('should return 1M for Claude Opus 4.7', () => {
+      const result = getModelContextLimit('claude-opus-4-7')
+      expect(result).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
+    it('should return 1M for Claude Opus 4.8', () => {
+      const result = getModelContextLimit('claude-opus-4-8')
       expect(result).toEqual({ limit: 1000000, isEstimate: false })
     })
 

--- a/packages/shared/src/constants/__tests__/model-pricing.test.ts
+++ b/packages/shared/src/constants/__tests__/model-pricing.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test'
+import { getModelPricing, calculateRequestCost, DEFAULT_MODEL_PRICING } from '../model-pricing'
+
+describe('Model Pricing', () => {
+  describe('getModelPricing', () => {
+    it('should return Fable 5 pricing', () => {
+      const result = getModelPricing('claude-fable-5')
+      expect(result.isEstimate).toBe(false)
+      expect(result.pricing).toEqual({ input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 })
+    })
+
+    it('should return Opus 4.8 pricing', () => {
+      const result = getModelPricing('claude-opus-4-8')
+      expect(result.isEstimate).toBe(false)
+      expect(result.pricing).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 })
+    })
+
+    it('should return the same pricing for Opus 4.5 through 4.8', () => {
+      const expected = getModelPricing('claude-opus-4-8').pricing
+      for (const model of ['claude-opus-4-5', 'claude-opus-4-6', 'claude-opus-4-7']) {
+        expect(getModelPricing(model).pricing).toEqual(expected)
+      }
+    })
+
+    it('should return legacy premium pricing for Opus 4.1 and Claude 3 Opus', () => {
+      for (const model of ['claude-opus-4-1-20250805', 'claude-3-opus-20240229']) {
+        const result = getModelPricing(model)
+        expect(result.isEstimate).toBe(false)
+        expect(result.pricing.input).toBe(15)
+        expect(result.pricing.output).toBe(75)
+      }
+    })
+
+    it('should return Sonnet pricing for Sonnet 4.6', () => {
+      const result = getModelPricing('claude-sonnet-4-6')
+      expect(result.isEstimate).toBe(false)
+      expect(result.pricing.input).toBe(3)
+      expect(result.pricing.output).toBe(15)
+    })
+
+    it('should return Haiku 4.5 pricing', () => {
+      const result = getModelPricing('claude-haiku-4-5-20251001')
+      expect(result.isEstimate).toBe(false)
+      expect(result.pricing.input).toBe(1)
+      expect(result.pricing.output).toBe(5)
+    })
+
+    it('should return Claude 3.5 Haiku pricing distinct from Claude 3 Haiku', () => {
+      expect(getModelPricing('claude-3-5-haiku-20241022').pricing.input).toBe(0.8)
+      expect(getModelPricing('claude-3-haiku-20240307').pricing.input).toBe(0.25)
+    })
+
+    it('should match models case-insensitively', () => {
+      const result = getModelPricing('CLAUDE-OPUS-4-8')
+      expect(result.isEstimate).toBe(false)
+      expect(result.pricing.input).toBe(5)
+    })
+
+    it('should return default pricing with estimate flag for unknown models', () => {
+      const result = getModelPricing('gpt-4')
+      expect(result.isEstimate).toBe(true)
+      expect(result.pricing).toEqual(DEFAULT_MODEL_PRICING)
+    })
+  })
+
+  describe('calculateRequestCost', () => {
+    it('should calculate input/output cost for Opus 4.8', () => {
+      const cost = calculateRequestCost('claude-opus-4-8', {
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      })
+      expect(cost).toBe(30) // $5 input + $25 output
+    })
+
+    it('should include cache token costs', () => {
+      const cost = calculateRequestCost('claude-opus-4-8', {
+        cacheReadTokens: 1_000_000,
+        cacheCreationTokens: 1_000_000,
+      })
+      expect(cost).toBe(6.75) // $0.50 read + $6.25 write
+    })
+
+    it('should treat missing usage fields as zero', () => {
+      expect(calculateRequestCost('claude-opus-4-8', {})).toBe(0)
+    })
+  })
+})

--- a/packages/shared/src/constants/model-limits.ts
+++ b/packages/shared/src/constants/model-limits.ts
@@ -17,7 +17,7 @@ export interface ModelContextRule {
  * Model context window rules
  * Order matters - more specific patterns should come before general ones
  *
- * Claude Opus 4.6 and Sonnet 4.6 support 1M context windows (GA March 2026).
+ * Claude Fable 5, Opus 4.6/4.7/4.8 and Sonnet 4.6 support 1M context windows.
  * Models with "[1m]" suffix in their display name also indicate 1M context.
  * Earlier Claude 4.x models use 200k context windows.
  *
@@ -32,9 +32,16 @@ export const MODEL_CONTEXT_RULES: ModelContextRule[] = [
     source: 'https://claude.com/blog/1m-context-ga',
   },
 
-  // Claude 4.6 (Opus & Sonnet) - 1M context window (GA March 2026)
+  // Claude Fable 5 - 1M context window (new top tier above Opus)
+  // Source: https://platform.claude.com/docs/en/about-claude/models/overview
+  { pattern: /claude-fable-5/i, limit: 1000000 },
+
+  // Claude Opus 4.6 / 4.7 / 4.8 - 1M context window
+  // Source: https://platform.claude.com/docs/en/about-claude/models/overview
+  { pattern: /claude-opus-4-[678]/i, limit: 1000000 },
+
+  // Claude Sonnet 4.6 - 1M context window (GA March 2026)
   // Source: https://claude.com/blog/1m-context-ga
-  { pattern: /claude-opus-4-6/i, limit: 1000000 },
   { pattern: /claude-sonnet-4-6/i, limit: 1000000 },
 
   // Claude 4.5 and earlier 4.x (new naming: claude-{family}-{version}) - 200k context

--- a/packages/shared/src/constants/model-pricing.ts
+++ b/packages/shared/src/constants/model-pricing.ts
@@ -1,0 +1,129 @@
+/**
+ * Model pricing configuration
+ *
+ * Pattern-based pricing (USD per million tokens) for Claude models, based on
+ * official Anthropic first-party API pricing.
+ *
+ * Cache pricing follows the standard Anthropic multipliers:
+ * - cache read  = 0.1x  input price
+ * - cache write = 1.25x input price (5-minute TTL)
+ *
+ * @see https://platform.claude.com/docs/en/about-claude/models/overview
+ * @see https://platform.claude.com/docs/en/pricing
+ */
+
+export interface ModelPricing {
+  /** USD per 1M input tokens */
+  input: number
+  /** USD per 1M output tokens */
+  output: number
+  /** USD per 1M cache read tokens */
+  cacheRead: number
+  /** USD per 1M cache write tokens (5-minute TTL) */
+  cacheWrite: number
+}
+
+export interface ModelPricingRule {
+  pattern: RegExp
+  pricing: ModelPricing
+}
+
+/**
+ * Model pricing rules
+ * Order matters - more specific patterns should come before general ones
+ */
+export const MODEL_PRICING_RULES: ModelPricingRule[] = [
+  // Claude Fable 5 - new top tier above Opus
+  {
+    pattern: /claude-fable-5/i,
+    pricing: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  },
+
+  // Claude Opus 4.5 / 4.6 / 4.7 / 4.8
+  {
+    pattern: /claude-opus-4-[5678]/i,
+    pricing: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  },
+
+  // Claude Opus 4.0 / 4.1 and Claude 3 Opus (legacy premium pricing)
+  {
+    pattern: /claude-opus-4|claude-3-opus|claude-4.*opus/i,
+    pricing: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  },
+
+  // Claude Sonnet (all generations share the same price point)
+  {
+    pattern:
+      /claude-sonnet-4|claude-3-7-sonnet|claude-3-5-sonnet|claude-3.*sonnet|claude-4.*sonnet/i,
+    pricing: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  },
+
+  // Claude Haiku 4.5
+  {
+    pattern: /claude-haiku-4/i,
+    pricing: { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+  },
+
+  // Claude 3.5 Haiku
+  {
+    pattern: /claude-3-5-haiku|claude-3\.5.*haiku/i,
+    pricing: { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
+  },
+
+  // Claude 3 Haiku
+  {
+    pattern: /claude-3.*haiku/i,
+    pricing: { input: 0.25, output: 1.25, cacheRead: 0.03, cacheWrite: 0.3 },
+  },
+
+  // Claude 2.x (retired, kept for historical request data)
+  {
+    pattern: /claude-2/i,
+    pricing: { input: 8, output: 24, cacheRead: 0.8, cacheWrite: 10 },
+  },
+]
+
+/**
+ * Default pricing for unknown models (Sonnet-tier as a middle-ground estimate)
+ */
+export const DEFAULT_MODEL_PRICING: ModelPricing = {
+  input: 3,
+  output: 15,
+  cacheRead: 0.3,
+  cacheWrite: 3.75,
+}
+
+/**
+ * Get the pricing for a given model
+ * @param model - The model identifier (e.g., "claude-opus-4-8")
+ * @returns An object with the pricing and whether it's an estimate (unknown model)
+ */
+export function getModelPricing(model: string): { pricing: ModelPricing; isEstimate: boolean } {
+  for (const rule of MODEL_PRICING_RULES) {
+    if (rule.pattern.test(model)) {
+      return { pricing: rule.pricing, isEstimate: false }
+    }
+  }
+  return { pricing: DEFAULT_MODEL_PRICING, isEstimate: true }
+}
+
+/**
+ * Calculate the estimated cost (USD) for token usage on a given model
+ */
+export function calculateRequestCost(
+  model: string,
+  usage: {
+    inputTokens?: number
+    outputTokens?: number
+    cacheReadTokens?: number
+    cacheCreationTokens?: number
+  }
+): number {
+  const { pricing } = getModelPricing(model)
+  return (
+    ((usage.inputTokens ?? 0) / 1_000_000) * pricing.input +
+    ((usage.outputTokens ?? 0) / 1_000_000) * pricing.output +
+    ((usage.cacheReadTokens ?? 0) / 1_000_000) * pricing.cacheRead +
+    ((usage.cacheCreationTokens ?? 0) / 1_000_000) * pricing.cacheWrite
+  )
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -77,6 +77,16 @@ export {
   type ModelContextRule,
 } from './constants/model-limits.js'
 
+// Export model pricing configuration
+export {
+  MODEL_PRICING_RULES,
+  DEFAULT_MODEL_PRICING,
+  getModelPricing,
+  calculateRequestCost,
+  type ModelPricing,
+  type ModelPricingRule,
+} from './constants/model-pricing.js'
+
 export {
   MSL_PROJECT_ID_HEADER,
   MSL_PROJECT_ID_HEADER_LOWER,

--- a/scripts/aws-bedrock-cost-report.ts
+++ b/scripts/aws-bedrock-cost-report.ts
@@ -234,6 +234,68 @@ type ModelPricingEntry = {
 }
 
 const MODEL_PRICING: readonly ModelPricingEntry[] = [
+  // Pricing for Claude Fable 5 / Opus 4.6-4.8 / Sonnet 4.6 mirrors first-party
+  // Anthropic API pricing (https://platform.claude.com/docs/en/pricing).
+  {
+    alias: 'claude-fable-5',
+    displayName: 'Claude Fable 5',
+    matchers: ['fable', '5'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.01, outputPerThousand: 0.05 },
+        cacheReadPerThousand: 0.001,
+        cacheWritePerThousand: 0.0125,
+      },
+    },
+  },
+  {
+    alias: 'claude-opus-4-8',
+    displayName: 'Claude Opus 4.8',
+    matchers: ['opus', '4-8'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.005, outputPerThousand: 0.025 },
+        cacheReadPerThousand: 0.0005,
+        cacheWritePerThousand: 0.00625,
+      },
+    },
+  },
+  {
+    alias: 'claude-opus-4-7',
+    displayName: 'Claude Opus 4.7',
+    matchers: ['opus', '4-7'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.005, outputPerThousand: 0.025 },
+        cacheReadPerThousand: 0.0005,
+        cacheWritePerThousand: 0.00625,
+      },
+    },
+  },
+  {
+    alias: 'claude-opus-4-6',
+    displayName: 'Claude Opus 4.6',
+    matchers: ['opus', '4-6'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.005, outputPerThousand: 0.025 },
+        cacheReadPerThousand: 0.0005,
+        cacheWritePerThousand: 0.00625,
+      },
+    },
+  },
+  {
+    alias: 'claude-sonnet-4-6',
+    displayName: 'Claude Sonnet 4.6',
+    matchers: ['sonnet', '4-6'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.003, outputPerThousand: 0.015 },
+        cacheReadPerThousand: 0.0003,
+        cacheWritePerThousand: 0.00375,
+      },
+    },
+  },
   {
     alias: 'claude-haiku-4-5',
     displayName: 'Claude Haiku 4.5',

--- a/services/dashboard/src/routes/partials/analytics-conversation.ts
+++ b/services/dashboard/src/routes/partials/analytics-conversation.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { html, raw } from 'hono/html'
 import { ProxyApiClient } from '../../services/api-client.js'
-import { getErrorMessage } from '@agent-prompttrain/shared'
+import { getErrorMessage, getModelPricing } from '@agent-prompttrain/shared'
 import type { ApiRequest } from '../../types/conversation.js'
 
 export const analyticsConversationPartialRoutes = new Hono<{
@@ -147,20 +147,11 @@ analyticsConversationPartialRoutes.get(
       }
 
       Object.entries(tokenStats.byModel).forEach(([model, stats]) => {
-        // Rough cost estimates per 1M tokens
-        const rates = {
-          'claude-3-opus': { input: 15, output: 75 },
-          'claude-3-sonnet': { input: 3, output: 15 },
-          'claude-3-haiku': { input: 0.25, output: 1.25 },
-          'claude-2': { input: 8, output: 24 },
-        }
+        // Cost estimates per 1M tokens from the shared model pricing registry
+        const { pricing } = getModelPricing(model)
 
-        const modelKey =
-          Object.keys(rates).find(key => model.toLowerCase().includes(key.split('-').pop()!)) ||
-          'claude-3-sonnet'
-        const rate = rates[modelKey as keyof typeof rates]
-
-        const cost = (stats.input / 1000000) * rate.input + (stats.output / 1000000) * rate.output
+        const cost =
+          (stats.input / 1000000) * pricing.input + (stats.output / 1000000) * pricing.output
         costs.byModel[model] = cost
         costs.total += cost
       })

--- a/services/proxy/src/main.ts
+++ b/services/proxy/src/main.ts
@@ -227,7 +227,7 @@ async function main() {
       if (process.env.AI_ANALYSIS_PROJECT_ID) {
         console.log('  - Enabled: Yes')
         console.log(
-          `  - Model: ${process.env.ANTHROPIC_ANALYSIS_MODEL || 'claude-opus-4-6 (default)'}`
+          `  - Model: ${process.env.ANTHROPIC_ANALYSIS_MODEL || 'claude-opus-4-8 (default)'}`
         )
         console.log(`  - Project: ${process.env.AI_ANALYSIS_PROJECT_ID}`)
         console.log(`  - Routing: Via local proxy`)


### PR DESCRIPTION
## Summary

Anthropic released new Claude models (Fable 5, Opus 4.8/4.7). This PR updates the proxy and dashboard so they are correctly recognized, priced, and used by default where appropriate.

Model data researched from the current Anthropic model catalog (June 2026):

| Model | ID | Context | $/1M in/out |
|---|---|---|---|
| Claude Fable 5 | `claude-fable-5` | 1M | $10 / $50 |
| Claude Opus 4.8 | `claude-opus-4-8` | 1M | $5 / $25 |
| Claude Opus 4.7 | `claude-opus-4-7` | 1M | $5 / $25 |
| Claude Sonnet 4.6 | `claude-sonnet-4-6` | 1M | $3 / $15 |
| Claude Haiku 4.5 | `claude-haiku-4-5` | 200K | $1 / $5 |

## Changes

### packages/shared
- **model-limits.ts**: 1M context window rules for `claude-fable-5` and `claude-opus-4-[678]` (Sonnet 4.6 already present)
- **model-pricing.ts (new)**: centralized, pattern-based pricing registry (`getModelPricing`, `calculateRequestCost`) per the monorepo's shared-logic rule (ADR-001); covers current + legacy models with cache read/write rates
- **ai-analysis.ts / config/index.ts**: default `ANTHROPIC_ANALYSIS_MODEL` bumped `claude-opus-4-6` → `claude-opus-4-8` (still env-overridable)
- **model-mapping.ts**: documented why 4.6+/Fable models have no legacy Bedrock ARN mapping (no verified IDs; unknown models safely pass through)

### services/dashboard
- Conversation analytics cost estimation now uses the shared pricing registry — it previously used hardcoded Claude-3-era rates, so costs for all modern models were computed at the wrong rate

### services/proxy
- Startup log reflects the new default analysis model

### scripts
- AWS Bedrock cost report: pricing entries for Fable 5, Opus 4.6/4.7/4.8, Sonnet 4.6 (placed before generic matchers; first-match-wins). Verified via `--list-pricing`

### Tests & docs
- New tests for the pricing registry; context-limit tests extended for the new models (15 new tests, all passing)
- Updated `.env.example`, environment-vars, ai-analysis, ai-analysis-security, monitoring docs, and changelog

## Validation

- `bun run typecheck` ✅
- `bun test` — 573 pass; the 18 failures/4 errors are pre-existing on `main` (Docker/Playwright environment-dependent suites, verified by running the same suite on a clean tree)
- `bun run scripts/aws-bedrock-cost-report.ts --list-pricing` shows new entries ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)