### PR TITLE
feat: Claude Fable 5 pricing and fallback-aware cost attribution

### DIFF
--- a/docs/03-Operations/monitoring.md
+++ b/docs/03-Operations/monitoring.md
@@ -443,24 +443,30 @@ LIMIT 10;
 
 ### Token Cost Calculation
 
-Track costs by model:
+Costs are computed from the shared per-model pricing registry
+(`packages/shared/src/constants/model-pricing.ts`), which is the single source
+of truth for current rates (including Claude Fable 5 at $10/$50 per MTok). Do
+not hardcode rate tables — use the registry helpers:
 
 ```javascript
-const tokenCosts = {
-  'claude-3-opus-20240229': { input: 15, output: 75 }, // per million tokens
-  'claude-3-sonnet-20240229': { input: 3, output: 15 },
-  'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
-}
+import { calculateRequestCost, calculateUsageCost } from '@agent-prompttrain/shared'
 
-function calculateCost(model, inputTokens, outputTokens) {
-  const costs = tokenCosts[model]
-  return {
-    input: (inputTokens / 1_000_000) * costs.input,
-    output: (outputTokens / 1_000_000) * costs.output,
-    total: (inputTokens / 1_000_000) * costs.input + (outputTokens / 1_000_000) * costs.output,
-  }
-}
+// Single model, from stored token counts:
+const cost = calculateRequestCost('claude-opus-4-8', {
+  inputTokens,
+  outputTokens,
+  cacheReadTokens,
+  cacheCreationTokens,
+})
+
+// Fallback-aware: pass the raw API `usage` object (with `iterations`) so a
+// Claude Fable 5 request re-served by an Opus 4.8 fallback is billed at the
+// model that actually ran each attempt (see ADR-035).
+const totalCost = calculateUsageCost(request.model, response.usage)
 ```
+
+See [ADR-035](../04-Architecture/ADRs/adr-035-model-pricing-registry-and-fallback-cost-attribution.md)
+for the registry design and fallback cost attribution.
 
 ### Budget Alerts
 

--- a/docs/04-Architecture/ADRs/README.md
+++ b/docs/04-Architecture/ADRs/README.md
@@ -32,40 +32,41 @@ What becomes easier or more difficult to do because of this change?
 
 ## Current ADRs
 
-| ADR                                                       | Title                                  | Status     | Date       |
-| --------------------------------------------------------- | -------------------------------------- | ---------- | ---------- |
-| [ADR-001](./adr-001-monorepo-structure.md)                | Monorepo Structure                     | Accepted   | 2024-01-15 |
-| [ADR-002](./adr-002-separate-docker-images.md)            | Separate Docker Images                 | Accepted   | 2024-01-20 |
-| [ADR-003](./adr-003-conversation-tracking.md)             | Conversation Tracking Design           | Accepted   | 2024-02-01 |
-| [ADR-004](./adr-004-proxy-authentication.md)              | Proxy-Level Authentication             | Accepted   | 2024-06-25 |
-| [ADR-005](./adr-005-token-usage-tracking.md)              | Comprehensive Token Usage Tracking     | Accepted   | 2024-06-25 |
-| [ADR-006](./adr-006-long-running-requests.md)             | Support for Long-Running Requests      | Accepted   | 2024-06-25 |
-| [ADR-007](./adr-007-subtask-tracking.md)                  | Sub-task Detection and Tracking        | Accepted   | 2024-06-25 |
-| [ADR-008](./adr-008-cicd-strategy.md)                     | CI/CD Strategy with GitHub Actions     | Accepted   | 2024-06-25 |
-| [ADR-009](./adr-009-dashboard-architecture.md)            | Dashboard Architecture with HTMX       | Accepted   | 2024-06-25 |
-| [ADR-010](./adr-010-docker-cli-integration.md)            | Docker-Based Claude CLI Integration    | Accepted   | 2024-06-25 |
-| [ADR-011](./adr-011-future-decisions.md)                  | Future Architectural Decisions         | Proposed   | 2024-06-25 |
-| [ADR-012](./adr-012-database-schema-evolution.md)         | Database Schema Evolution Strategy     | Accepted   | 2025-06-26 |
-| [ADR-013](./adr-013-typescript-project-references.md)     | TypeScript Project References          | Accepted   | 2025-06-27 |
-| [ADR-014](./adr-014-sql-query-logging.md)                 | SQL Query Logging                      | Accepted   | 2025-06-30 |
-| [ADR-015](./adr-015-subtask-conversation-migration.md)    | Subtask Conversation Migration         | Accepted   | 2025-01-07 |
-| [ADR-018](./adr-018-ai-powered-conversation-analysis.md)  | AI-Powered Conversation Analysis       | Accepted   | 2025-01-12 |
-| [ADR-019](./adr-019-dashboard-read-only-mode-security.md) | Dashboard Read-Only Mode Security      | Superseded | 2025-01-23 |
-| [ADR-020](./adr-020-circuit-breaker-removal.md)           | Circuit Breaker Removal                | Accepted   | 2025-08-04 |
-| [ADR-021](./adr-021-e2e-testing-strategy.md)              | E2E Testing Strategy                   | Accepted   | —          |
-| [ADR-022](./adr-022-multi-architecture-docker-support.md) | Multi-Architecture Docker Support      | Accepted   | —          |
-| [ADR-023](./adr-023-wildcard-subdomain-support.md)        | Wildcard Subtrain Support              | Superseded | —          |
-| [ADR-024](./adr-024-train-id-header-routing.md)           | Header-Based Train and Account Routing | Accepted   | 2025-09-17 |
-| [ADR-025](./adr-025-dashboard-sso-proxy.md)               | Dashboard SSO via OAuth2 Proxy         | Accepted   | —          |
-| [ADR-026](./adr-026-database-credential-storage.md)       | Database-Based Credential Storage      | Accepted   | —          |
-| [ADR-027](./adr-027-mandatory-user-authentication.md)     | Mandatory User Authentication          | Accepted   | 2025-08-19 |
-| [ADR-028](./adr-028-proxy-service-operational-modes.md)   | Proxy Service Operational Modes        | Accepted   | —          |
-| [ADR-029](./adr-029-project-privacy-model.md)             | Project Privacy Model                  | Accepted   | —          |
-| [ADR-030](./adr-030-multi-provider-support.md)            | Multi-Provider Support                 | Accepted   | —          |
-| [ADR-031](./adr-031-account-pool-auto-switching.md)       | Account Pool Auto-Switching            | Accepted   | —          |
-| [ADR-032](./adr-032-centralized-usage-cache.md)           | Centralized Usage Cache                | Accepted   | —          |
-| [ADR-033](./adr-033-api-key-lifecycle-management.md)      | API Key Lifecycle Management           | Accepted   | —          |
-| [ADR-034](./adr-034-project-system-prompt-override.md)    | Project System Prompt Override         | Accepted   | 2026-03-19 |
+| ADR                                                                          | Title                                              | Status     | Date       |
+| ---------------------------------------------------------------------------- | -------------------------------------------------- | ---------- | ---------- |
+| [ADR-001](./adr-001-monorepo-structure.md)                                   | Monorepo Structure                                 | Accepted   | 2024-01-15 |
+| [ADR-002](./adr-002-separate-docker-images.md)                               | Separate Docker Images                             | Accepted   | 2024-01-20 |
+| [ADR-003](./adr-003-conversation-tracking.md)                                | Conversation Tracking Design                       | Accepted   | 2024-02-01 |
+| [ADR-004](./adr-004-proxy-authentication.md)                                 | Proxy-Level Authentication                         | Accepted   | 2024-06-25 |
+| [ADR-005](./adr-005-token-usage-tracking.md)                                 | Comprehensive Token Usage Tracking                 | Accepted   | 2024-06-25 |
+| [ADR-006](./adr-006-long-running-requests.md)                                | Support for Long-Running Requests                  | Accepted   | 2024-06-25 |
+| [ADR-007](./adr-007-subtask-tracking.md)                                     | Sub-task Detection and Tracking                    | Accepted   | 2024-06-25 |
+| [ADR-008](./adr-008-cicd-strategy.md)                                        | CI/CD Strategy with GitHub Actions                 | Accepted   | 2024-06-25 |
+| [ADR-009](./adr-009-dashboard-architecture.md)                               | Dashboard Architecture with HTMX                   | Accepted   | 2024-06-25 |
+| [ADR-010](./adr-010-docker-cli-integration.md)                               | Docker-Based Claude CLI Integration                | Accepted   | 2024-06-25 |
+| [ADR-011](./adr-011-future-decisions.md)                                     | Future Architectural Decisions                     | Proposed   | 2024-06-25 |
+| [ADR-012](./adr-012-database-schema-evolution.md)                            | Database Schema Evolution Strategy                 | Accepted   | 2025-06-26 |
+| [ADR-013](./adr-013-typescript-project-references.md)                        | TypeScript Project References                      | Accepted   | 2025-06-27 |
+| [ADR-014](./adr-014-sql-query-logging.md)                                    | SQL Query Logging                                  | Accepted   | 2025-06-30 |
+| [ADR-015](./adr-015-subtask-conversation-migration.md)                       | Subtask Conversation Migration                     | Accepted   | 2025-01-07 |
+| [ADR-018](./adr-018-ai-powered-conversation-analysis.md)                     | AI-Powered Conversation Analysis                   | Accepted   | 2025-01-12 |
+| [ADR-019](./adr-019-dashboard-read-only-mode-security.md)                    | Dashboard Read-Only Mode Security                  | Superseded | 2025-01-23 |
+| [ADR-020](./adr-020-circuit-breaker-removal.md)                              | Circuit Breaker Removal                            | Accepted   | 2025-08-04 |
+| [ADR-021](./adr-021-e2e-testing-strategy.md)                                 | E2E Testing Strategy                               | Accepted   | —          |
+| [ADR-022](./adr-022-multi-architecture-docker-support.md)                    | Multi-Architecture Docker Support                  | Accepted   | —          |
+| [ADR-023](./adr-023-wildcard-subdomain-support.md)                           | Wildcard Subtrain Support                          | Superseded | —          |
+| [ADR-024](./adr-024-train-id-header-routing.md)                              | Header-Based Train and Account Routing             | Accepted   | 2025-09-17 |
+| [ADR-025](./adr-025-dashboard-sso-proxy.md)                                  | Dashboard SSO via OAuth2 Proxy                     | Accepted   | —          |
+| [ADR-026](./adr-026-database-credential-storage.md)                          | Database-Based Credential Storage                  | Accepted   | —          |
+| [ADR-027](./adr-027-mandatory-user-authentication.md)                        | Mandatory User Authentication                      | Accepted   | 2025-08-19 |
+| [ADR-028](./adr-028-proxy-service-operational-modes.md)                      | Proxy Service Operational Modes                    | Accepted   | —          |
+| [ADR-029](./adr-029-project-privacy-model.md)                                | Project Privacy Model                              | Accepted   | —          |
+| [ADR-030](./adr-030-multi-provider-support.md)                               | Multi-Provider Support                             | Accepted   | —          |
+| [ADR-031](./adr-031-account-pool-auto-switching.md)                          | Account Pool Auto-Switching                        | Accepted   | —          |
+| [ADR-032](./adr-032-centralized-usage-cache.md)                              | Centralized Usage Cache                            | Accepted   | —          |
+| [ADR-033](./adr-033-api-key-lifecycle-management.md)                         | API Key Lifecycle Management                       | Accepted   | —          |
+| [ADR-034](./adr-034-project-system-prompt-override.md)                       | Project System Prompt Override                     | Accepted   | 2026-03-19 |
+| [ADR-035](./adr-035-model-pricing-registry-and-fallback-cost-attribution.md) | Model Pricing Registry & Fallback Cost Attribution | Accepted   | 2026-07-05 |
 
 ## Creating a New ADR
 

