### PR TITLE
[codex] fix account pool usage-unavailable fallback

### DIFF
--- a/docs/04-Architecture/ADRs/README.md
+++ b/docs/04-Architecture/ADRs/README.md
@@ -32,40 +32,41 @@ What becomes easier or more difficult to do because of this change?
 
 ## Current ADRs
 
-| ADR                                                       | Title                                  | Status     | Date       |
-| --------------------------------------------------------- | -------------------------------------- | ---------- | ---------- |
-| [ADR-001](./adr-001-monorepo-structure.md)                | Monorepo Structure                     | Accepted   | 2024-01-15 |
-| [ADR-002](./adr-002-separate-docker-images.md)            | Separate Docker Images                 | Accepted   | 2024-01-20 |
-| [ADR-003](./adr-003-conversation-tracking.md)             | Conversation Tracking Design           | Accepted   | 2024-02-01 |
-| [ADR-004](./adr-004-proxy-authentication.md)              | Proxy-Level Authentication             | Accepted   | 2024-06-25 |
-| [ADR-005](./adr-005-token-usage-tracking.md)              | Comprehensive Token Usage Tracking     | Accepted   | 2024-06-25 |
-| [ADR-006](./adr-006-long-running-requests.md)             | Support for Long-Running Requests      | Accepted   | 2024-06-25 |
-| [ADR-007](./adr-007-subtask-tracking.md)                  | Sub-task Detection and Tracking        | Accepted   | 2024-06-25 |
-| [ADR-008](./adr-008-cicd-strategy.md)                     | CI/CD Strategy with GitHub Actions     | Accepted   | 2024-06-25 |
-| [ADR-009](./adr-009-dashboard-architecture.md)            | Dashboard Architecture with HTMX       | Accepted   | 2024-06-25 |
-| [ADR-010](./adr-010-docker-cli-integration.md)            | Docker-Based Claude CLI Integration    | Accepted   | 2024-06-25 |
-| [ADR-011](./adr-011-future-decisions.md)                  | Future Architectural Decisions         | Proposed   | 2024-06-25 |
-| [ADR-012](./adr-012-database-schema-evolution.md)         | Database Schema Evolution Strategy     | Accepted   | 2025-06-26 |
-| [ADR-013](./adr-013-typescript-project-references.md)     | TypeScript Project References          | Accepted   | 2025-06-27 |
-| [ADR-014](./adr-014-sql-query-logging.md)                 | SQL Query Logging                      | Accepted   | 2025-06-30 |
-| [ADR-015](./adr-015-subtask-conversation-migration.md)    | Subtask Conversation Migration         | Accepted   | 2025-01-07 |
-| [ADR-018](./adr-018-ai-powered-conversation-analysis.md)  | AI-Powered Conversation Analysis       | Accepted   | 2025-01-12 |
-| [ADR-019](./adr-019-dashboard-read-only-mode-security.md) | Dashboard Read-Only Mode Security      | Superseded | 2025-01-23 |
-| [ADR-020](./adr-020-circuit-breaker-removal.md)           | Circuit Breaker Removal                | Accepted   | 2025-08-04 |
-| [ADR-021](./adr-021-e2e-testing-strategy.md)              | E2E Testing Strategy                   | Accepted   | —          |
-| [ADR-022](./adr-022-multi-architecture-docker-support.md) | Multi-Architecture Docker Support      | Accepted   | —          |
-| [ADR-023](./adr-023-wildcard-subdomain-support.md)        | Wildcard Subtrain Support              | Superseded | —          |
-| [ADR-024](./adr-024-train-id-header-routing.md)           | Header-Based Train and Account Routing | Accepted   | 2025-09-17 |
-| [ADR-025](./adr-025-dashboard-sso-proxy.md)               | Dashboard SSO via OAuth2 Proxy         | Accepted   | —          |
-| [ADR-026](./adr-026-database-credential-storage.md)       | Database-Based Credential Storage      | Accepted   | —          |
-| [ADR-027](./adr-027-mandatory-user-authentication.md)     | Mandatory User Authentication          | Accepted   | 2025-08-19 |
-| [ADR-028](./adr-028-proxy-service-operational-modes.md)   | Proxy Service Operational Modes        | Accepted   | —          |
-| [ADR-029](./adr-029-project-privacy-model.md)             | Project Privacy Model                  | Accepted   | —          |
-| [ADR-030](./adr-030-multi-provider-support.md)            | Multi-Provider Support                 | Accepted   | —          |
-| [ADR-031](./adr-031-account-pool-auto-switching.md)       | Account Pool Auto-Switching            | Accepted   | —          |
-| [ADR-032](./adr-032-centralized-usage-cache.md)           | Centralized Usage Cache                | Accepted   | —          |
-| [ADR-033](./adr-033-api-key-lifecycle-management.md)      | API Key Lifecycle Management           | Accepted   | —          |
-| [ADR-034](./adr-034-project-system-prompt-override.md)    | Project System Prompt Override         | Accepted   | 2026-03-19 |
+| ADR                                                             | Title                                   | Status     | Date       |
+| --------------------------------------------------------------- | --------------------------------------- | ---------- | ---------- |
+| [ADR-001](./adr-001-monorepo-structure.md)                      | Monorepo Structure                      | Accepted   | 2024-01-15 |
+| [ADR-002](./adr-002-separate-docker-images.md)                  | Separate Docker Images                  | Accepted   | 2024-01-20 |
+| [ADR-003](./adr-003-conversation-tracking.md)                   | Conversation Tracking Design            | Accepted   | 2024-02-01 |
+| [ADR-004](./adr-004-proxy-authentication.md)                    | Proxy-Level Authentication              | Accepted   | 2024-06-25 |
+| [ADR-005](./adr-005-token-usage-tracking.md)                    | Comprehensive Token Usage Tracking      | Accepted   | 2024-06-25 |
+| [ADR-006](./adr-006-long-running-requests.md)                   | Support for Long-Running Requests       | Accepted   | 2024-06-25 |
+| [ADR-007](./adr-007-subtask-tracking.md)                        | Sub-task Detection and Tracking         | Accepted   | 2024-06-25 |
+| [ADR-008](./adr-008-cicd-strategy.md)                           | CI/CD Strategy with GitHub Actions      | Accepted   | 2024-06-25 |
+| [ADR-009](./adr-009-dashboard-architecture.md)                  | Dashboard Architecture with HTMX        | Accepted   | 2024-06-25 |
+| [ADR-010](./adr-010-docker-cli-integration.md)                  | Docker-Based Claude CLI Integration     | Accepted   | 2024-06-25 |
+| [ADR-011](./adr-011-future-decisions.md)                        | Future Architectural Decisions          | Proposed   | 2024-06-25 |
+| [ADR-012](./adr-012-database-schema-evolution.md)               | Database Schema Evolution Strategy      | Accepted   | 2025-06-26 |
+| [ADR-013](./adr-013-typescript-project-references.md)           | TypeScript Project References           | Accepted   | 2025-06-27 |
+| [ADR-014](./adr-014-sql-query-logging.md)                       | SQL Query Logging                       | Accepted   | 2025-06-30 |
+| [ADR-015](./adr-015-subtask-conversation-migration.md)          | Subtask Conversation Migration          | Accepted   | 2025-01-07 |
+| [ADR-018](./adr-018-ai-powered-conversation-analysis.md)        | AI-Powered Conversation Analysis        | Accepted   | 2025-01-12 |
+| [ADR-019](./adr-019-dashboard-read-only-mode-security.md)       | Dashboard Read-Only Mode Security       | Superseded | 2025-01-23 |
+| [ADR-020](./adr-020-circuit-breaker-removal.md)                 | Circuit Breaker Removal                 | Accepted   | 2025-08-04 |
+| [ADR-021](./adr-021-e2e-testing-strategy.md)                    | E2E Testing Strategy                    | Accepted   | —          |
+| [ADR-022](./adr-022-multi-architecture-docker-support.md)       | Multi-Architecture Docker Support       | Accepted   | —          |
+| [ADR-023](./adr-023-wildcard-subdomain-support.md)              | Wildcard Subtrain Support               | Superseded | —          |
+| [ADR-024](./adr-024-train-id-header-routing.md)                 | Header-Based Train and Account Routing  | Accepted   | 2025-09-17 |
+| [ADR-025](./adr-025-dashboard-sso-proxy.md)                     | Dashboard SSO via OAuth2 Proxy          | Accepted   | —          |
+| [ADR-026](./adr-026-database-credential-storage.md)             | Database-Based Credential Storage       | Accepted   | —          |
+| [ADR-027](./adr-027-mandatory-user-authentication.md)           | Mandatory User Authentication           | Accepted   | 2025-08-19 |
+| [ADR-028](./adr-028-proxy-service-operational-modes.md)         | Proxy Service Operational Modes         | Accepted   | —          |
+| [ADR-029](./adr-029-project-privacy-model.md)                   | Project Privacy Model                   | Accepted   | —          |
+| [ADR-030](./adr-030-multi-provider-support.md)                  | Multi-Provider Support                  | Accepted   | —          |
+| [ADR-031](./adr-031-account-pool-auto-switching.md)             | Account Pool Auto-Switching             | Accepted   | —          |
+| [ADR-032](./adr-032-centralized-usage-cache.md)                 | Centralized Usage Cache                 | Accepted   | —          |
+| [ADR-033](./adr-033-api-key-lifecycle-management.md)            | API Key Lifecycle Management            | Accepted   | —          |
+| [ADR-034](./adr-034-project-system-prompt-override.md)          | Project System Prompt Override          | Accepted   | 2026-03-19 |
+| [ADR-035](./adr-035-account-pool-usage-unavailable-fallback.md) | Account Pool Usage Unavailable Fallback | Accepted   | 2026-06-21 |
 
 ## Creating a New ADR
 

