### PR TITLE
fix(proxy): raise request size limit to 32MB to match Claude API

### DIFF
--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -155,8 +155,8 @@ export const config = {
   // Request validation
   validation: {
     get maxRequestSize() {
-      return env.int('MAX_REQUEST_SIZE', 10 * 1024 * 1024)
-    }, // 10MB
+      return env.int('MAX_REQUEST_SIZE', 32 * 1024 * 1024)
+    }, // 32MB — matches the Claude API request limit
     get maxMessageCount() {
       return env.int('MAX_MESSAGE_COUNT', 100)
     },

--- a/services/proxy/src/middleware/validation.ts
+++ b/services/proxy/src/middleware/validation.ts
@@ -5,10 +5,9 @@ import {
   maskSensitiveData,
   truncateString,
 } from '@agent-prompttrain/shared'
+import { config } from '@agent-prompttrain/shared/config'
 import { getRequestLogger } from './logger'
 
-// Request size limits
-const MAX_REQUEST_SIZE = 10 * 1024 * 1024 // 10MB
 // Validation middleware
 export function validationMiddleware() {
   return async (c: Context, next: Next) => {
@@ -27,11 +26,14 @@ export function validationMiddleware() {
       throw new ValidationError('Content-Type must be application/json')
     }
 
-    // Check request size
+    // Check request size. Matches the Claude API's own 32MB request limit by
+    // default (configurable via MAX_REQUEST_SIZE); a stricter cap here would
+    // reject requests Claude itself would accept.
+    const maxRequestSize = config.validation.maxRequestSize
     const contentLength = parseInt(c.req.header('content-length') || '0')
-    if (contentLength > MAX_REQUEST_SIZE) {
-      logger.warn('Request too large', { contentLength, limit: MAX_REQUEST_SIZE })
-      throw new ValidationError(`Request size exceeds limit of ${MAX_REQUEST_SIZE} bytes`)
+    if (contentLength > maxRequestSize) {
+      logger.warn('Request too large', { contentLength, limit: maxRequestSize })
+      throw new ValidationError(`Request size exceeds limit of ${maxRequestSize} bytes`)
     }
 
     // Parse and validate request body


### PR DESCRIPTION
## Problem

The proxy intermittently fails to forward Claude Code requests, returning a 500 and breaking the CLI:

```
WARN Request too large { contentLength: 11657345, limit: 10485760 }
ERROR Unhandled error { message: "Request size exceeds limit of 10485760 bytes" }
statusCode: 500
```

The proxy hardcoded a **10MB** request-size cap in `validation.ts` and ignored the existing `MAX_REQUEST_SIZE` config. Claude Code legitimately sends requests larger than 10MB (the failing one was ~11.1MB), but the **Claude Messages API itself accepts up to 32MB** — so the proxy was rejecting requests Claude would have accepted.

## Fix

- Wire the validation middleware to the existing `config.validation.maxRequestSize` (previously dead config).
- Raise the default from 10MB → **32MB** to match the Claude API request limit.
- Limit remains configurable via the `MAX_REQUEST_SIZE` env var.

## Verification

- `bun run typecheck` passes.
- Confirmed the default now resolves to `33554432` (32MB) and the previously-rejected 11.1MB request is allowed.
- Pre-existing test failures (AI-analysis integration, Claude-CLI E2E, Playwright specs) are environmental (require Docker/Postgres) and unrelated to this change.

## Out of scope (noted for follow-up)

`app.onError` reads `err.status` while `BaseError` exposes `err.statusCode`, so all operational errors (including this `ValidationError`, which is 400) are returned as **500 `internal_error`**. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)