--- a/docs/04-Architecture/ADRs/adr-031-account-pool-auto-switching.md
+++ b/docs/04-Architecture/ADRs/adr-031-account-pool-auto-switching.md
@@ -38,8 +38,8 @@ Add an `AccountPoolService` that automatically selects the best account from a p
 
 ### Key Design Decisions
 
-- **Usage source**: Anthropic OAuth usage API (`/api/oauth/usage`) — returns real utilization percentages for 5h and 7d windows
-- **Trigger**: Switch when EITHER the 5-hour OR 7-day utilization exceeds the per-account threshold
+- **Usage source**: Anthropic OAuth usage API (`/api/oauth/usage`) — returns real utilization percentages for 5h and 7d windows, plus a structured `limits[]` array with model-scoped weekly limits (e.g. a separate Claude Fable 5 allowance)
+- **Trigger**: Switch when EITHER the 5-hour OR 7-day utilization exceeds the per-account threshold, or (amended 2026-07-05) when an active model-scoped limit matching the requested model exceeds the threshold — scoped limits gate only requests for that model, so a saturated Fable limit never blocks Sonnet/Opus traffic
 - **Threshold config**: Per-account `token_limit_threshold` column in `credentials` table (0-1 scale, default 0.80)
 - **Selection strategy**: Sticky least-loaded — stay on current account until threshold exceeded, then switch to least-loaded alternative
 - **Exhaustion behavior**: Return HTTP 429 with `estimated_reset` from `resets_at` and `Retry-After` header