--- a/docs/04-Architecture/ADRs/adr-035-account-pool-usage-unavailable-fallback.md
+++ b/docs/04-Architecture/ADRs/adr-035-account-pool-usage-unavailable-fallback.md
@@ -1,0 +1,54 @@
+# ADR-035: Account Pool Usage Unavailable Fallback
+
+## Status
+
+Accepted
+
+## Context
+
+Account pool auto-switching uses Anthropic's OAuth usage API to avoid selecting accounts whose 5-hour or 7-day utilization exceeds the configured threshold. The original policy from [ADR-031](./adr-031-account-pool-auto-switching.md) treated unavailable usage data as 100% utilization.
+
+Production logs showed this policy could reject all accounts before a proxied request reached the normal authentication path:
+
+- `UsageCacheService` could not retrieve an OAuth usage token for each linked account.
+- `AccountPoolService` converted each missing usage result to `maxUtilization = 1`.
+- The proxy returned HTTP 429 with "all accounts in pool have exceeded their utilization threshold" even though actual utilization was unknown.
+
+This made credential refresh or usage-endpoint failures indistinguishable from real account exhaustion.
+
+## Decision
+
+Treat unavailable usage as an unknown signal, not as confirmed exhaustion.
+
+Account pool selection now follows this policy:
+
+1. If any account has known usage below its threshold, choose the least-utilized known account.
+2. If all accounts with known usage are over threshold but one or more accounts have unavailable usage, choose a deterministic fallback account from the unknown-usage set.
+3. If every account has known usage and all are over threshold, return `AccountPoolExhaustedError` with HTTP 429.
+
+The fallback preserves sticky routing when possible. Otherwise it uses the linked account order returned from `project_accounts`. The selected account still flows through `AuthenticationService`, so OAuth refresh failures are surfaced as authentication failures instead of synthetic utilization exhaustion.
+
+This supersedes the "treat unknown usage as 100%" part of [ADR-031](./adr-031-account-pool-auto-switching.md) while preserving proactive threshold enforcement whenever usage data is available.
+
+## Consequences
+
+### Positive
+
+- Usage API or token lookup outages no longer block every proxied request with a misleading pool-exhaustion 429.
+- Real over-threshold states still return 429 when usage is known for every account.
+- Authentication failures are reported by the authentication path that actually owns OAuth refresh behavior.
+
+### Negative
+
+- During a usage-signal outage, the proxy may send a request to an account that is actually over its Anthropic limit. In that case, the upstream API can still return its own rate-limit response.
+- Pool selection is less optimized while all usage data is unavailable because there is no reliable utilization signal.
+
+## Links
+
+- [ADR-031: Account Pool Auto-Switching](./adr-031-account-pool-auto-switching.md)
+- [ADR-032: Centralized Usage Cache](./adr-032-centralized-usage-cache.md)
+
+---
+
+Date: 2026-06-21
+Authors: AI Agent

--- a/services/proxy/src/services/AuthenticationService.ts
+++ b/services/proxy/src/services/AuthenticationService.ts
@@ -92,7 +92,8 @@ export class AuthenticationService {
         projectId,
         metadata: {
           accountId: selection.credential.account_id,
-          maxUtilization: Math.round(selection.maxUtilization * 100),
+          maxUtilization:
+            selection.maxUtilization === null ? null : Math.round(selection.maxUtilization * 100),
         },
       })
     }

--- a/services/proxy/src/services/__tests__/account-pool-service.test.ts
+++ b/services/proxy/src/services/__tests__/account-pool-service.test.ts
@@ -341,8 +341,8 @@ describe('AccountPoolService', () => {
 
   // ── Scenario 7: Anthropic API failure ────────────────────────────────────
 
-  describe('Anthropic API failure (conservative)', () => {
-    test('treats account as over threshold when API returns error', async () => {
+  describe('Anthropic usage API failure', () => {
+    test('falls back to a linked account when usage is unavailable for all accounts', async () => {
       const cred1 = makeAnthropicCredential({
         id: 'cred-1',
         account_id: 'acct-1',
@@ -358,16 +358,39 @@ describe('AccountPoolService', () => {
       // Both accounts fail to return usage
       mockFetchFailure()
 
-      try {
-        await service.selectAccount('project-1')
-        expect(true).toBe(false)
-      } catch (error) {
-        // null usage -> maxUtilization = 1 -> all over threshold -> exhausted
-        expect(error).toBeInstanceOf(AccountPoolExhaustedError)
-      }
+      const result = await service.selectAccount('project-1')
+
+      expect(result.credential.id).toBe('cred-1')
+      expect(result.fromPool).toBe(true)
+      expect(result.maxUtilization).toBeNull()
     })
 
-    test('treats account as over threshold when getApiKey returns null', async () => {
+    test('prefers an account with known below-threshold usage over unavailable usage', async () => {
+      const cred1 = makeAnthropicCredential({
+        id: 'cred-1',
+        account_id: 'acct-1',
+        token_limit_threshold: 0.8,
+      })
+      const cred2 = makeAnthropicCredential({
+        id: 'cred-2',
+        account_id: 'acct-2',
+        token_limit_threshold: 0.8,
+      })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+      mockGetApiKey.mockImplementation((credId: string) =>
+        Promise.resolve(credId === 'cred-1' ? null : `token-${credId}`)
+      )
+      mockFetchWithUsage({
+        'cred-2': makeUsageResponse(45, 35),
+      })
+
+      const result = await service.selectAccount('project-1')
+
+      expect(result.credential.id).toBe('cred-2')
+      expect(result.maxUtilization).toBe(0.45)
+    })
+
+    test('falls back when getApiKey returns null for every usage check', async () => {
       const cred1 = makeAnthropicCredential({
         id: 'cred-1',
         token_limit_threshold: 0.8,
@@ -379,12 +402,11 @@ describe('AccountPoolService', () => {
       mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
       mockGetApiKey.mockImplementation(() => Promise.resolve(null))
 
-      try {
-        await service.selectAccount('project-1')
-        expect(true).toBe(false)
-      } catch (error) {
-        expect(error).toBeInstanceOf(AccountPoolExhaustedError)
-      }
+      const result = await service.selectAccount('project-1')
+
+      expect(result.credential.id).toBe('cred-1')
+      expect(result.fromPool).toBe(true)
+      expect(result.maxUtilization).toBeNull()
     })
   })
 

--- a/services/proxy/src/services/account-pool-service.ts
+++ b/services/proxy/src/services/account-pool-service.ts
@@ -31,10 +31,15 @@ export class AccountPoolExhaustedError extends Error {
 export interface AccountSelection {
   /** The selected credential to use for the request */
   credential: Credential
-  /** Highest utilization across 5h and 7d windows (0-1, normalized) */
-  maxUtilization: number
+  /** Highest utilization across 5h and 7d windows (0-1, normalized), or null when usage is unavailable */
+  maxUtilization: number | null
   /** True if selected from a multi-account pool, false if using default account */
   fromPool: boolean
+}
+
+interface UsageEvaluation {
+  credential: AnthropicCredential
+  maxUtilization: number | null
 }
 
 /**
@@ -94,7 +99,7 @@ export class AccountPoolService {
         const cachedEntry = await this.usageCacheService.getUsage(stickyCredential)
         const maxUtilization = this.computeMaxUtilization(cachedEntry?.usage ?? null)
 
-        if (maxUtilization < stickyCredential.token_limit_threshold) {
+        if (maxUtilization !== null && maxUtilization < stickyCredential.token_limit_threshold) {
           logger.debug('Reusing sticky account (under threshold)', {
             metadata: {
               projectId,
@@ -110,7 +115,7 @@ export class AccountPoolService {
           }
         }
 
-        logger.info('Sticky account over threshold, searching pool', {
+        logger.info('Sticky account unavailable or over threshold, searching pool', {
           metadata: {
             projectId,
             accountId: stickyCredential.account_id,
@@ -123,7 +128,7 @@ export class AccountPoolService {
 
     // Fetch usage for all Anthropic accounts in parallel
     const usageMap = await this.usageCacheService.getUsageMultiple(anthropicCredentials)
-    const usageResults = anthropicCredentials.map(credential => {
+    const usageResults: UsageEvaluation[] = anthropicCredentials.map(credential => {
       const entry = usageMap.get(credential.id)
       const maxUtilization = this.computeMaxUtilization(entry?.usage ?? null)
       return { credential, maxUtilization }
@@ -131,10 +136,42 @@ export class AccountPoolService {
 
     // Filter to accounts under their respective thresholds
     const available = usageResults.filter(
-      ({ credential, maxUtilization }) => maxUtilization < credential.token_limit_threshold
+      (result): result is UsageEvaluation & { maxUtilization: number } =>
+        result.maxUtilization !== null &&
+        result.maxUtilization < result.credential.token_limit_threshold
     )
 
     if (available.length === 0) {
+      const unknownUsage = usageResults.filter(r => r.maxUtilization === null)
+      if (unknownUsage.length > 0) {
+        const stickyFallback = stickyCredentialId
+          ? unknownUsage.find(r => r.credential.id === stickyCredentialId)
+          : undefined
+        const fallback = stickyFallback ?? unknownUsage[0]
+
+        this.stickyMap.set(projectId, fallback.credential.id)
+
+        logger.warn('OAuth usage unavailable for account pool; using fallback account', {
+          metadata: {
+            projectId,
+            accountId: fallback.credential.account_id,
+            unknownUsageCount: unknownUsage.length,
+            poolSize: anthropicCredentials.length,
+            utilizations: usageResults.map(r => ({
+              accountId: r.credential.account_id,
+              maxUtilization: r.maxUtilization,
+              threshold: r.credential.token_limit_threshold,
+            })),
+          },
+        })
+
+        return {
+          credential: fallback.credential,
+          maxUtilization: null,
+          fromPool: true,
+        }
+      }
+
       // Find the earliest reset time across all accounts for the error
       const estimatedReset = this.findEarliestReset(anthropicCredentials, usageMap)
 
@@ -202,11 +239,11 @@ export class AccountPoolService {
 
   /**
    * Compute the maximum utilization across 5-hour and 7-day windows.
-   * Returns 1 (treat as over threshold) if usage data is null (conservative).
+   * Returns null if usage data is unavailable.
    */
-  private computeMaxUtilization(usage: AnthropicOAuthUsageResponse | null): number {
+  private computeMaxUtilization(usage: AnthropicOAuthUsageResponse | null): number | null {
     if (!usage) {
-      return 1
+      return null
     }
 
     // API returns utilization as 0-100, normalize to 0-1 to match token_limit_threshold


### PR DESCRIPTION
## Summary

- change account-pool selection so missing OAuth usage data is treated as unknown, not confirmed exhaustion
- keep real pool exhaustion behavior when every account has known over-threshold usage
- add ADR-035 documenting the fallback policy and tests for all-unknown and mixed-known usage paths

## Root cause

Production logs showed usage fetches failing at token lookup, after which the pool converted missing usage to 100% utilization and returned the misleading synthetic 429 even when actual usage could be 0.

## Validation

- bun run typecheck
- bun test services/proxy/src/services/__tests__/account-pool-service.test.ts services/proxy/src/services/__tests__/usage-cache-service.test.ts