--- a/docs/04-Architecture/ADRs/adr-035-model-pricing-registry-and-fallback-cost-attribution.md
+++ b/docs/04-Architecture/ADRs/adr-035-model-pricing-registry-and-fallback-cost-attribution.md
@@ -1,0 +1,110 @@
+# ADR-035: Model Pricing Registry and Fallback Cost Attribution
+
+## Status
+
+Accepted
+
+## Context
+
+The proxy stores token usage (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`) per request in a model-agnostic way (see [ADR-005](./adr-005-token-usage-tracking.md)). Cost, however, was computed in two disconnected, out-of-date places in the dashboard:
+
+- `services/dashboard/src/utils/conversation.ts` (`calculateCost`) — a flat, model-blind rate (Opus-era $15/$75), overridable only by two global env vars.
+- `services/dashboard/src/routes/partials/analytics-conversation.ts` — a hardcoded `rates` map covering only Claude 3-era models (`claude-3-opus/sonnet/haiku`, `claude-2`), matched by a fuzzy `.includes()` that silently defaulted unknown models to Sonnet rates.
+
+Neither knew about current models. **Claude Fable 5** (`claude-fable-5`) makes this concretely wrong:
+
+1. Its pricing is $10/$50 per MTok — 2× Opus 4.8 and outside every existing rate entry, so it was being costed at the Sonnet default (~5× too low).
+2. Fable 5 ships safety classifiers that can decline a request. With server-side fallback, the request is re-served by another model (e.g. Opus 4.8) **inside the same API call**. The response `usage.iterations` array records each attempt with its own `model` and token counts, and the API bills each attempt at the rate of the model that actually ran it — a decline before any output is not billed at all. The Messages API `usage` object is otherwise unchanged for Fable 5 (there is no new top-level token-count field).
+
+A single "Fable 5 request" can therefore incur Opus 4.8 token costs. Attributing the whole request to `claude-fable-5` at Fable rates over/mis-states cost. We need (a) a single, current, per-model pricing source and (b) cost attribution that follows `usage.iterations` to the model that actually ran each attempt.
+
+## Decision Drivers
+
+- **Correctness**: current per-model rates, and cost attributed to the model that actually served each attempt.
+- **Single source of truth**: one pricing registry in `packages/shared`, reused by every consumer (ADR-001).
+- **No schema change**: usage is already persisted verbatim in `usage_data` (JSONB), including `iterations`; attribution is a read-time computation.
+- **Low blast radius**: additive; unknown models keep working via a flagged default estimate.
+
+## Considered Options
+
+1. **Per-model pricing registry in `packages/shared` + fallback-aware attribution (chosen)**
+   - Regex-based pricing rules (`getModelPricing`, `calculateRequestCost`) plus `getBilledUsageByModel`/`calculateUsageCost` that read `usage.iterations`.
+   - Pros: single source of truth; correct fallback attribution; reusable across proxy/dashboard/scripts; unknown models flagged as estimates.
+   - Cons: regex ordering must be maintained; attribution relies on the documented `iterations` shape.
+
+2. **Patch the existing hardcoded dashboard rate maps in place**
+   - Pros: smallest diff.
+   - Cons: keeps two divergent sources of truth; still no fallback attribution; not reusable by the proxy or scripts.
+
+3. **Persist a computed `cost` column at write time**
+   - Pros: cheap reads; historical cost frozen at request time.
+   - Cons: schema migration; rates baked in at write time can't be corrected retroactively; larger change than warranted.
+
+## Decision
+
+Add a shared pricing module `packages/shared/src/constants/model-pricing.ts`:
+
+- `MODEL_PRICING_RULES` / `getModelPricing(model)` — regex-matched USD-per-MTok rates for input, output, cache read, and cache write, including `claude-fable-5`/`claude-mythos-5` ($10/$50), Opus 4.5–4.8 ($5/$25), legacy Opus (4.0/4.1/3) ($15/$75), all Sonnet generations incl. Sonnet 5 ($3/$15), and the Haiku/Claude-2 tiers. Unknown models fall back to `DEFAULT_MODEL_PRICING` (Sonnet-tier) with `isEstimate: true`.
+- `calculateRequestCost(model, usage)` — single-model cost from camelCase token counts.
+- `getBilledUsageByModel(topLevelModel, usage)` / `calculateUsageCost(...)` — **fallback-aware**: when `usage.iterations` is present, cost is attributed per iteration to the model that ran it, and attempts that declined before producing output (`output_tokens === 0`) are dropped because they are not billed. With no iterations, the top-level usage is attributed to the request's model.
+
+Consumers:
+
+- Dashboard per-model breakdown (`analytics-conversation.ts`) now attributes tokens **and** cost to the model that actually ran each attempt, replacing the obsolete Claude-3 rate map.
+- Single-request cost (`request-details.ts`) uses the registry (fallback-aware) instead of the flat `calculateCost`. `calculateCost` itself is left in place as a generic env-configurable fallback.
+- `packages/shared/src/types/claude.ts` gains an optional `iterations?: ClaudeUsageIteration[]` on the response `usage` type.
+- 1M context-window rules (`model-limits.ts`) add Fable 5/Mythos 5, Opus 4.7/4.8, and Sonnet 5.
+- `model-mapping.ts` gets a clarifying comment: newer models have no verified legacy ARN-versioned Bedrock IDs and intentionally pass through unchanged.
+
+### Implementation Details
+
+```ts
+// Fallback example straight from the refusals-and-fallback docs:
+// Fable 5 declines (output_tokens: 0), Opus 4.8 serves the turn.
+calculateUsageCost('claude-fable-5', {
+  input_tokens: 412,
+  output_tokens: 264,
+  iterations: [
+    { type: 'message', model: 'claude-fable-5', input_tokens: 535, output_tokens: 0 },
+    { type: 'fallback_message', model: 'claude-opus-4-8', input_tokens: 412, output_tokens: 264 },
+  ],
+})
+// → billed at Opus 4.8 rates only; the declined Fable 5 attempt is not billed.
+```
+
+## Consequences
+
+### Positive
+
+- One current, tested pricing source reused across services.
+- Fallback requests are costed against the model that actually served them.
+- Unknown/future models degrade gracefully (flagged estimate) rather than silently mis-pricing.
+
+### Negative
+
+- Regex rule ordering must be kept correct (most specific first); adding a model means adding a rule.
+- The shared registry and the standalone `scripts/aws-bedrock-cost-report.ts` table remain separate (the script targets Bedrock per-region pricing); both must be updated when rates change.
+
+### Risks and Mitigations
+
+- **Risk**: the `output_tokens === 0 ⇒ unbilled` heuristic could under-count a genuinely-billed mid-stream decline.
+  - **Mitigation**: matches the documented pre-output-refusal billing rule and the canonical `iterations` example; mid-output declines carry `output_tokens > 0` and are billed normally. Covered by unit tests.
+- **Risk**: `usage.iterations` shape drift.
+  - **Mitigation**: parsing is permissive (all fields optional) and falls back to top-level attribution when `iterations` is absent.
+
+## Links
+
+- [ADR-005: Token Usage Tracking](./adr-005-token-usage-tracking.md)
+- [ADR-001: Monorepo Structure](./adr-001-monorepo-structure.md)
+- [ADR-030: Multi-Provider Support](./adr-030-multi-provider-support.md)
+- [Anthropic — Refusals and fallback](https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback)
+- [Anthropic — Models overview](https://platform.claude.com/docs/en/about-claude/models/overview)
+
+## Notes
+
+Fable 5 uses the same tokenizer as Opus 4.8, so token _counts_ are unchanged versus Opus 4.7/4.8 — only the per-token _price_ differs (and, on fallback, the model those tokens are billed against). No count-conversion logic is needed.
+
+---
+
+Date: 2026-07-05
+Authors: AI agent (Claude)

--- a/docs/06-Reference/api-schemas.md
+++ b/docs/06-Reference/api-schemas.md
@@ -487,9 +487,10 @@ function isValidProjectId(projectId: string): boolean {
 // Validate model
 function isValidModel(model: string): boolean {
   // Models follow pattern: claude-{tier}-{version}-{date}
-  // Examples: claude-opus-4-5-20251101, claude-sonnet-4-5-20250929
+  // Examples: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-5-20250929
   const validModelPatterns = [
-    /^claude-(opus|sonnet|haiku)-\d+-\d+(-\d{8})?$/,
+    /^claude-(fable|mythos)-\d+$/, // Claude Fable 5 / Mythos 5
+    /^claude-(opus|sonnet|haiku)-\d+(-\d+)?(-\d{8})?$/,
     /^claude-3(-5)?-(opus|sonnet|haiku)-\d{8}$/,
   ]
   return validModelPatterns.some(pattern => pattern.test(model))

--- a/docs/06-Reference/changelog.md
+++ b/docs/06-Reference/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Account pool no longer routes requests to accounts whose model-scoped limit is exhausted (fixes upstream `429 "This request could exceed your account's rate limit"` despite low 5h/7d usage)
+  - Anthropic's OAuth usage response now carries a structured `limits[]` array with model-scoped weekly limits (e.g. a separate Claude Fable 5 allowance); the legacy `seven_day_opus`/`seven_day_sonnet` fields are null in live responses
+  - Account selection is now model-aware: a saturated Fable-scoped limit exhausts the pool for Fable requests only, without blocking other models; sticky accounts are re-evaluated per requested model
+  - Pool-exhausted 429s now surface the scoped limit's reset time
+  - Dashboard/public token-usage pages now render model-scoped limit bars (e.g. "7-Day Fable") so exhausted limits are visible instead of only 5h/7d windows
+
 ### Changed
 
 - Token Usage overview: projects with zero tokens are now hidden from the project list

--- a/docs/06-Reference/changelog.md
+++ b/docs/06-Reference/changelog.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Model pricing registry and Claude Fable 5 support (see [ADR-035](../04-Architecture/ADRs/adr-035-model-pricing-registry-and-fallback-cost-attribution.md))
+  - New `packages/shared` pricing registry (`getModelPricing`, `calculateRequestCost`) with current per-model rates, including Claude Fable 5 / Mythos 5 ($10/$50 per MTok); replaces the obsolete hardcoded Claude-3-era rate table in the dashboard
+  - Fallback-aware cost attribution (`getBilledUsageByModel`, `calculateUsageCost`): a Claude Fable 5 request re-served by an Opus 4.8 fallback is costed at the model that actually ran each attempt via the response `usage.iterations` array; pre-output declines are treated as unbilled
+  - Dashboard per-model token/cost breakdown and single-request cost now use the registry (model-aware, fallback-aware)
+  - Added Claude Fable 5 / Mythos 5, Opus 4.7 / 4.8, and Sonnet 5 to the 1M context-window rules
+  - Added an optional `iterations` field to the shared Claude `usage` type
 - Public token usage status page at `/public/token-usage` (no authentication required)
   - Shows Anthropic OAuth rate limit utilization (5h and 7d windows) per account
   - Compact multi-column layout with progress bars, reset times, and last-checked timestamps

--- a/packages/shared/src/config/model-mapping.ts
+++ b/packages/shared/src/config/model-mapping.ts
@@ -11,6 +11,12 @@ export interface BedrockModelConfig {
 /**
  * Map of Anthropic model names to Bedrock model IDs
  * Updated as of November 2025
+ *
+ * Note: Newer models (Claude Fable 5, Opus 4.6/4.7/4.8, Sonnet 4.6/5) have no
+ * verified `{region}.anthropic.{model}-vN:0` IDs for this legacy ARN-versioned
+ * Bedrock integration, so they intentionally have no entry here.
+ * `mapToBedrockModel()` passes unknown model IDs through unchanged, so
+ * first-party requests for these models are unaffected.
  */
 export const MODEL_MAPPING: Record<string, string> = {
   // Claude 4.5 Opus (Latest - November 2025)

--- a/packages/shared/src/constants/__tests__/model-limits.test.ts
+++ b/packages/shared/src/constants/__tests__/model-limits.test.ts
@@ -8,6 +8,29 @@ import {
 
 describe('Model Context Limits', () => {
   describe('getModelContextLimit', () => {
+    // Test 1M context models - Claude Fable 5 / Mythos 5
+    it('should return 1M for Claude Fable 5', () => {
+      expect(getModelContextLimit('claude-fable-5')).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
+    it('should return 1M for Claude Mythos 5', () => {
+      expect(getModelContextLimit('claude-mythos-5')).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
+    // Test 1M context models - Claude Opus 4.7 / 4.8
+    it('should return 1M for Claude Opus 4.7', () => {
+      expect(getModelContextLimit('claude-opus-4-7')).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
+    it('should return 1M for Claude Opus 4.8', () => {
+      expect(getModelContextLimit('claude-opus-4-8')).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
+    // Test 1M context models - Claude Sonnet 5
+    it('should return 1M for Claude Sonnet 5', () => {
+      expect(getModelContextLimit('claude-sonnet-5')).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
     // Test 1M context models - Claude 4.6 (Opus & Sonnet)
     it('should return 1M for Claude Opus 4.6', () => {
       const result = getModelContextLimit('claude-opus-4-6')

--- a/packages/shared/src/constants/__tests__/model-pricing.test.ts
+++ b/packages/shared/src/constants/__tests__/model-pricing.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  getModelPricing,
+  calculateRequestCost,
+  getBilledUsageByModel,
+  calculateUsageCost,
+  DEFAULT_MODEL_PRICING,
+  type RawUsage,
+} from '../model-pricing'
+
+describe('Model Pricing', () => {
+  describe('getModelPricing', () => {
+    it('prices Claude Fable 5 at $10 / $50 per MTok', () => {
+      const { pricing, isEstimate } = getModelPricing('claude-fable-5')
+      expect(isEstimate).toBe(false)
+      expect(pricing).toEqual({ input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 })
+    })
+
+    it('prices Claude Mythos 5 the same as Fable 5', () => {
+      expect(getModelPricing('claude-mythos-5').pricing).toEqual(
+        getModelPricing('claude-fable-5').pricing
+      )
+    })
+
+    it('prices Opus 4.8 at $5 / $25 per MTok', () => {
+      const { pricing } = getModelPricing('claude-opus-4-8')
+      expect(pricing).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 })
+    })
+
+    it('keeps legacy Opus (4.1 / 3) at $15 / $75 per MTok', () => {
+      expect(getModelPricing('claude-opus-4-1').pricing.input).toBe(15)
+      expect(getModelPricing('claude-3-opus-20240229').pricing.output).toBe(75)
+    })
+
+    it('prices Sonnet 5 and Sonnet 4.x at $3 / $15 per MTok', () => {
+      expect(getModelPricing('claude-sonnet-5').pricing.input).toBe(3)
+      expect(getModelPricing('claude-sonnet-4-6').pricing.output).toBe(15)
+    })
+
+    it('returns default pricing (flagged as estimate) for unknown models', () => {
+      const { pricing, isEstimate } = getModelPricing('some-future-model')
+      expect(isEstimate).toBe(true)
+      expect(pricing).toEqual(DEFAULT_MODEL_PRICING)
+    })
+  })
+
+  describe('calculateRequestCost', () => {
+    it('computes cost across input, output, and cache tokens', () => {
+      const cost = calculateRequestCost('claude-fable-5', {
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        cacheReadTokens: 1_000_000,
+        cacheCreationTokens: 1_000_000,
+      })
+      // 10 + 50 + 1 + 12.5
+      expect(cost).toBeCloseTo(73.5, 6)
+    })
+
+    it('treats missing token fields as zero', () => {
+      expect(calculateRequestCost('claude-opus-4-8', { inputTokens: 1_000_000 })).toBeCloseTo(5, 6)
+    })
+  })
+
+  describe('getBilledUsageByModel — fallback attribution', () => {
+    it('attributes tokens/cost to the top-level model when there are no iterations', () => {
+      const usage: RawUsage = { input_tokens: 1_000_000, output_tokens: 1_000_000 }
+      const entries = getBilledUsageByModel('claude-fable-5', usage)
+      expect(entries).toHaveLength(1)
+      expect(entries[0].model).toBe('claude-fable-5')
+      expect(entries[0].cost).toBeCloseTo(60, 6) // 10 input + 50 output
+    })
+
+    it('bills only the serving model when Fable 5 declines before output', () => {
+      // Real shape from the refusals-and-fallback docs: Fable 5 declines with
+      // output_tokens: 0, Opus 4.8 serves the turn.
+      const usage: RawUsage = {
+        input_tokens: 412,
+        output_tokens: 264,
+        iterations: [
+          {
+            type: 'message',
+            model: 'claude-fable-5',
+            input_tokens: 535,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          {
+            type: 'fallback_message',
+            model: 'claude-opus-4-8',
+            input_tokens: 412,
+            output_tokens: 264,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        ],
+      }
+      const entries = getBilledUsageByModel('claude-fable-5', usage)
+      // The declined Fable 5 attempt (0 output) is not billed and is dropped.
+      expect(entries).toHaveLength(1)
+      expect(entries[0].model).toBe('claude-opus-4-8')
+      expect(entries[0].inputTokens).toBe(412)
+      expect(entries[0].outputTokens).toBe(264)
+
+      // Cost is billed at Opus 4.8 rates, not Fable 5 rates.
+      const expected = (412 / 1_000_000) * 5 + (264 / 1_000_000) * 25
+      expect(calculateUsageCost('claude-fable-5', usage)).toBeCloseTo(expected, 9)
+    })
+
+    it('returns no billed entries when every attempt declines before output', () => {
+      const usage: RawUsage = {
+        input_tokens: 500,
+        output_tokens: 0,
+        iterations: [
+          { type: 'message', model: 'claude-fable-5', input_tokens: 500, output_tokens: 0 },
+          {
+            type: 'fallback_message',
+            model: 'claude-opus-4-8',
+            input_tokens: 500,
+            output_tokens: 0,
+          },
+        ],
+      }
+      expect(getBilledUsageByModel('claude-fable-5', usage)).toHaveLength(0)
+      expect(calculateUsageCost('claude-fable-5', usage)).toBe(0)
+    })
+
+    it('returns no entries for undefined usage', () => {
+      expect(getBilledUsageByModel('claude-fable-5', undefined)).toHaveLength(0)
+      expect(calculateUsageCost('claude-fable-5', undefined)).toBe(0)
+    })
+  })
+})

--- a/packages/shared/src/constants/model-limits.ts
+++ b/packages/shared/src/constants/model-limits.ts
@@ -17,10 +17,11 @@ export interface ModelContextRule {
  * Model context window rules
  * Order matters - more specific patterns should come before general ones
  *
- * Claude Opus 4.6 and Sonnet 4.6 support 1M context windows (GA March 2026).
- * Models with "[1m]" suffix in their display name also indicate 1M context.
- * Earlier Claude 4.x models use 200k context windows.
+ * Claude Fable 5, Opus 4.6/4.7/4.8, Sonnet 5 and Sonnet 4.6 support 1M context
+ * windows. Models with "[1m]" suffix in their display name also indicate 1M
+ * context. Earlier Claude 4.x models use 200k context windows.
  *
+ * @see https://platform.claude.com/docs/en/about-claude/models/overview
  * @see https://claude.com/blog/1m-context-ga
  */
 export const MODEL_CONTEXT_RULES: ModelContextRule[] = [
@@ -32,9 +33,20 @@ export const MODEL_CONTEXT_RULES: ModelContextRule[] = [
     source: 'https://claude.com/blog/1m-context-ga',
   },
 
-  // Claude 4.6 (Opus & Sonnet) - 1M context window (GA March 2026)
+  // Claude Fable 5 / Mythos 5 - 1M context window (new top tier above Opus)
+  // Source: https://platform.claude.com/docs/en/about-claude/models/overview
+  { pattern: /claude-(fable|mythos)-5/i, limit: 1000000 },
+
+  // Claude Opus 4.6 / 4.7 / 4.8 - 1M context window
+  // Source: https://platform.claude.com/docs/en/about-claude/models/overview
+  { pattern: /claude-opus-4-[678]/i, limit: 1000000 },
+
+  // Claude Sonnet 5 - 1M context window
+  // Source: https://platform.claude.com/docs/en/about-claude/models/overview
+  { pattern: /claude-sonnet-5/i, limit: 1000000 },
+
+  // Claude Sonnet 4.6 - 1M context window (GA March 2026)
   // Source: https://claude.com/blog/1m-context-ga
-  { pattern: /claude-opus-4-6/i, limit: 1000000 },
   { pattern: /claude-sonnet-4-6/i, limit: 1000000 },
 
   // Claude 4.5 and earlier 4.x (new naming: claude-{family}-{version}) - 200k context

--- a/packages/shared/src/constants/model-pricing.ts
+++ b/packages/shared/src/constants/model-pricing.ts
@@ -1,0 +1,243 @@
+/**
+ * Model pricing configuration and cost attribution
+ *
+ * Pattern-based pricing (USD per million tokens) for Claude models, based on
+ * official Anthropic first-party API pricing.
+ *
+ * Cache pricing follows the standard Anthropic multipliers:
+ * - cache read  = 0.1x  input price
+ * - cache write = 1.25x input price (5-minute TTL)
+ *
+ * ## Fallback token attribution (Claude Fable 5)
+ *
+ * Claude Fable 5 can decline a request via its safety classifiers; with
+ * server-side fallback the request is re-served by another model (e.g.
+ * `claude-opus-4-8`) inside the same API call. The response `usage.iterations`
+ * array records every attempt, each with its own `model` and token counts, and
+ * the API bills each attempt at the rate of the model that ran it — the
+ * top-level `usage` reflects only the attempt that produced the returned
+ * message. A decline that happens before any output is generated is not billed.
+ *
+ * {@link getBilledUsageByModel} and {@link calculateUsageCost} implement this:
+ * when `iterations` are present, cost is attributed per-iteration to the model
+ * that actually ran, and pre-output declines (output_tokens === 0) are treated
+ * as free.
+ *
+ * @see https://platform.claude.com/docs/en/about-claude/models/overview
+ * @see https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback
+ */
+
+export interface ModelPricing {
+  /** USD per 1M input tokens */
+  input: number
+  /** USD per 1M output tokens */
+  output: number
+  /** USD per 1M cache read tokens */
+  cacheRead: number
+  /** USD per 1M cache write tokens (5-minute TTL) */
+  cacheWrite: number
+}
+
+export interface ModelPricingRule {
+  pattern: RegExp
+  pricing: ModelPricing
+}
+
+/**
+ * Model pricing rules.
+ * Order matters — more specific patterns must come before general ones.
+ */
+export const MODEL_PRICING_RULES: ModelPricingRule[] = [
+  // Claude Fable 5 / Mythos 5 — top tier above Opus ($10 / $50 per MTok)
+  {
+    pattern: /claude-(fable|mythos)-5/i,
+    pricing: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  },
+
+  // Claude Opus 4.5 / 4.6 / 4.7 / 4.8 ($5 / $25 per MTok)
+  {
+    pattern: /claude-opus-4-[5678]/i,
+    pricing: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  },
+
+  // Claude Opus 4.0 / 4.1 and Claude 3 Opus (legacy premium pricing)
+  {
+    pattern: /claude-opus-4|claude-3-opus|claude-4.*opus/i,
+    pricing: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  },
+
+  // Claude Sonnet 5 / 4.x / 3.x (all Sonnet generations share this price point)
+  {
+    pattern: /claude-sonnet-5|claude-sonnet-4|claude-3.*sonnet|claude-4.*sonnet/i,
+    pricing: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  },
+
+  // Claude Haiku 4.5
+  {
+    pattern: /claude-haiku-4/i,
+    pricing: { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+  },
+
+  // Claude 3.5 Haiku
+  {
+    pattern: /claude-3-5-haiku|claude-3\.5.*haiku/i,
+    pricing: { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
+  },
+
+  // Claude 3 Haiku
+  {
+    pattern: /claude-3.*haiku/i,
+    pricing: { input: 0.25, output: 1.25, cacheRead: 0.03, cacheWrite: 0.3 },
+  },
+
+  // Claude 2.x (retired, kept for historical request data)
+  {
+    pattern: /claude-2/i,
+    pricing: { input: 8, output: 24, cacheRead: 0.8, cacheWrite: 10 },
+  },
+]
+
+/**
+ * Default pricing for unknown models (Sonnet-tier as a middle-ground estimate)
+ */
+export const DEFAULT_MODEL_PRICING: ModelPricing = {
+  input: 3,
+  output: 15,
+  cacheRead: 0.3,
+  cacheWrite: 3.75,
+}
+
+/**
+ * Get the pricing for a given model.
+ * @param model - The model identifier (e.g., "claude-fable-5")
+ * @returns The pricing and whether it's an estimate (unknown model → default)
+ */
+export function getModelPricing(model: string): { pricing: ModelPricing; isEstimate: boolean } {
+  for (const rule of MODEL_PRICING_RULES) {
+    if (rule.pattern.test(model)) {
+      return { pricing: rule.pricing, isEstimate: false }
+    }
+  }
+  return { pricing: DEFAULT_MODEL_PRICING, isEstimate: true }
+}
+
+/** Token counts in camelCase, as used by the dashboard/storage layer. */
+export interface TokenUsageInput {
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
+}
+
+/**
+ * Calculate the estimated cost (USD) for token usage on a single model.
+ */
+export function calculateRequestCost(model: string, usage: TokenUsageInput): number {
+  const { pricing } = getModelPricing(model)
+  return (
+    ((usage.inputTokens ?? 0) / 1_000_000) * pricing.input +
+    ((usage.outputTokens ?? 0) / 1_000_000) * pricing.output +
+    ((usage.cacheReadTokens ?? 0) / 1_000_000) * pricing.cacheRead +
+    ((usage.cacheCreationTokens ?? 0) / 1_000_000) * pricing.cacheWrite
+  )
+}
+
+/**
+ * A single attempt recorded in the Claude API response `usage.iterations`.
+ * Field names are the raw API (snake_case) shape.
+ */
+export interface RawUsageIteration {
+  /** "message" = an attempt that ran (and may have declined); "fallback_message" = the attempt that served the turn */
+  type?: string
+  model?: string
+  input_tokens?: number
+  output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+}
+
+/**
+ * The raw Claude API response `usage` object (snake_case), optionally carrying
+ * per-attempt `iterations` when server-side fallback ran.
+ */
+export interface RawUsage {
+  input_tokens?: number
+  output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+  iterations?: RawUsageIteration[]
+}
+
+/** Billed token usage attributed to a specific model, with its computed cost. */
+export interface BilledUsageEntry {
+  model: string
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  /** True when the model didn't match a known pricing rule (cost is an estimate). */
+  isEstimate: boolean
+  /** Estimated cost in USD for this entry. */
+  cost: number
+}
+
+/**
+ * Attribute billed token usage to the model(s) that actually ran, handling
+ * Claude Fable 5 fallback.
+ *
+ * When `usage.iterations` is present, each billed attempt is attributed to its
+ * own `model`. Attempts that declined before producing any output
+ * (`output_tokens === 0`) are omitted because they are not billed. When there
+ * are no iterations, the top-level usage is attributed to `topLevelModel`.
+ *
+ * @param topLevelModel - The model recorded for the request (used when there are no iterations, and as a fallback for iterations missing a model).
+ * @param usage - The raw API `usage` object.
+ */
+export function getBilledUsageByModel(topLevelModel: string, usage?: RawUsage): BilledUsageEntry[] {
+  const toEntry = (model: string, u: RawUsageIteration | RawUsage): BilledUsageEntry => {
+    const inputTokens = u.input_tokens ?? 0
+    const outputTokens = u.output_tokens ?? 0
+    const cacheReadTokens = u.cache_read_input_tokens ?? 0
+    const cacheCreationTokens = u.cache_creation_input_tokens ?? 0
+    const { isEstimate } = getModelPricing(model)
+    return {
+      model,
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
+      isEstimate,
+      cost: calculateRequestCost(model, {
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
+      }),
+    }
+  }
+
+  if (!usage) {
+    return []
+  }
+
+  const iterations = usage.iterations
+  if (Array.isArray(iterations) && iterations.length > 0) {
+    return (
+      iterations
+        // Skip pre-output declines: a refusal before any output is generated is
+        // not billed (see refusals-and-fallback billing rules).
+        .filter(it => (it.output_tokens ?? 0) > 0)
+        .map(it => toEntry(it.model || topLevelModel, it))
+    )
+  }
+
+  return [toEntry(topLevelModel, usage)]
+}
+
+/**
+ * Calculate the total estimated cost (USD) for a request's raw API usage,
+ * attributing fallback iterations to the model that actually ran each attempt.
+ */
+export function calculateUsageCost(topLevelModel: string, usage?: RawUsage): number {
+  return getBilledUsageByModel(topLevelModel, usage).reduce((sum, entry) => sum + entry.cost, 0)
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -77,6 +77,22 @@ export {
   type ModelContextRule,
 } from './constants/model-limits.js'
 
+// Export model pricing configuration and fallback-aware cost attribution
+export {
+  MODEL_PRICING_RULES,
+  DEFAULT_MODEL_PRICING,
+  getModelPricing,
+  calculateRequestCost,
+  getBilledUsageByModel,
+  calculateUsageCost,
+  type ModelPricing,
+  type ModelPricingRule,
+  type TokenUsageInput,
+  type RawUsage,
+  type RawUsageIteration,
+  type BilledUsageEntry,
+} from './constants/model-pricing.js'
+
 export {
   MSL_PROJECT_ID_HEADER,
   MSL_PROJECT_ID_HEADER_LOWER,

--- a/packages/shared/src/types/claude.ts
+++ b/packages/shared/src/types/claude.ts
@@ -68,6 +68,24 @@ export interface ClaudeMessagesRequest {
   [key: string]: any // Allow any additional fields in the request
 }
 
+/**
+ * A single attempt recorded in `usage.iterations` when server-side fallback
+ * runs (e.g. a Claude Fable 5 request re-served by Claude Opus 4.8). Each
+ * attempt is billed at its own model's rate; a decline before any output
+ * (`output_tokens === 0`) is not billed.
+ *
+ * @see https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback
+ */
+export interface ClaudeUsageIteration {
+  /** "message" = an attempt that ran/declined; "fallback_message" = the attempt that served the turn */
+  type?: 'message' | 'fallback_message'
+  model?: string
+  input_tokens?: number
+  output_tokens?: number
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
+}
+
 // Response types
 export interface ClaudeMessagesResponse {
   id: string
@@ -82,6 +100,8 @@ export interface ClaudeMessagesResponse {
     output_tokens: number
     cache_creation_input_tokens?: number
     cache_read_input_tokens?: number
+    /** Per-attempt token counts when server-side fallback ran (Claude Fable 5). */
+    iterations?: ClaudeUsageIteration[]
   }
 }
 

--- a/packages/shared/src/types/oauth-usage.ts
+++ b/packages/shared/src/types/oauth-usage.ts
@@ -25,6 +25,37 @@ export interface OAuthExtraUsage {
 }
 
 /**
+ * Scope of a limit entry. Model-scoped limits (e.g. a separate weekly
+ * allowance for Claude Fable 5) carry a `model` object; `id` and/or
+ * `display_name` may be populated.
+ */
+export interface OAuthLimitScope {
+  model: { id: string | null; display_name: string | null } | null
+  surface: string | null
+}
+
+/**
+ * A single entry in the `limits` array of the OAuth usage response.
+ *
+ * This is the forward-compatible limit surface: Anthropic has migrated
+ * model-specific data out of the legacy `seven_day_opus`/`seven_day_sonnet`
+ * fields (now null in live responses) into this array. Known kinds:
+ * `session` (mirrors five_hour), `weekly_all` (mirrors seven_day), and
+ * `weekly_scoped` (model-specific weekly limit, e.g. Claude Fable 5).
+ */
+export interface OAuthLimitEntry {
+  kind: string
+  group: string | null
+  /** Usage percentage (0-100) */
+  percent: number | null
+  severity: string | null
+  /** ISO timestamp when this limit resets (null when not active) */
+  resets_at: string | null
+  scope: OAuthLimitScope | null
+  is_active: boolean | null
+}
+
+/**
  * Raw response from Anthropic OAuth usage API
  */
 export interface AnthropicOAuthUsageResponse {
@@ -34,12 +65,17 @@ export interface AnthropicOAuthUsageResponse {
   seven_day: OAuthUsageWindow | null
   /** 7-day OAuth apps specific limit */
   seven_day_oauth_apps: OAuthUsageWindow | null
-  /** 7-day Opus model specific limit */
+  /** 7-day Opus model specific limit (legacy — null in current responses) */
   seven_day_opus: OAuthUsageWindow | null
-  /** 7-day Sonnet model specific limit */
+  /** 7-day Sonnet model specific limit (legacy — null in current responses) */
   seven_day_sonnet: OAuthUsageWindow | null
   /** Internal/experimental field */
   iguana_necktie: OAuthUsageWindow | null
+  /**
+   * Structured limits, including model-scoped weekly limits (e.g. Claude
+   * Fable 5). Optional: older cached entries may not carry it.
+   */
+  limits?: OAuthLimitEntry[] | null
   /** Extra usage for paid accounts */
   extra_usage: OAuthExtraUsage
 }

--- a/scripts/aws-bedrock-cost-report.ts
+++ b/scripts/aws-bedrock-cost-report.ts
@@ -235,6 +235,74 @@ type ModelPricingEntry = {
 
 const MODEL_PRICING: readonly ModelPricingEntry[] = [
   {
+    alias: 'claude-fable-5',
+    displayName: 'Claude Fable 5',
+    matchers: ['fable'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.01, outputPerThousand: 0.05 },
+        batch: { inputPerThousand: 0.005, outputPerThousand: 0.025 },
+        cacheReadPerThousand: 0.001,
+        cacheWritePerThousand: 0.0125,
+      },
+      us: {
+        standard: { inputPerThousand: 0.011, outputPerThousand: 0.055 },
+        batch: { inputPerThousand: 0.0055, outputPerThousand: 0.0275 },
+        cacheReadPerThousand: 0.0011,
+        cacheWritePerThousand: 0.01375,
+      },
+    },
+  },
+  {
+    alias: 'claude-mythos-5',
+    displayName: 'Claude Mythos 5',
+    matchers: ['mythos'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.01, outputPerThousand: 0.05 },
+        batch: { inputPerThousand: 0.005, outputPerThousand: 0.025 },
+        cacheReadPerThousand: 0.001,
+        cacheWritePerThousand: 0.0125,
+      },
+    },
+  },
+  {
+    alias: 'claude-opus-4-8',
+    displayName: 'Claude Opus 4.8',
+    matchers: ['opus', '4-8'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.005, outputPerThousand: 0.025 },
+        cacheReadPerThousand: 0.0005,
+        cacheWritePerThousand: 0.00625,
+      },
+    },
+  },
+  {
+    alias: 'claude-opus-4-7',
+    displayName: 'Claude Opus 4.7',
+    matchers: ['opus', '4-7'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.005, outputPerThousand: 0.025 },
+        cacheReadPerThousand: 0.0005,
+        cacheWritePerThousand: 0.00625,
+      },
+    },
+  },
+  {
+    alias: 'claude-sonnet-5',
+    displayName: 'Claude Sonnet 5',
+    matchers: ['sonnet-5'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.003, outputPerThousand: 0.015 },
+        cacheReadPerThousand: 0.0003,
+        cacheWritePerThousand: 0.00375,
+      },
+    },
+  },
+  {
     alias: 'claude-haiku-4-5',
     displayName: 'Claude Haiku 4.5',
     matchers: ['haiku', '4-5'],

--- a/services/dashboard/src/routes/partials/analytics-conversation.ts
+++ b/services/dashboard/src/routes/partials/analytics-conversation.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { html, raw } from 'hono/html'
 import { ProxyApiClient } from '../../services/api-client.js'
-import { getErrorMessage } from '@agent-prompttrain/shared'
+import { getErrorMessage, getBilledUsageByModel, type RawUsage } from '@agent-prompttrain/shared'
 import type { ApiRequest } from '../../types/conversation.js'
 
 export const analyticsConversationPartialRoutes = new Hono<{
@@ -82,24 +82,36 @@ analyticsConversationPartialRoutes.get(
         timeline: [] as Array<{ timestamp: Date; cumulativeTokens: number; model: string }>,
       }
 
+      // Model-aware, fallback-aware cost accounting.
+      // For Claude Fable 5 requests re-served by a fallback model, usage.iterations
+      // splits tokens across the models that actually ran; getBilledUsageByModel
+      // attributes billed tokens/cost to each and drops unbilled pre-output declines.
+      const costs = {
+        total: 0,
+        byModel: {} as Record<string, number>,
+      }
+
       // Process each request
       filteredRequests.forEach((req: ApiRequest) => {
-        const usage = req.response_body?.usage
-        if (usage) {
-          const inputTokens = usage.input_tokens || 0
-          const outputTokens = usage.output_tokens || 0
-          const cacheReadTokens = usage.cache_read_input_tokens || 0
-          const cacheCreationTokens = usage.cache_creation_input_tokens || 0
+        const usage = req.response_body?.usage as RawUsage | undefined
+        const entries = getBilledUsageByModel(req.model || 'unknown', usage)
+        if (entries.length === 0) {
+          return
+        }
 
-          tokenStats.totalInputTokens += inputTokens
-          tokenStats.totalOutputTokens += outputTokens
-          tokenStats.totalCacheReadTokens += cacheReadTokens
-          tokenStats.totalCacheCreationTokens += cacheCreationTokens
+        let reqInput = 0
+        let reqOutput = 0
+        let servedModel = req.model || 'unknown'
 
-          // By model
-          const model = req.model || 'unknown'
-          if (!tokenStats.byModel[model]) {
-            tokenStats.byModel[model] = {
+        entries.forEach(entry => {
+          tokenStats.totalInputTokens += entry.inputTokens
+          tokenStats.totalOutputTokens += entry.outputTokens
+          tokenStats.totalCacheReadTokens += entry.cacheReadTokens
+          tokenStats.totalCacheCreationTokens += entry.cacheCreationTokens
+
+          // By model (attributed to the model that actually ran the attempt)
+          if (!tokenStats.byModel[entry.model]) {
+            tokenStats.byModel[entry.model] = {
               input: 0,
               output: 0,
               cacheRead: 0,
@@ -107,29 +119,37 @@ analyticsConversationPartialRoutes.get(
               requests: 0,
             }
           }
-          tokenStats.byModel[model].input += inputTokens
-          tokenStats.byModel[model].output += outputTokens
-          tokenStats.byModel[model].cacheRead += cacheReadTokens
-          tokenStats.byModel[model].cacheCreation += cacheCreationTokens
-          tokenStats.byModel[model].requests++
+          tokenStats.byModel[entry.model].input += entry.inputTokens
+          tokenStats.byModel[entry.model].output += entry.outputTokens
+          tokenStats.byModel[entry.model].cacheRead += entry.cacheReadTokens
+          tokenStats.byModel[entry.model].cacheCreation += entry.cacheCreationTokens
+          tokenStats.byModel[entry.model].requests++
 
-          // By account
-          const account = req.account_id || 'unknown'
-          if (!tokenStats.byAccount[account]) {
-            tokenStats.byAccount[account] = { input: 0, output: 0, total: 0, requests: 0 }
-          }
-          tokenStats.byAccount[account].input += inputTokens
-          tokenStats.byAccount[account].output += outputTokens
-          tokenStats.byAccount[account].total += inputTokens + outputTokens
-          tokenStats.byAccount[account].requests++
+          // Cost (per-model rates, incl. Claude Fable 5 at $10/$50 per MTok)
+          costs.byModel[entry.model] = (costs.byModel[entry.model] || 0) + entry.cost
+          costs.total += entry.cost
 
-          // Timeline
-          tokenStats.timeline.push({
-            timestamp: new Date(req.timestamp),
-            cumulativeTokens: inputTokens + outputTokens,
-            model,
-          })
+          reqInput += entry.inputTokens
+          reqOutput += entry.outputTokens
+          servedModel = entry.model
+        })
+
+        // By account
+        const account = req.account_id || 'unknown'
+        if (!tokenStats.byAccount[account]) {
+          tokenStats.byAccount[account] = { input: 0, output: 0, total: 0, requests: 0 }
         }
+        tokenStats.byAccount[account].input += reqInput
+        tokenStats.byAccount[account].output += reqOutput
+        tokenStats.byAccount[account].total += reqInput + reqOutput
+        tokenStats.byAccount[account].requests++
+
+        // Timeline (one point per request, attributed to the serving model)
+        tokenStats.timeline.push({
+          timestamp: new Date(req.timestamp),
+          cumulativeTokens: reqInput + reqOutput,
+          model: servedModel,
+        })
       })
 
       // Sort timeline and calculate cumulative
@@ -139,31 +159,6 @@ analyticsConversationPartialRoutes.get(
         ...point,
         cumulativeTokens: (cumulative += point.cumulativeTokens),
       }))
-
-      // Calculate costs (rough estimates)
-      const costs = {
-        total: 0,
-        byModel: {} as Record<string, number>,
-      }
-
-      Object.entries(tokenStats.byModel).forEach(([model, stats]) => {
-        // Rough cost estimates per 1M tokens
-        const rates = {
-          'claude-3-opus': { input: 15, output: 75 },
-          'claude-3-sonnet': { input: 3, output: 15 },
-          'claude-3-haiku': { input: 0.25, output: 1.25 },
-          'claude-2': { input: 8, output: 24 },
-        }
-
-        const modelKey =
-          Object.keys(rates).find(key => model.toLowerCase().includes(key.split('-').pop()!)) ||
-          'claude-3-sonnet'
-        const rate = rates[modelKey as keyof typeof rates]
-
-        const cost = (stats.input / 1000000) * rate.input + (stats.output / 1000000) * rate.output
-        costs.byModel[model] = cost
-        costs.total += cost
-      })
 
       const content = html`
         <div style="padding: 1.5rem;">

--- a/services/dashboard/src/routes/request-details.ts
+++ b/services/dashboard/src/routes/request-details.ts
@@ -1,7 +1,12 @@
 import { Hono } from 'hono'
 import { html, raw } from 'hono/html'
-import { getErrorMessage } from '@agent-prompttrain/shared'
-import { parseConversation, calculateCost } from '../utils/conversation.js'
+import {
+  getErrorMessage,
+  calculateUsageCost,
+  calculateRequestCost,
+  type RawUsage,
+} from '@agent-prompttrain/shared'
+import { parseConversation } from '../utils/conversation.js'
 import { formatDuration, escapeHtml } from '../utils/formatters.js'
 import { layout } from '../layout/index.js'
 import { isSparkRecommendation, parseSparkRecommendation } from '../utils/spark.js'
@@ -111,8 +116,16 @@ requestDetailsRoutes.get('/request/:id', async c => {
       timestamp: details.timestamp,
     })
 
-    // Calculate cost
-    const cost = calculateCost(conversation.totalInputTokens, conversation.totalOutputTokens)
+    // Calculate cost (model-aware; attributes Claude Fable 5 fallback iterations
+    // to the model that actually served each attempt)
+    const rawUsage = details.responseBody?.usage as RawUsage | undefined
+    const totalCost = rawUsage
+      ? calculateUsageCost(details.model || 'unknown', rawUsage)
+      : calculateRequestCost(details.model || 'unknown', {
+          inputTokens: conversation.totalInputTokens,
+          outputTokens: conversation.totalOutputTokens,
+        })
+    const cost = { totalCost, formattedTotal: `$${totalCost.toFixed(4)}` }
 
     // Detect Spark recommendations
     const sparkRecommendations: Array<{

--- a/services/proxy/src/routes/api.ts
+++ b/services/proxy/src/routes/api.ts
@@ -1706,6 +1706,25 @@ apiRoutes.get('/oauth-usage/:accountId', async c => {
       }
     }
 
+    // Model-scoped limits from the structured limits[] array (e.g. the
+    // separate Claude Fable 5 weekly allowance). These have no legacy window
+    // field — without this, a saturated model limit is invisible while
+    // Anthropic rejects requests for that model with a 429.
+    for (const limit of entry.usage.limits ?? []) {
+      const scopedModelName = limit.scope?.model?.display_name || limit.scope?.model?.id
+      if (!scopedModelName) {
+        continue // unscoped kinds (session/weekly_all) duplicate 5h/7d above
+      }
+      const groupLabel = limit.group === 'session' ? 'Session' : '7-Day'
+      windows.push({
+        name: `${groupLabel} ${scopedModelName}`,
+        short_name: `${limit.group === 'session' ? '5h' : '7d'} ${scopedModelName}`,
+        utilization: limit.percent ?? 0,
+        resets_at: limit.resets_at ? formatResetTime(new Date(limit.resets_at)) : '—',
+        resets_at_iso: limit.resets_at ?? '',
+      })
+    }
+
     const oauthResponse = {
       success: true,
       data: {

--- a/services/proxy/src/services/AuthenticationService.ts
+++ b/services/proxy/src/services/AuthenticationService.ts
@@ -35,7 +35,12 @@ export class AuthenticationService {
     this.accountPoolService = new AccountPoolService(this.pool, this.usageCacheService)
   }
 
-  async authenticate(context: RequestContext): Promise<AuthResult> {
+  /**
+   * @param model - The Claude model requested, when known. Passed to the
+   *   account pool so model-scoped limits (e.g. Claude Fable 5's separate
+   *   weekly allowance) gate accounts for that model only.
+   */
+  async authenticate(context: RequestContext, model?: string): Promise<AuthResult> {
     const requestedAccount = context.account
     const projectId = context.projectId
 
@@ -69,7 +74,7 @@ export class AuthenticationService {
     // Priority 2: Account pool or default account
     let selection
     try {
-      selection = await this.accountPoolService.selectAccount(projectId)
+      selection = await this.accountPoolService.selectAccount(projectId, model)
     } catch (error) {
       if (error instanceof AccountPoolExhaustedError) {
         throw error

--- a/services/proxy/src/services/ProxyService.ts
+++ b/services/proxy/src/services/ProxyService.ts
@@ -187,7 +187,9 @@ export class ProxyService {
           accountName: 'passthrough',
         }
       } else {
-        auth = await this.authService.authenticate(context)
+        // Pass the requested model so account selection can honor
+        // model-scoped limits (e.g. Claude Fable 5's separate weekly allowance)
+        auth = await this.authService.authenticate(context, rawRequest.model)
       }
 
       // Bedrock accounts are not supported on /v1/messages endpoint

--- a/services/proxy/src/services/__tests__/account-pool-service.test.ts
+++ b/services/proxy/src/services/__tests__/account-pool-service.test.ts
@@ -501,4 +501,202 @@ describe('AccountPoolService', () => {
       expect(callsAfterSecond).toBeGreaterThan(callsAfterFirst)
     })
   })
+
+  // ── Scenario: model-scoped limits (limits[] array) ────────────────────────
+  //
+  // Anthropic's OAuth usage response carries a `limits` array with entries like
+  // {kind: "weekly_scoped", percent, scope: {model: {display_name: "Fable"}}, is_active}.
+  // A saturated model-scoped limit must gate requests FOR that model even when
+  // the overall five_hour/seven_day windows are low — but must NOT block other
+  // models. See the "429 despite plenty of tokens left" incident.
+
+  describe('model-scoped limits (limits[] array)', () => {
+    function makeUsageWithFableLimit(
+      fableUtilization: number,
+      fiveHour = 10,
+      sevenDay = 20
+    ): AnthropicOAuthUsageResponse {
+      return {
+        ...makeUsageResponse(fiveHour, sevenDay),
+        limits: [
+          {
+            kind: 'session',
+            group: 'session',
+            percent: fiveHour,
+            severity: 'normal',
+            resets_at: '2026-02-24T12:00:00Z',
+            scope: null,
+            is_active: true,
+          },
+          {
+            kind: 'weekly_all',
+            group: 'weekly',
+            percent: sevenDay,
+            severity: 'normal',
+            resets_at: '2026-02-28T00:00:00Z',
+            scope: null,
+            is_active: true,
+          },
+          {
+            kind: 'weekly_scoped',
+            group: 'weekly',
+            percent: fableUtilization,
+            severity: fableUtilization >= 100 ? 'exceeded' : 'normal',
+            resets_at: '2026-03-01T00:00:00Z',
+            scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+            is_active: fableUtilization > 0,
+          },
+        ],
+      }
+    }
+
+    test('saturated Fable-scoped limit exhausts the pool for Fable requests', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+
+      // Both accounts: overall windows low, Fable weekly limit saturated
+      mockFetchWithUsage({
+        'cred-1': makeUsageWithFableLimit(100),
+        'cred-2': makeUsageWithFableLimit(99),
+      })
+
+      await expect(service.selectAccount('project-1', 'claude-fable-5')).rejects.toThrow(
+        AccountPoolExhaustedError
+      )
+    })
+
+    test('saturated Fable-scoped limit does NOT block other models', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+
+      mockFetchWithUsage({
+        'cred-1': makeUsageWithFableLimit(100),
+        'cred-2': makeUsageWithFableLimit(100),
+      })
+
+      const result = await service.selectAccount('project-1', 'claude-sonnet-5')
+      expect(result.fromPool).toBe(true)
+      // Overall windows are 10/20 → utilization reflects those, not the Fable limit
+      expect(result.maxUtilization).toBeLessThan(0.8)
+    })
+
+    test('prefers the account whose Fable-scoped limit is under threshold', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+
+      mockFetchWithUsage({
+        'cred-1': makeUsageWithFableLimit(100), // Fable exhausted
+        'cred-2': makeUsageWithFableLimit(30), // Fable fine
+      })
+
+      const result = await service.selectAccount('project-1', 'claude-fable-5')
+      expect(result.credential.id).toBe('cred-2')
+    })
+
+    test('matches scoped limit via scope.model.id when present', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+
+      const usage: AnthropicOAuthUsageResponse = {
+        ...makeUsageResponse(10, 20),
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            group: 'weekly',
+            percent: 100,
+            severity: 'exceeded',
+            resets_at: '2026-03-01T00:00:00Z',
+            scope: { model: { id: 'claude-fable-5', display_name: null }, surface: null },
+            is_active: true,
+          },
+        ],
+      }
+      mockFetchWithUsage({ 'cred-1': usage, 'cred-2': usage })
+
+      await expect(service.selectAccount('project-1', 'claude-fable-5')).rejects.toThrow(
+        AccountPoolExhaustedError
+      )
+    })
+
+    test('sticky account over its scoped limit is abandoned for the requested model', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+
+      // First request (sonnet) selects cred-1 (lowest overall) and makes it sticky
+      mockFetchWithUsage({
+        'cred-1': makeUsageWithFableLimit(100, 10, 20),
+        'cred-2': makeUsageWithFableLimit(0, 30, 40),
+      })
+      const first = await service.selectAccount('project-1', 'claude-sonnet-5')
+      expect(first.credential.id).toBe('cred-1')
+
+      // Fable request must NOT reuse sticky cred-1 (Fable limit saturated there)
+      usageCacheService.clearCache()
+      const second = await service.selectAccount('project-1', 'claude-fable-5')
+      expect(second.credential.id).toBe('cred-2')
+    })
+
+    test('inactive scoped limits are ignored', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+
+      const usage: AnthropicOAuthUsageResponse = {
+        ...makeUsageResponse(10, 20),
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            group: 'weekly',
+            percent: 0,
+            severity: 'normal',
+            resets_at: null,
+            scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+            is_active: false,
+          },
+        ],
+      }
+      mockFetchWithUsage({ 'cred-1': usage, 'cred-2': usage })
+
+      const result = await service.selectAccount('project-1', 'claude-fable-5')
+      expect(result.fromPool).toBe(true)
+    })
+
+    test('legacy responses without limits[] keep the old behavior', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+
+      mockFetchWithUsage({
+        'cred-1': makeUsageResponse(30, 20),
+        'cred-2': makeUsageResponse(50, 40),
+      })
+
+      const result = await service.selectAccount('project-1', 'claude-fable-5')
+      expect(result.credential.id).toBe('cred-1')
+    })
+
+    test('exhausted-pool error surfaces the scoped limit reset time', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+
+      mockFetchWithUsage({
+        'cred-1': makeUsageWithFableLimit(100),
+        'cred-2': makeUsageWithFableLimit(100),
+      })
+
+      try {
+        await service.selectAccount('project-1', 'claude-fable-5')
+        expect.unreachable('should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(AccountPoolExhaustedError)
+        expect((error as AccountPoolExhaustedError).estimatedReset).not.toBeNull()
+      }
+    })
+  })
 })

--- a/services/proxy/src/services/account-pool-service.ts
+++ b/services/proxy/src/services/account-pool-service.ts
@@ -3,6 +3,7 @@ import type {
   Credential,
   AnthropicCredential,
   AnthropicOAuthUsageResponse,
+  OAuthLimitEntry,
 } from '@agent-prompttrain/shared'
 import {
   getProjectLinkedCredentials,
@@ -66,8 +67,12 @@ export class AccountPoolService {
    * 2. If sticky is over threshold, evaluates all linked Anthropic accounts
    * 3. Picks the account with the lowest max utilization that is under threshold
    * 4. Throws AccountPoolExhaustedError if no accounts are available
+   *
+   * @param model - The Claude model requested (e.g. "claude-fable-5"). When
+   *   provided, model-scoped limits from the usage response (e.g. the separate
+   *   Claude Fable 5 weekly allowance) gate accounts for that model only.
    */
-  async selectAccount(projectId: string): Promise<AccountSelection> {
+  async selectAccount(projectId: string, model?: string): Promise<AccountSelection> {
     // Try pool mode: check if project has 2+ linked accounts
     let linkedCredentials: Credential[] = []
     try {
@@ -92,7 +97,7 @@ export class AccountPoolService {
       const stickyCredential = anthropicCredentials.find(c => c.id === stickyCredentialId)
       if (stickyCredential) {
         const cachedEntry = await this.usageCacheService.getUsage(stickyCredential)
-        const maxUtilization = this.computeMaxUtilization(cachedEntry?.usage ?? null)
+        const maxUtilization = this.computeMaxUtilization(cachedEntry?.usage ?? null, model)
 
         if (maxUtilization < stickyCredential.token_limit_threshold) {
           logger.debug('Reusing sticky account (under threshold)', {
@@ -125,7 +130,7 @@ export class AccountPoolService {
     const usageMap = await this.usageCacheService.getUsageMultiple(anthropicCredentials)
     const usageResults = anthropicCredentials.map(credential => {
       const entry = usageMap.get(credential.id)
-      const maxUtilization = this.computeMaxUtilization(entry?.usage ?? null)
+      const maxUtilization = this.computeMaxUtilization(entry?.usage ?? null, model)
       return { credential, maxUtilization }
     })
 
@@ -136,7 +141,7 @@ export class AccountPoolService {
 
     if (available.length === 0) {
       // Find the earliest reset time across all accounts for the error
-      const estimatedReset = this.findEarliestReset(anthropicCredentials, usageMap)
+      const estimatedReset = this.findEarliestReset(anthropicCredentials, usageMap, model)
 
       logger.warn('All accounts in pool exhausted', {
         metadata: {
@@ -201,10 +206,16 @@ export class AccountPoolService {
   }
 
   /**
-   * Compute the maximum utilization across 5-hour and 7-day windows.
+   * Compute the maximum utilization across 5-hour and 7-day windows plus any
+   * applicable entries in the structured `limits` array.
    * Returns 1 (treat as over threshold) if usage data is null (conservative).
+   *
+   * Model-scoped limits (e.g. the separate Claude Fable 5 weekly allowance)
+   * only count when the requested `model` matches the limit's scope — a
+   * saturated Fable limit must not block Sonnet/Opus traffic. Unscoped active
+   * limits count for every request.
    */
-  private computeMaxUtilization(usage: AnthropicOAuthUsageResponse | null): number {
+  private computeMaxUtilization(usage: AnthropicOAuthUsageResponse | null, model?: string): number {
     if (!usage) {
       return 1
     }
@@ -212,7 +223,52 @@ export class AccountPoolService {
     // API returns utilization as 0-100, normalize to 0-1 to match token_limit_threshold
     const fiveHour = (usage.five_hour?.utilization ?? 0) / 100
     const sevenDay = (usage.seven_day?.utilization ?? 0) / 100
-    return Math.max(fiveHour, sevenDay)
+    let max = Math.max(fiveHour, sevenDay)
+
+    for (const limit of usage.limits ?? []) {
+      if (!this.limitApplies(limit, model)) {
+        continue
+      }
+      max = Math.max(max, (limit.percent ?? 0) / 100)
+    }
+
+    return max
+  }
+
+  /**
+   * Whether a limit entry applies to a request for the given model.
+   *
+   * - Inactive limits never apply.
+   * - Unscoped (global) limits always apply. These duplicate the legacy
+   *   five_hour/seven_day windows today, so including them is a no-op now and
+   *   a safety net if the legacy fields are ever dropped.
+   * - Model-scoped limits apply only when the requested model matches the
+   *   scope's `model.id` (exact) or `model.display_name` (substring, e.g.
+   *   display_name "Fable" matches "claude-fable-5"). With no model provided
+   *   (non-Messages endpoints), scoped limits are skipped — blocking all
+   *   traffic on a single-model limit would be worse than the upstream 429.
+   */
+  private limitApplies(limit: OAuthLimitEntry, model?: string): boolean {
+    if (!limit.is_active) {
+      return false
+    }
+
+    const scopedModel = limit.scope?.model
+    if (!scopedModel) {
+      return true
+    }
+
+    if (!model) {
+      return false
+    }
+
+    if (scopedModel.id) {
+      return scopedModel.id.toLowerCase() === model.toLowerCase()
+    }
+    if (scopedModel.display_name) {
+      return model.toLowerCase().includes(scopedModel.display_name.toLowerCase())
+    }
+    return false
   }
 
   /**
@@ -221,7 +277,8 @@ export class AccountPoolService {
    */
   private findEarliestReset(
     credentials: AnthropicCredential[],
-    usageMap: Map<string, CachedUsageEntry>
+    usageMap: Map<string, CachedUsageEntry>,
+    model?: string
   ): string | null {
     let earliest: string | null = null
 
@@ -234,6 +291,9 @@ export class AccountPoolService {
       const resetTimes = [
         cached.usage.five_hour?.resets_at,
         cached.usage.seven_day?.resets_at,
+        ...(cached.usage.limits ?? [])
+          .filter(limit => this.limitApplies(limit, model))
+          .map(limit => limit.resets_at),
       ].filter((t): t is string => t !== null && t !== undefined)
 
       for (const resetTime of resetTimes) {


### PR DESCRIPTION
## Summary

Investigated the report that **Claude Fable 5** "has a separate token count" and turned the findings into a feature.

**Finding:** the Messages API `usage` object is *unchanged* for Fable 5 (Anthropic's docs confirm the API is unchanged for Opus/Sonnet/Haiku). What is genuinely separate is:
- **Pricing** — $10/$50 per MTok, 2× Opus 4.8 (cache reads $1/MTok).
- **Fallback billing** — Fable 5's safety classifiers can decline a request; with server-side fallback it is re-served by another model (e.g. Opus 4.8) *inside the same call*. The response `usage.iterations` array records each attempt with its own `model` + token counts, and each is billed at the model that actually ran it; a decline before output is unbilled.

The proxy stored tokens fine but costed everything with a **model-blind, Claude-3-era rate table**, so Fable 5 was mis-priced (~5× low) and fallback tokens were mis-attributed.

## Changes

- **`packages/shared/src/constants/model-pricing.ts`** (new): per-model pricing registry (`getModelPricing`, `calculateRequestCost`) with current rates incl. Fable 5 / Mythos 5, plus **fallback-aware attribution** (`getBilledUsageByModel`, `calculateUsageCost`) that reads `usage.iterations` and drops unbilled pre-output declines.
- **Dashboard**: per-model token/cost breakdown (`analytics-conversation.ts`) and single-request cost (`request-details.ts`) now use the registry — model-aware and fallback-aware. Removed the obsolete hardcoded Claude-3 rate map. `calculateCost` left in place as a generic fallback (per scope).
- **`types/claude.ts`**: optional `iterations` (`ClaudeUsageIteration`) on the response `usage` type.
- **`model-limits.ts`**: Fable 5/Mythos 5, Opus 4.7/4.8, Sonnet 5 added to the 1M context rules.
- **`model-mapping.ts`**: clarifying comment — newer models have no verified legacy ARN-versioned Bedrock IDs and pass through unchanged (no invented IDs).
- **`scripts/aws-bedrock-cost-report.ts`**: added the new models to its standalone pricing table.
- **Docs**: [ADR-035](docs/04-Architecture/ADRs/adr-035-model-pricing-registry-and-fallback-cost-attribution.md), changelog, `monitoring.md` (obsolete cost example → registry), `api-schemas.md` (model regex).

## Testing

- `bun run typecheck` — clean
- `bun test` — 276 pass, 0 fail (incl. new `model-pricing.test.ts`: 40 pricing/limits assertions covering the documented Fable 5 → Opus 4.8 fallback billing example)
- Verified `scripts/aws-bedrock-cost-report.ts --list-pricing` resolves the 5 new models

## Notes

Fable 5 uses the same tokenizer as Opus 4.8, so token *counts* are unchanged vs Opus 4.7/4.8 — only the per-token *price* differs (and, on fallback, which model those tokens bill against). No count-conversion needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up: fix for "429 despite plenty of tokens left"

Investigation of user reports of upstream `429 "This request could exceed your account's rate limit"` while dashboards showed low usage found the root cause (verified against the live `/api/oauth/usage` response):

- Anthropic now returns a structured `limits[]` array including **model-scoped weekly limits** (e.g. `{kind: "weekly_scoped", scope: {model: {display_name: "Fable"}}}`) — confirming Claude Fable 5 has its own separate allowance — and has **nulled the legacy `seven_day_opus`/`seven_day_sonnet` fields**.
- The proxy was blind to `limits[]`: pool selection checked only `five_hour`/`seven_day`, and the dashboard rendered only the legacy window list. An account with a saturated Fable limit looked healthy, stayed sticky, kept receiving Fable traffic → Anthropic rejected predictively.

**Fix (`f09188b`):**
- Typed `limits[]` (`OAuthLimitEntry`/`OAuthLimitScope`) on the shared usage response
- Model-aware account selection: `selectAccount(projectId, model)` — active model-scoped limits gate only matching models (`scope.model.id` exact or `display_name` substring match), so a saturated Fable limit never blocks Sonnet/Opus traffic; sticky accounts re-evaluated per model; model threaded from `ProxyService` → `authenticate`
- Pool-exhausted 429 `estimated_reset` now includes scoped-limit resets
- Dashboard/public token-usage pages render model-scoped limit bars (e.g. "7-Day Fable")
- 8 new account-pool tests (TDD: written failing first); ADR-031 amended; changelog updated
