### PR TITLE
feat: automate OAuth relogin with Gmail

### DIFF
--- a/credentials/README.md
+++ b/credentials/README.md
@@ -7,9 +7,11 @@ credentials/
 ├── accounts/                # Anthropic account credentials
 │   ├── account-primary.credentials.json
 │   └── account-secondary.credentials.json
-└── train-client-keys/       # Proxy client API keys per train
-    ├── train-alpha.client-keys.json
-    └── train-beta.client-keys.json
+├── train-client-keys/       # Proxy client API keys per train
+│   ├── train-alpha.client-keys.json
+│   └── train-beta.client-keys.json
+├── gmail-oauth-client.json  # Optional local Gmail Desktop OAuth client
+└── gmail-oauth-token.json   # Optional local Gmail token (mode 0600)
 ```
 
 ## Account Credential Files
@@ -101,3 +103,4 @@ Neither header is forwarded to Anthropic.
 - Keep production secrets out of version control
 - Rotate Anthropic keys and client tokens regularly
 - Separate credentials per environment (development, staging, production)
+- Prefer a dedicated mailbox for Gmail-assisted relogin; Gmail read-only access is mailbox-wide

--- a/docs/02-User-Guide/authentication.md
+++ b/docs/02-User-Guide/authentication.md
@@ -225,6 +225,64 @@ Each account still requires Anthropic's email verification and authorization app
 automates opening a private browser window and clipboard handoffs, but does not access the user's
 inbox.
 
+##### Gmail-Assisted Relogin
+
+Gmail assistance removes the inbox lookup and terminal copy/paste steps while keeping the final
+Anthropic approval explicit. It is opt-in and runs only on the operator's workstation; the deployed
+proxy and dashboard never receive Gmail access.
+
+One-time setup:
+
+1. Create a Google Cloud project and enable the Gmail API.
+2. Configure the OAuth consent screen for the Gmail account that receives the credential emails.
+3. Create an OAuth client with application type **Desktop app**.
+4. Download the client JSON to `credentials/gmail-oauth-client.json`.
+5. Ensure Google Chrome is installed, or install Playwright Chromium with
+   `bunx playwright install chromium`.
+6. Connect the mailbox:
+
+   ```bash
+   bun run auth:gmail-connect
+   ```
+
+The connection grants `gmail.readonly`. Google does not provide a scope that limits message-body
+access to one label, so a dedicated mailbox that receives only Anthropic authentication messages
+is recommended. The token is stored at `credentials/gmail-oauth-token.json`; both files are ignored
+by Git and must remain owner-readable only.
+
+Run the assisted relogin:
+
+```bash
+# All credentials
+bun run auth:oauth-relogin --gmail
+
+# One credential
+bun run auth:oauth-relogin --gmail --account acc_marketing
+```
+
+For each credential, the script creates a new non-persistent browser context, attempts to submit the
+stored email, waits for a fresh matching message, validates and opens the login link in the same
+context, and waits while you review and click **Authorize**. It reads and exchanges the resulting
+authorization code automatically. If the email field cannot be identified, enter the displayed
+email in the controlled browser; Gmail polling continues in the background.
+
+The Gmail-assisted flow rejects messages that predate the current attempt, do not come from
+`@mail.anthropic.com`, do not identify the expected recipient, or do not contain an HTTPS link on
+an Anthropic-controlled host. Message bodies, login links, and OAuth tokens are never logged.
+
+Optional local configuration:
+
+```bash
+GMAIL_OAUTH_CLIENT_FILE=credentials/gmail-oauth-client.json
+GMAIL_OAUTH_TOKEN_FILE=credentials/gmail-oauth-token.json
+GMAIL_AUTH_POLL_TIMEOUT_MS=180000
+OAUTH_BROWSER_CHANNEL=chrome
+OAUTH_APPROVAL_TIMEOUT_MS=300000
+```
+
+See [ADR-036](../04-Architecture/ADRs/adr-036-gmail-assisted-oauth-relogin.md) for the security
+model and alternatives.
+
 #### Step 2: Create a Train
 
 Create a train via the dashboard API:

--- a/docs/04-Architecture/ADRs/README.md
+++ b/docs/04-Architecture/ADRs/README.md
@@ -67,6 +67,7 @@ What becomes easier or more difficult to do because of this change?
 | [ADR-033](./adr-033-api-key-lifecycle-management.md)                         | API Key Lifecycle Management                       | Accepted   | —          |
 | [ADR-034](./adr-034-project-system-prompt-override.md)                       | Project System Prompt Override                     | Accepted   | 2026-03-19 |
 | [ADR-035](./adr-035-model-pricing-registry-and-fallback-cost-attribution.md) | Model Pricing Registry & Fallback Cost Attribution | Accepted   | 2026-07-05 |
+| [ADR-036](./adr-036-gmail-assisted-oauth-relogin.md)                         | Gmail-Assisted Anthropic OAuth Relogin             | Accepted   | 2026-07-22 |
 
 ## Creating a New ADR
 

--- a/docs/04-Architecture/ADRs/adr-036-gmail-assisted-oauth-relogin.md
+++ b/docs/04-Architecture/ADRs/adr-036-gmail-assisted-oauth-relogin.md
@@ -1,0 +1,114 @@
+# ADR-036: Gmail-Assisted Anthropic OAuth Relogin
+
+## Status
+
+Accepted
+
+## Context
+
+Anthropic OAuth credentials occasionally require interactive reauthorization. The authorization
+flow sends a one-time login link to the account email address before presenting the final consent
+screen. When several credentials need reauthorization, manually finding each message, opening its
+link, and copying the final authorization code is slow and error-prone.
+
+All credential addresses can forward to one Gmail inbox, but login emails contain bearer links and
+must be handled as secrets. The existing manual relogin flow must also remain available when Gmail
+or browser automation is unavailable.
+
+## Decision Drivers
+
+- Minimize repetitive inbox and clipboard work without removing explicit user consent
+- Keep login links and authorization codes out of logs and persistent storage
+- Isolate browser sessions between Anthropic accounts
+- Fail closed when message sender, recipient, age, link host, or OAuth state cannot be validated
+- Preserve the current manual and headless relogin workflow
+
+## Considered Options
+
+1. **Gmail API with a controlled Playwright browser**
+   - Pros: read-only mailbox access, precise time/sender/recipient filtering, isolated browser
+     contexts, deterministic parsing, and automatic final-code capture
+   - Cons: one-time Google Cloud OAuth setup; Gmail read-only permission can read the entire
+     authorized mailbox; browser automation depends on Anthropic's login UI
+
+2. **Gmail IMAP with an app password**
+   - Pros: small implementation and no Google Cloud project
+   - Cons: broad mailbox credentials, Google discourages app passwords, and app passwords are not
+     available for every Google account security configuration
+
+3. **Domain-level inbound email webhook**
+   - Pros: no access to the personal Gmail inbox and strong message isolation
+   - Cons: provider-specific infrastructure, changes to production mail routing, and additional
+     secret delivery/storage concerns
+
+4. **AI-based email interpretation**
+   - Pros: tolerates superficial email template changes
+   - Cons: exposes bearer links to another system, can select the wrong link, costs more, and adds
+     no useful capability over deterministic MIME and URL parsing
+
+## Decision
+
+Add an opt-in Gmail-assisted mode to the local OAuth scripts:
+
+- `auth:gmail-connect` performs a one-time Google OAuth desktop flow using
+  `gmail.readonly` and stores the refresh token under the ignored `credentials/` directory.
+- `auth:oauth-relogin --gmail` launches one fresh Playwright browser context per Anthropic
+  credential.
+- The script enters the stored credential email when the login form can be identified. Manual
+  entry remains available if the page changes.
+- After the email request, the script polls Gmail only for messages newer than the request and
+  validates the sender and intended recipient before examining message content.
+- Only HTTPS links on an allowlist of Anthropic-controlled hosts are eligible. The selected link
+  stays in memory and is opened in the same browser context.
+- The user must review and click the final Anthropic authorization control.
+- The browser reads the resulting `code#state` value. The state must exactly match the PKCE flow
+  before token exchange.
+- `--no-browser` retains the existing fully manual flow; Gmail assistance is never required by the
+  proxy runtime.
+
+No message body, login link, Google token, or Anthropic authorization code may be logged. Gmail
+credentials must not be stored in PostgreSQL or committed to Git.
+
+## Consequences
+
+### Positive
+
+- Relogin normally requires only the explicit approval click for each account.
+- Each account receives a clean browser context, preventing accidental cross-account reuse.
+- Parsing and validation are deterministic and testable without sending email content to AI.
+- The feature is local-only and does not add Gmail access to the deployed proxy or dashboard.
+
+### Negative
+
+- Operators must create a Google OAuth desktop client and authorize Gmail once.
+- `gmail.readonly` is a restricted scope with mailbox-wide read capability; Gmail does not provide
+  a per-label read scope.
+- Anthropic login-page changes may require selector maintenance, although the flow falls back to
+  manual email entry.
+
+### Risks and Mitigations
+
+- **Risk**: A compromised local token can read the authorized inbox.
+  - **Mitigation**: Prefer a dedicated mailbox containing only Anthropic authentication messages,
+    store tokens with owner-only permissions, and make Gmail assistance opt-in.
+- **Risk**: A forged or stale message supplies a malicious link.
+  - **Mitigation**: Require a fresh internal timestamp, expected sender domain, intended recipient,
+    HTTPS, and an Anthropic-controlled hostname.
+- **Risk**: Browser session state leaks between accounts.
+  - **Mitigation**: Create and close a new non-persistent browser context for every credential.
+- **Risk**: UI automation approves unintended access.
+  - **Mitigation**: Never automate the final authorization click.
+
+## Links
+
+- [Authentication Guide](../../02-User-Guide/authentication.md)
+- [ADR-021: End-to-End Testing Strategy](./adr-021-e2e-testing-strategy.md)
+- [Google Gmail API scopes](https://developers.google.com/workspace/gmail/api/auth/scopes)
+- [Google Gmail API message filtering](https://developers.google.com/workspace/gmail/api/guides/filtering)
+- [Anthropic login documentation](https://support.claude.com/en/articles/13189465-log-in-to-your-claude-account)
+- [Google app password guidance](https://support.google.com/accounts/answer/185833)
+
+---
+
+Date: 2026-07-22
+Authors: Codex

--- a/docs/06-Reference/environment-vars.md
+++ b/docs/06-Reference/environment-vars.md
@@ -111,9 +111,17 @@ SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 
 ### OAuth Configuration
 
-| Variable                 | Description                | Default                                |
-| ------------------------ | -------------------------- | -------------------------------------- |
-| `CLAUDE_OAUTH_CLIENT_ID` | OAuth client ID for Claude | `9d1c250a-e61b-44d9-88ed-5944d1962f5e` |
+| Variable                     | Description                                         | Default                                |
+| ---------------------------- | --------------------------------------------------- | -------------------------------------- |
+| `CLAUDE_OAUTH_CLIENT_ID`     | OAuth client ID for Claude                          | `9d1c250a-e61b-44d9-88ed-5944d1962f5e` |
+| `GMAIL_OAUTH_CLIENT_FILE`    | Local Google OAuth Desktop client JSON              | `credentials/gmail-oauth-client.json`  |
+| `GMAIL_OAUTH_TOKEN_FILE`     | Local Gmail refresh/access token file               | `credentials/gmail-oauth-token.json`   |
+| `GMAIL_AUTH_POLL_TIMEOUT_MS` | Maximum wait for each Anthropic login email         | `180000`                               |
+| `OAUTH_BROWSER_CHANNEL`      | Playwright browser channel for Gmail-assisted OAuth | `chrome`                               |
+| `OAUTH_APPROVAL_TIMEOUT_MS`  | Maximum wait for manual Anthropic approval          | `300000`                               |
+
+Gmail configuration is used only by local authentication scripts and is not required by either
+deployed service. See the [Authentication Guide](../02-User-Guide/authentication.md#gmail-assisted-relogin).
 
 ## Directory Configuration
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "auth:oauth-status": "bun run scripts/auth/check-oauth-status.ts",
     "auth:oauth-refresh": "bun run scripts/auth/oauth-refresh-all.ts",
     "auth:oauth-relogin": "bun run scripts/auth/oauth-relogin-all.ts",
+    "auth:gmail-connect": "bun run scripts/auth/gmail-connect.ts",
     "test:generate-fixture": "bun run scripts/generate-conversation-test-fixture.ts",
     "ai:check-jobs": "bun run scripts/check-analysis-jobs.ts",
     "ai:check-content": "bun run scripts/check-analysis-content.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -146,6 +146,28 @@ bun run scripts/auth/oauth-relogin-all.ts --no-browser --no-clipboard
 The browser fallback always prints the authorization URL, so the workflow also works on headless
 hosts.
 
+After completing the one-time Gmail connection described below, add `--gmail` to use a controlled
+browser that finds and opens each fresh Anthropic login email and captures the final authorization
+code. The final Anthropic approval remains manual.
+
+```bash
+bun run auth:oauth-relogin --gmail
+bun run auth:oauth-relogin --gmail --account acc_team_alpha
+```
+
+### gmail-connect.ts
+
+Authorizes local, read-only Gmail access for assisted Anthropic OAuth relogin. Create a Google OAuth
+Desktop app, download its client JSON to `credentials/gmail-oauth-client.json`, then run:
+
+```bash
+bun run auth:gmail-connect
+```
+
+The resulting token is written to `credentials/gmail-oauth-token.json` with owner-only permissions.
+Both paths are ignored by Git. Prefer a dedicated mailbox because Gmail's read-only scope is not
+limited to matching messages or labels.
+
 ### bedrock-login.ts
 
 Adds AWS Bedrock credentials to the database. Interactive CLI that prompts for AWS API key, account details, and region.

--- a/scripts/auth/gmail-auth.test.ts
+++ b/scripts/auth/gmail-auth.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  GMAIL_READONLY_SCOPE,
+  createGoogleAuthorizationRequest,
+  exchangeGoogleAuthorizationCode,
+  extractAnthropicLoginLink,
+  isAllowedAnthropicLink,
+  isExpectedAnthropicSender,
+  isExpectedRecipient,
+  waitForAnthropicLoginLink,
+  type GmailMessage,
+  type GmailMessageReader,
+} from './gmail-auth.ts'
+
+function encodeBody(value: string): string {
+  return Buffer.from(value).toString('base64url')
+}
+
+function message(options: {
+  id?: string
+  receivedAt?: number
+  from?: string
+  to?: string
+  body?: string
+}): GmailMessage {
+  return {
+    id: options.id || 'message-1',
+    internalDate: String(options.receivedAt || 10_000),
+    payload: {
+      mimeType: 'multipart/alternative',
+      headers: [
+        { name: 'From', value: options.from || 'Claude <login@mail.anthropic.com>' },
+        { name: 'To', value: options.to || 'Account <alpha@example.com>' },
+      ],
+      parts: [
+        {
+          mimeType: 'text/html',
+          body: {
+            data: encodeBody(
+              options.body ||
+                '<a href="https://claude.ai/login?token=one-time">Sign in with Claude.ai</a>'
+            ),
+          },
+        },
+      ],
+    },
+  }
+}
+
+describe('Gmail OAuth setup', () => {
+  test('builds a read-only offline Google authorization request with PKCE', () => {
+    const request = createGoogleAuthorizationRequest(
+      { clientId: 'client-id', clientSecret: 'client-secret' },
+      'http://127.0.0.1:12345/oauth2/callback'
+    )
+    const url = new URL(request.url)
+
+    expect(url.origin).toBe('https://accounts.google.com')
+    expect(url.searchParams.get('scope')).toBe(GMAIL_READONLY_SCOPE)
+    expect(url.searchParams.get('access_type')).toBe('offline')
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(url.searchParams.get('state')).toBe(request.state)
+    expect(request.codeVerifier.length).toBeGreaterThan(40)
+  })
+
+  test('exchanges the desktop callback using PKCE and retains the refresh token', async () => {
+    let requestBody = ''
+    const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = String(init?.body || '')
+      return new Response(
+        JSON.stringify({
+          access_token: 'gmail-access-token',
+          refresh_token: 'gmail-refresh-token',
+          expires_in: 3600,
+          scope: GMAIL_READONLY_SCOPE,
+          token_type: 'Bearer',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }) as typeof fetch
+
+    const token = await exchangeGoogleAuthorizationCode(
+      { clientId: 'client-id', clientSecret: 'client-secret' },
+      'authorization-code',
+      'pkce-verifier',
+      'http://127.0.0.1:12345/oauth2/callback',
+      fetchImpl
+    )
+
+    const parameters = new URLSearchParams(requestBody)
+    expect(parameters.get('grant_type')).toBe('authorization_code')
+    expect(parameters.get('code_verifier')).toBe('pkce-verifier')
+    expect(token.refresh_token).toBe('gmail-refresh-token')
+    expect(token.expires_at).toBeGreaterThan(Date.now())
+  })
+})
+
+describe('Anthropic login email validation', () => {
+  test('requires the expected sender and forwarded recipient', () => {
+    const valid = message({})
+    expect(isExpectedAnthropicSender(valid)).toBeTrue()
+    expect(isExpectedRecipient(valid, 'alpha@example.com')).toBeTrue()
+
+    expect(
+      isExpectedAnthropicSender(message({ from: 'Claude <login@anthropic.example>' }))
+    ).toBeFalse()
+    expect(isExpectedRecipient(valid, 'other@example.com')).toBeFalse()
+    expect(
+      isExpectedRecipient(message({ to: 'alpha@example.com.evil.example' }), 'alpha@example.com')
+    ).toBeFalse()
+  })
+
+  test('prefers the sign-in anchor and rejects non-Anthropic hosts', () => {
+    const candidate = message({
+      body: `
+        <a href="https://support.anthropic.com/help">Help</a>
+        <a href="https://claude.ai/login?token=secret&amp;source=email">Sign in with Claude.ai</a>
+        <a href="https://evil.example/login?token=secret">Sign in elsewhere</a>
+      `,
+    })
+
+    expect(extractAnthropicLoginLink(candidate)).toBe(
+      'https://claude.ai/login?token=secret&source=email'
+    )
+    expect(isAllowedAnthropicLink('https://links.mail.anthropic.com/click/abc')).toBeTrue()
+    expect(isAllowedAnthropicLink('http://claude.ai/login')).toBeFalse()
+    expect(isAllowedAnthropicLink('https://claude.ai.evil.example/login')).toBeFalse()
+    expect(
+      extractAnthropicLoginLink(
+        message({ body: '<a href="https://support.anthropic.com/help">Help center</a>' })
+      )
+    ).toBeNull()
+  })
+
+  test('extracts a plain-text tracking link using its sign-in context', () => {
+    expect(
+      extractAnthropicLoginLink(
+        message({
+          body: 'Sign in with Claude.ai: https://links.mail.anthropic.com/c/random-token',
+        })
+      )
+    ).toBe('https://links.mail.anthropic.com/c/random-token')
+  })
+
+  test('polls until a fresh message for the expected account arrives', async () => {
+    let currentTime = 20_000
+    let polls = 0
+    let fullMessageReads = 0
+    const messages = new Map<string, GmailMessage>([
+      ['stale', message({ id: 'stale', receivedAt: 15_000 })],
+      [
+        'wrong-account',
+        message({ id: 'wrong-account', receivedAt: 21_000, to: 'other@example.com' }),
+      ],
+      ['fresh', message({ id: 'fresh', receivedAt: 22_000 })],
+    ])
+    const reader: GmailMessageReader = {
+      listMessages: async query => {
+        expect(query).toContain('from:(mail.anthropic.com)')
+        polls += 1
+        return polls === 1 ? ['stale', 'wrong-account'] : ['fresh']
+      },
+      getMessageMetadata: async id => messages.get(id)!,
+      getMessage: async id => {
+        fullMessageReads += 1
+        return messages.get(id)!
+      },
+    }
+
+    const result = await waitForAnthropicLoginLink(reader, {
+      accountEmail: 'alpha@example.com',
+      requestedAfter: 20_000,
+      timeoutMs: 5_000,
+      pollIntervalMs: 1_000,
+      now: () => currentTime,
+      sleep: async milliseconds => {
+        currentTime += milliseconds
+      },
+    })
+
+    expect(result.messageId).toBe('fresh')
+    expect(result.url).toContain('https://claude.ai/login')
+    expect(polls).toBe(2)
+    expect(fullMessageReads).toBe(1)
+  })
+})

--- a/scripts/auth/gmail-auth.ts
+++ b/scripts/auth/gmail-auth.ts
@@ -1,0 +1,537 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute, resolve } from 'node:path'
+
+export const GMAIL_READONLY_SCOPE = 'https://www.googleapis.com/auth/gmail.readonly'
+export const DEFAULT_GMAIL_CLIENT_FILE = 'credentials/gmail-oauth-client.json'
+export const DEFAULT_GMAIL_TOKEN_FILE = 'credentials/gmail-oauth-token.json'
+export const DEFAULT_GMAIL_POLL_TIMEOUT_MS = 180_000
+
+const GOOGLE_AUTHORIZATION_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const GMAIL_API_URL = 'https://gmail.googleapis.com/gmail/v1/users/me'
+const DEFAULT_POLL_INTERVAL_MS = 2_000
+
+type FetchLike = typeof fetch
+
+export interface GoogleOAuthClient {
+  clientId: string
+  clientSecret: string
+}
+
+interface GoogleOAuthClientFile {
+  installed?: {
+    client_id?: string
+    client_secret?: string
+  }
+}
+
+export interface GmailOAuthToken {
+  access_token: string
+  refresh_token: string
+  expires_at: number
+  scope: string
+  token_type: string
+}
+
+interface GoogleTokenResponse {
+  access_token?: string
+  refresh_token?: string
+  expires_in?: number
+  scope?: string
+  token_type?: string
+  error?: string
+  error_description?: string
+}
+
+export interface GoogleAuthorizationRequest {
+  url: string
+  state: string
+  codeVerifier: string
+}
+
+interface GmailHeader {
+  name?: string
+  value?: string
+}
+
+interface GmailMessagePart {
+  mimeType?: string
+  headers?: GmailHeader[]
+  body?: {
+    data?: string
+  }
+  parts?: GmailMessagePart[]
+}
+
+export interface GmailMessage {
+  id?: string
+  internalDate?: string
+  payload?: GmailMessagePart
+}
+
+interface GmailMessageList {
+  messages?: Array<{ id?: string }>
+}
+
+export interface GmailMessageReader {
+  listMessages(query: string): Promise<string[]>
+  getMessageMetadata(id: string): Promise<GmailMessage>
+  getMessage(id: string): Promise<GmailMessage>
+}
+
+export interface WaitForAnthropicLoginLinkOptions {
+  accountEmail: string
+  requestedAfter: number
+  timeoutMs?: number
+  pollIntervalMs?: number
+  now?: () => number
+  sleep?: (milliseconds: number) => Promise<void>
+}
+
+export interface AnthropicLoginLink {
+  url: string
+  messageId: string
+  receivedAt: number
+}
+
+function resolveLocalPath(path: string): string {
+  return isAbsolute(path) ? path : resolve(process.cwd(), path)
+}
+
+export function getGmailClientFilePath(): string {
+  return resolveLocalPath(process.env.GMAIL_OAUTH_CLIENT_FILE || DEFAULT_GMAIL_CLIENT_FILE)
+}
+
+export function getGmailTokenFilePath(): string {
+  return resolveLocalPath(process.env.GMAIL_OAUTH_TOKEN_FILE || DEFAULT_GMAIL_TOKEN_FILE)
+}
+
+async function readJsonFile(path: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Unable to read OAuth configuration at ${path}: ${message}`)
+  }
+}
+
+export async function loadGoogleOAuthClient(
+  path = getGmailClientFilePath()
+): Promise<GoogleOAuthClient> {
+  const value = (await readJsonFile(path)) as GoogleOAuthClientFile
+  const clientId = value.installed?.client_id?.trim()
+  const clientSecret = value.installed?.client_secret?.trim()
+
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      `Invalid Google OAuth client file at ${path}. Create and download a Desktop app client.`
+    )
+  }
+
+  await chmod(path, 0o600)
+  return { clientId, clientSecret }
+}
+
+export async function loadGmailOAuthToken(
+  path = getGmailTokenFilePath()
+): Promise<GmailOAuthToken> {
+  const value = (await readJsonFile(path)) as Partial<GmailOAuthToken>
+  if (
+    !value.access_token ||
+    !value.refresh_token ||
+    typeof value.expires_at !== 'number' ||
+    !value.scope ||
+    !value.token_type
+  ) {
+    throw new Error(`Invalid Gmail OAuth token file at ${path}. Run bun run auth:gmail-connect.`)
+  }
+
+  await chmod(path, 0o600)
+  return value as GmailOAuthToken
+}
+
+export async function saveGmailOAuthToken(
+  token: GmailOAuthToken,
+  path = getGmailTokenFilePath()
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(token, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+  await chmod(path, 0o600)
+}
+
+function base64UrlEncode(value: Buffer): string {
+  return value.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+export function createGoogleAuthorizationRequest(
+  client: GoogleOAuthClient,
+  redirectUri: string
+): GoogleAuthorizationRequest {
+  const state = base64UrlEncode(randomBytes(24))
+  const codeVerifier = base64UrlEncode(randomBytes(48))
+  const codeChallenge = base64UrlEncode(createHash('sha256').update(codeVerifier).digest())
+  const url = new URL(GOOGLE_AUTHORIZATION_URL)
+
+  url.searchParams.set('client_id', client.clientId)
+  url.searchParams.set('redirect_uri', redirectUri)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', GMAIL_READONLY_SCOPE)
+  url.searchParams.set('access_type', 'offline')
+  url.searchParams.set('prompt', 'consent')
+  url.searchParams.set('state', state)
+  url.searchParams.set('code_challenge', codeChallenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+
+  return { url: url.toString(), state, codeVerifier }
+}
+
+async function readGoogleTokenResponse(response: Response): Promise<GoogleTokenResponse> {
+  const data = (await response.json().catch(() => ({}))) as GoogleTokenResponse
+  if (!response.ok) {
+    const reason = data.error_description || data.error || response.statusText
+    throw new Error(`Google OAuth token request failed (${response.status}): ${reason}`)
+  }
+  return data
+}
+
+export async function exchangeGoogleAuthorizationCode(
+  client: GoogleOAuthClient,
+  code: string,
+  codeVerifier: string,
+  redirectUri: string,
+  fetchImpl: FetchLike = fetch
+): Promise<GmailOAuthToken> {
+  const response = await fetchImpl(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: client.clientId,
+      client_secret: client.clientSecret,
+      code,
+      code_verifier: codeVerifier,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+    }),
+  })
+  const data = await readGoogleTokenResponse(response)
+
+  if (!data.access_token || !data.refresh_token || !data.expires_in) {
+    throw new Error('Google OAuth response did not include access and refresh tokens.')
+  }
+
+  return {
+    access_token: data.access_token,
+    refresh_token: data.refresh_token,
+    expires_at: Date.now() + data.expires_in * 1000,
+    scope: data.scope || GMAIL_READONLY_SCOPE,
+    token_type: data.token_type || 'Bearer',
+  }
+}
+
+async function refreshGmailOAuthToken(
+  client: GoogleOAuthClient,
+  token: GmailOAuthToken,
+  tokenPath: string,
+  fetchImpl: FetchLike
+): Promise<GmailOAuthToken> {
+  const response = await fetchImpl(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: client.clientId,
+      client_secret: client.clientSecret,
+      refresh_token: token.refresh_token,
+      grant_type: 'refresh_token',
+    }),
+  })
+  const data = await readGoogleTokenResponse(response)
+
+  if (!data.access_token || !data.expires_in) {
+    throw new Error('Google OAuth refresh response did not include an access token.')
+  }
+
+  const refreshed: GmailOAuthToken = {
+    access_token: data.access_token,
+    refresh_token: token.refresh_token,
+    expires_at: Date.now() + data.expires_in * 1000,
+    scope: data.scope || token.scope,
+    token_type: data.token_type || token.token_type,
+  }
+  await saveGmailOAuthToken(refreshed, tokenPath)
+  return refreshed
+}
+
+export class GmailClient implements GmailMessageReader {
+  private token: GmailOAuthToken
+
+  constructor(
+    private readonly oauthClient: GoogleOAuthClient,
+    token: GmailOAuthToken,
+    private readonly tokenPath = getGmailTokenFilePath(),
+    private readonly fetchImpl: FetchLike = fetch
+  ) {
+    this.token = token
+  }
+
+  private async accessToken(forceRefresh = false): Promise<string> {
+    if (forceRefresh || this.token.expires_at <= Date.now() + 60_000) {
+      this.token = await refreshGmailOAuthToken(
+        this.oauthClient,
+        this.token,
+        this.tokenPath,
+        this.fetchImpl
+      )
+    }
+    return this.token.access_token
+  }
+
+  private async request<T>(path: string): Promise<T> {
+    const execute = async (forceRefresh: boolean): Promise<Response> =>
+      this.fetchImpl(`${GMAIL_API_URL}${path}`, {
+        headers: { Authorization: `Bearer ${await this.accessToken(forceRefresh)}` },
+      })
+
+    let response = await execute(false)
+    if (response.status === 401) {
+      response = await execute(true)
+    }
+    if (!response.ok) {
+      throw new Error(`Gmail API request failed (${response.status} ${response.statusText}).`)
+    }
+    return (await response.json()) as T
+  }
+
+  async listMessages(query: string): Promise<string[]> {
+    const parameters = new URLSearchParams({ q: query, maxResults: '10' })
+    const data = await this.request<GmailMessageList>(`/messages?${parameters}`)
+    return (data.messages || []).flatMap(message => (message.id ? [message.id] : []))
+  }
+
+  getMessageMetadata(id: string): Promise<GmailMessage> {
+    const parameters = new URLSearchParams({ format: 'metadata' })
+    for (const header of [
+      'From',
+      'To',
+      'Delivered-To',
+      'X-Original-To',
+      'Envelope-To',
+      'X-Forwarded-To',
+    ]) {
+      parameters.append('metadataHeaders', header)
+    }
+    return this.request<GmailMessage>(
+      `/messages/${encodeURIComponent(id)}?${parameters.toString()}`
+    )
+  }
+
+  getMessage(id: string): Promise<GmailMessage> {
+    return this.request<GmailMessage>(`/messages/${encodeURIComponent(id)}?format=full`)
+  }
+}
+
+export async function createGmailClient(): Promise<GmailClient> {
+  const [client, token] = await Promise.all([loadGoogleOAuthClient(), loadGmailOAuthToken()])
+  return new GmailClient(client, token)
+}
+
+function getHeader(message: GmailMessage, name: string): string {
+  const header = message.payload?.headers?.find(
+    candidate => candidate.name?.toLowerCase() === name.toLowerCase()
+  )
+  return header?.value || ''
+}
+
+function extractEmailAddress(value: string): string | null {
+  return extractEmailAddresses(value)[0] || null
+}
+
+function extractEmailAddresses(value: string): string[] {
+  return Array.from(value.matchAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi), match =>
+    match[0].toLowerCase()
+  )
+}
+
+export function isExpectedAnthropicSender(message: GmailMessage): boolean {
+  const sender = extractEmailAddress(getHeader(message, 'From'))
+  return sender?.endsWith('@mail.anthropic.com') ?? false
+}
+
+export function isExpectedRecipient(message: GmailMessage, accountEmail: string): boolean {
+  const expected = accountEmail.trim().toLowerCase()
+  if (!expected) {
+    return false
+  }
+
+  const recipientHeaders = ['To', 'Delivered-To', 'X-Original-To', 'Envelope-To', 'X-Forwarded-To']
+  return recipientHeaders.some(name =>
+    extractEmailAddresses(getHeader(message, name)).includes(expected)
+  )
+}
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  return Buffer.from(normalized, 'base64').toString('utf8')
+}
+
+function decodeQuotedPrintable(value: string): string {
+  return value
+    .replace(/=\r?\n/g, '')
+    .replace(/=([0-9A-F]{2})/gi, (_match, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16))
+    )
+}
+
+function collectMessageBodies(part: GmailMessagePart | undefined, result: string[]): void {
+  if (!part) {
+    return
+  }
+  if (part.body?.data && (!part.mimeType || part.mimeType.startsWith('text/'))) {
+    result.push(decodeQuotedPrintable(decodeBase64Url(part.body.data)))
+  }
+  for (const child of part.parts || []) {
+    collectMessageBodies(child, result)
+  }
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#(?:39|x27);/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_match, hex: string) =>
+      String.fromCodePoint(Number.parseInt(hex, 16))
+    )
+    .replace(/&#([0-9]+);/g, (_match, decimal: string) =>
+      String.fromCodePoint(Number.parseInt(decimal, 10))
+    )
+}
+
+export function isAllowedAnthropicLink(value: string): boolean {
+  try {
+    const url = new URL(decodeHtmlEntities(value))
+    if (url.protocol !== 'https:') {
+      return false
+    }
+    const hostname = url.hostname.toLowerCase()
+    return (
+      hostname === 'claude.ai' ||
+      hostname.endsWith('.claude.ai') ||
+      hostname === 'anthropic.com' ||
+      hostname.endsWith('.anthropic.com')
+    )
+  } catch {
+    return false
+  }
+}
+
+interface LinkCandidate {
+  url: string
+  context: string
+  order: number
+}
+
+function collectLinkCandidates(body: string): LinkCandidate[] {
+  const candidates: LinkCandidate[] = []
+  const anchorPattern = /<a\b[^>]*href\s*=\s*(["'])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi
+  let anchor: RegExpExecArray | null
+
+  while ((anchor = anchorPattern.exec(body))) {
+    candidates.push({
+      url: decodeHtmlEntities(anchor[2] || ''),
+      context: (anchor[3] || '').replace(/<[^>]+>/g, ' '),
+      order: candidates.length,
+    })
+  }
+
+  const rawUrlPattern = /https:\/\/[^\s<>"']+/gi
+  for (const match of body.matchAll(rawUrlPattern)) {
+    const url = decodeHtmlEntities(match[0]).replace(/[),.;]+$/, '')
+    if (!candidates.some(candidate => candidate.url === url)) {
+      const matchIndex = match.index || 0
+      const lineStart = body.lastIndexOf('\n', matchIndex - 1) + 1
+      const nextLineBreak = body.indexOf('\n', matchIndex + match[0].length)
+      const lineEnd = nextLineBreak === -1 ? body.length : nextLineBreak
+      candidates.push({
+        url,
+        context: body.slice(lineStart, lineEnd).replace(/<[^>]+>/g, ' '),
+        order: candidates.length,
+      })
+    }
+  }
+  return candidates
+}
+
+function scoreLink(candidate: LinkCandidate): number {
+  const searchable = `${candidate.context} ${candidate.url}`.toLowerCase()
+  let score = 0
+  if (/sign\s*in|log\s*in|continue|verify/.test(candidate.context.toLowerCase())) {
+    score += 100
+  }
+  if (/login|signin|verify|magic|auth/.test(candidate.url.toLowerCase())) {
+    score += 25
+  }
+  if (/unsubscribe|privacy|terms|support|help/.test(searchable)) {
+    score -= 100
+  }
+  return score
+}
+
+export function extractAnthropicLoginLink(message: GmailMessage): string | null {
+  const bodies: string[] = []
+  collectMessageBodies(message.payload, bodies)
+  const candidates = bodies
+    .flatMap(collectLinkCandidates)
+    .filter(candidate => isAllowedAnthropicLink(candidate.url))
+    .filter(candidate => scoreLink(candidate) > 0)
+    .sort((left, right) => scoreLink(right) - scoreLink(left) || left.order - right.order)
+  return candidates[0]?.url || null
+}
+
+export async function waitForAnthropicLoginLink(
+  reader: GmailMessageReader,
+  options: WaitForAnthropicLoginLinkOptions
+): Promise<AnthropicLoginLink> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_GMAIL_POLL_TIMEOUT_MS
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const now = options.now ?? Date.now
+  const sleep = options.sleep ?? (milliseconds => Bun.sleep(milliseconds))
+  const deadline = now() + timeoutMs
+  const queryStart = Math.floor((options.requestedAfter - 1_000) / 1_000)
+  const query = `from:(mail.anthropic.com) after:${queryStart}`
+  const inspectedMessageIds = new Set<string>()
+
+  do {
+    const ids = await reader.listMessages(query)
+    for (const id of ids) {
+      if (inspectedMessageIds.has(id)) {
+        continue
+      }
+      inspectedMessageIds.add(id)
+      const metadata = await reader.getMessageMetadata(id)
+      const receivedAt = Number(metadata.internalDate || 0)
+      if (!Number.isFinite(receivedAt) || receivedAt < options.requestedAfter - 1_000) {
+        continue
+      }
+      if (
+        !isExpectedAnthropicSender(metadata) ||
+        !isExpectedRecipient(metadata, options.accountEmail)
+      ) {
+        continue
+      }
+      const message = await reader.getMessage(id)
+      const url = extractAnthropicLoginLink(message)
+      if (url) {
+        return { url, messageId: message.id || id, receivedAt }
+      }
+    }
+
+    if (now() < deadline) {
+      await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - now())))
+    }
+  } while (now() < deadline)
+
+  throw new Error(
+    `Timed out waiting for a fresh Anthropic login email addressed to ${options.accountEmail}.`
+  )
+}

--- a/scripts/auth/gmail-connect.test.ts
+++ b/scripts/auth/gmail-connect.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test'
+import { startGoogleOAuthCallbackServer } from './gmail-connect.ts'
+
+test('local Google OAuth callback captures code and state without displaying them', async () => {
+  const server = await startGoogleOAuthCallbackServer(5_000)
+
+  try {
+    const response = await fetch(`${server.redirectUri}?code=authorization-code&state=oauth-state`)
+    expect(response.status).toBe(200)
+    expect(await response.text()).not.toContain('authorization-code')
+    expect(await server.result).toEqual({
+      code: 'authorization-code',
+      state: 'oauth-state',
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/scripts/auth/gmail-connect.ts
+++ b/scripts/auth/gmail-connect.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import {
+  createGoogleAuthorizationRequest,
+  exchangeGoogleAuthorizationCode,
+  getGmailTokenFilePath,
+  loadGoogleOAuthClient,
+  saveGmailOAuthToken,
+} from './gmail-auth.ts'
+import { openSystemBrowser } from './oauth-browser.ts'
+
+const CALLBACK_PATH = '/oauth2/callback'
+const CALLBACK_TIMEOUT_MS = 300_000
+
+interface GoogleOAuthCallback {
+  code: string
+  state: string
+}
+
+export interface GoogleOAuthCallbackServer {
+  redirectUri: string
+  result: Promise<GoogleOAuthCallback>
+  close(): Promise<void>
+}
+
+export async function startGoogleOAuthCallbackServer(
+  timeoutMs = CALLBACK_TIMEOUT_MS
+): Promise<GoogleOAuthCallbackServer> {
+  let resolveResult: (result: GoogleOAuthCallback) => void
+  let rejectResult: (error: Error) => void
+  let settled = false
+
+  const result = new Promise<GoogleOAuthCallback>((resolve, reject) => {
+    resolveResult = resolve
+    rejectResult = reject
+  })
+
+  const server: Server = createServer((request, response) => {
+    const requestUrl = new URL(request.url || '/', 'http://127.0.0.1')
+    if (requestUrl.pathname !== CALLBACK_PATH) {
+      response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+      response.end('Not found')
+      return
+    }
+
+    const error = requestUrl.searchParams.get('error')
+    const code = requestUrl.searchParams.get('code')
+    const state = requestUrl.searchParams.get('state')
+
+    if (error || !code || !state) {
+      response.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' })
+      response.end('Gmail authorization failed. Return to the terminal for details.')
+      if (!settled) {
+        settled = true
+        rejectResult(
+          new Error(`Google OAuth authorization failed: ${error || 'missing callback data'}`)
+        )
+      }
+      return
+    }
+
+    response.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' })
+    response.end('Gmail connected. You can close this tab and return to the terminal.')
+    if (!settled) {
+      settled = true
+      resolveResult({ code, state })
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  const address = server.address() as AddressInfo
+  const timeout = setTimeout(() => {
+    if (!settled) {
+      settled = true
+      rejectResult(new Error('Timed out waiting for Google OAuth authorization.'))
+    }
+  }, timeoutMs)
+  timeout.unref()
+
+  return {
+    redirectUri: `http://127.0.0.1:${address.port}${CALLBACK_PATH}`,
+    result,
+    close: async () => {
+      clearTimeout(timeout)
+      if (!server.listening) {
+        return
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close(error => (error ? reject(error) : resolve()))
+      })
+    },
+  }
+}
+
+export async function connectGmail(): Promise<number> {
+  let callbackServer: GoogleOAuthCallbackServer | null = null
+
+  try {
+    const client = await loadGoogleOAuthClient()
+    callbackServer = await startGoogleOAuthCallbackServer()
+    const authorization = createGoogleAuthorizationRequest(client, callbackServer.redirectUri)
+    const opened = await openSystemBrowser(authorization.url)
+
+    console.log('Gmail read-only authorization')
+    console.log('=============================\n')
+    console.log(
+      opened
+        ? 'Opened Google authorization in your browser.'
+        : 'Browser launch unavailable. Open this URL manually:'
+    )
+    if (!opened) {
+      console.log(authorization.url)
+    }
+    console.log('\nApprove read-only Gmail access. Waiting for the local callback...')
+
+    const callback = await callbackServer.result
+    if (callback.state !== authorization.state) {
+      throw new Error('Google OAuth state mismatch. Authorization was not saved.')
+    }
+
+    const token = await exchangeGoogleAuthorizationCode(
+      client,
+      callback.code,
+      authorization.codeVerifier,
+      callbackServer.redirectUri
+    )
+    await saveGmailOAuthToken(token)
+
+    console.log(`\nGmail connected. Token saved securely at ${getGmailTokenFilePath()}.`)
+    console.log('Run bun run auth:oauth-relogin --gmail to use assisted relogin.')
+    return 0
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    return 1
+  } finally {
+    await callbackServer?.close()
+  }
+}
+
+if (import.meta.main) {
+  if (process.argv.slice(2).some(argument => argument === '--help' || argument === '-h')) {
+    console.log('Usage: bun run auth:gmail-connect')
+  } else {
+    process.exitCode = await connectGmail()
+  }
+}

--- a/scripts/auth/oauth-browser.test.ts
+++ b/scripts/auth/oauth-browser.test.ts
@@ -3,6 +3,7 @@ import {
   resolveClipboardReadCommand,
   resolveClipboardWriteCommand,
   resolvePrivateBrowserCommand,
+  resolveSystemBrowserCommand,
   validateAuthorizationCode,
 } from './oauth-browser.ts'
 
@@ -42,6 +43,19 @@ describe('OAuth browser assistance', () => {
     ).toBeNull()
   })
 
+  test('uses the platform URL opener for normal browser sessions', () => {
+    expect(
+      resolveSystemBrowserCommand(
+        'https://accounts.google.com/o/oauth2/v2/auth',
+        'linux',
+        fakeWhich({ 'xdg-open': '/usr/bin/xdg-open' })
+      )
+    ).toEqual({
+      executable: '/usr/bin/xdg-open',
+      args: ['https://accounts.google.com/o/oauth2/v2/auth'],
+    })
+  })
+
   test('selects supported clipboard commands', () => {
     const write = resolveClipboardWriteCommand('linux', fakeWhich({ xclip: '/usr/bin/xclip' }))
     const read = resolveClipboardReadCommand('linux', fakeWhich({ xclip: '/usr/bin/xclip' }))
@@ -63,6 +77,9 @@ describe('OAuth browser assistance', () => {
     )
     expect(() => validateAuthorizationCode('code#state#extra')).toThrow(
       'Expected the complete code#state value'
+    )
+    expect(() => validateAuthorizationCode('code#other-state', 'expected-state')).toThrow(
+      'code belongs to a different OAuth flow'
     )
   })
 })

--- a/scripts/auth/oauth-browser.ts
+++ b/scripts/auth/oauth-browser.ts
@@ -51,6 +51,30 @@ export function resolvePrivateBrowserCommand(
   return executable ? { executable, args: ['--incognito', '--new-window', url] } : null
 }
 
+export function resolveSystemBrowserCommand(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+  which: Which = command => Bun.which(command)
+): CommandSpec | null {
+  const candidates: Array<{ command: string; args: string[] }> =
+    platform === 'darwin'
+      ? [{ command: 'open', args: [url] }]
+      : platform === 'win32'
+        ? [{ command: 'rundll32.exe', args: ['url.dll,FileProtocolHandler', url] }]
+        : [
+            { command: 'xdg-open', args: [url] },
+            { command: 'gio', args: ['open', url] },
+          ]
+
+  for (const candidate of candidates) {
+    const executable = which(candidate.command)
+    if (executable) {
+      return { executable, args: candidate.args }
+    }
+  }
+  return null
+}
+
 export function resolveClipboardWriteCommand(
   platform: NodeJS.Platform = process.platform,
   which: Which = command => Bun.which(command)
@@ -127,6 +151,29 @@ export async function openPrivateBrowser(url: string): Promise<boolean> {
   }
 }
 
+export async function openSystemBrowser(url: string): Promise<boolean> {
+  if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    return false
+  }
+
+  const command = resolveSystemBrowserCommand(url)
+  if (!command) {
+    return false
+  }
+
+  try {
+    const subprocess = Bun.spawn([command.executable, ...command.args], {
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+    subprocess.unref()
+    return true
+  } catch {
+    return false
+  }
+}
+
 export async function copyTextToClipboard(text: string): Promise<boolean> {
   const command = resolveClipboardWriteCommand()
   if (!command) {
@@ -169,11 +216,14 @@ export function readTextFromClipboard(): string | null {
   }
 }
 
-export function validateAuthorizationCode(value: string): string {
+export function validateAuthorizationCode(value: string, expectedState?: string): string {
   const code = value.trim()
   const [authorizationCode, state, ...extra] = code.split('#')
   if (!authorizationCode || !state || extra.length > 0) {
     throw new Error('Invalid authorization code format. Expected the complete code#state value.')
+  }
+  if (expectedState && state !== expectedState) {
+    throw new Error('Invalid authorization code state. The code belongs to a different OAuth flow.')
   }
   return code
 }

--- a/scripts/auth/oauth-cli.test.ts
+++ b/scripts/auth/oauth-cli.test.ts
@@ -28,6 +28,7 @@ describe('OAuth CLI options', () => {
     expect(parseOAuthLoginOptions(['--no-browser', '--no-clipboard'])).toEqual({
       openBrowser: false,
       useClipboard: false,
+      gmailAssisted: false,
       help: false,
     })
   })
@@ -37,8 +38,22 @@ describe('OAuth CLI options', () => {
       accountId: 'acc_team_alpha',
       openBrowser: false,
       useClipboard: true,
+      gmailAssisted: false,
       help: false,
     })
+  })
+
+  test('enables Gmail assistance and rejects incompatible browser options', () => {
+    expect(parseReloginOptions(['--gmail', '--account=acc_team_alpha'])).toEqual({
+      accountId: 'acc_team_alpha',
+      openBrowser: true,
+      useClipboard: true,
+      gmailAssisted: true,
+      help: false,
+    })
+    expect(() => parseReloginOptions(['--gmail', '--no-browser'])).toThrow(
+      '--gmail cannot be combined with --no-browser'
+    )
   })
 
   test('rejects missing or unknown options', () => {

--- a/scripts/auth/oauth-controlled-browser.test.ts
+++ b/scripts/auth/oauth-controlled-browser.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { extractAuthorizationCode } from './oauth-controlled-browser.ts'
+
+describe('controlled OAuth browser code extraction', () => {
+  test('extracts the exact code and expected state from page text', () => {
+    expect(
+      extractAuthorizationCode(
+        ['Authorization complete\ncopy-this-code#expected-state\nYou may close this page.'],
+        'expected-state'
+      )
+    ).toBe('copy-this-code#expected-state')
+  })
+
+  test('extracts code and state from callback URL parameters', () => {
+    expect(
+      extractAuthorizationCode(
+        ['https://console.anthropic.com/oauth/code/callback?code=callback-code&state=expected'],
+        'expected'
+      )
+    ).toBe('callback-code#expected')
+  })
+
+  test('rejects codes from a different OAuth flow', () => {
+    expect(extractAuthorizationCode(['secret-code#wrong-state'], 'expected-state')).toBeNull()
+    expect(
+      extractAuthorizationCode(
+        ['https://console.anthropic.com/oauth/code/callback?code=secret&state=wrong'],
+        'expected'
+      )
+    ).toBeNull()
+  })
+})

--- a/scripts/auth/oauth-controlled-browser.ts
+++ b/scripts/auth/oauth-controlled-browser.ts
@@ -1,0 +1,162 @@
+import { chromium, type Browser, type BrowserContext, type Page } from 'playwright'
+
+const DEFAULT_APPROVAL_TIMEOUT_MS = 300_000
+const EMAIL_FIELD_TIMEOUT_MS = 20_000
+
+export interface ControlledOAuthBrowser {
+  openAuthorization(url: string): Promise<void>
+  submitAccountEmail(accountEmail: string): Promise<boolean>
+  openLoginLink(url: string): Promise<void>
+  waitForAuthorizationCode(expectedState: string, timeoutMs?: number): Promise<string>
+  close(): Promise<void>
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function authorizationCodeFromUrl(value: string, expectedState: string): string | null {
+  try {
+    const url = new URL(value)
+    const queryCode = url.searchParams.get('code')
+    const queryState = url.searchParams.get('state')
+    if (queryCode && queryState === expectedState) {
+      return `${queryCode}#${queryState}`
+    }
+
+    const fragment = new URLSearchParams(url.hash.replace(/^#/, ''))
+    const fragmentCode = fragment.get('code')
+    const fragmentState = fragment.get('state')
+    if (fragmentCode && fragmentState === expectedState) {
+      return `${fragmentCode}#${fragmentState}`
+    }
+  } catch {
+    // Most candidates are page text rather than URLs.
+  }
+  return null
+}
+
+export function extractAuthorizationCode(
+  candidates: string[],
+  expectedState: string
+): string | null {
+  const escapedState = escapeRegExp(expectedState)
+  const codePattern = new RegExp(`([^\\s#"'<>]+)#${escapedState}(?=$|[\\s"'<>])`)
+
+  for (const candidate of candidates) {
+    const fromUrl = authorizationCodeFromUrl(candidate, expectedState)
+    if (fromUrl) {
+      return fromUrl
+    }
+
+    const match = candidate.match(codePattern)
+    if (match?.[1]) {
+      return `${match[1]}#${expectedState}`
+    }
+  }
+  return null
+}
+
+class PlaywrightOAuthBrowser implements ControlledOAuthBrowser {
+  constructor(
+    private readonly browser: Browser,
+    private readonly context: BrowserContext,
+    private readonly page: Page
+  ) {}
+
+  async openAuthorization(url: string): Promise<void> {
+    await this.page.goto(url, { waitUntil: 'domcontentloaded' })
+  }
+
+  async submitAccountEmail(accountEmail: string): Promise<boolean> {
+    const emailInput = this.page
+      .locator(
+        'input[type="email"], input[name="email"], input[autocomplete="email"], input[id*="email" i]'
+      )
+      .first()
+
+    try {
+      await emailInput.waitFor({ state: 'visible', timeout: EMAIL_FIELD_TIMEOUT_MS })
+      await emailInput.fill(accountEmail)
+      await emailInput.press('Enter')
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async openLoginLink(url: string): Promise<void> {
+    await this.page.goto(url, { waitUntil: 'domcontentloaded' })
+  }
+
+  async waitForAuthorizationCode(
+    expectedState: string,
+    timeoutMs = Number(process.env.OAUTH_APPROVAL_TIMEOUT_MS) || DEFAULT_APPROVAL_TIMEOUT_MS
+  ): Promise<string> {
+    const deadline = Date.now() + timeoutMs
+
+    while (Date.now() < deadline) {
+      if (this.page.isClosed()) {
+        throw new Error('The OAuth browser was closed before authorization completed.')
+      }
+
+      const pageText = await this.page
+        .locator('body')
+        .innerText({ timeout: 1_000 })
+        .catch(() => '')
+      const fieldValues = await this.page
+        .locator('input, textarea, code, pre')
+        .evaluateAll(elements =>
+          elements.map(element => {
+            if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+              return element.value
+            }
+            return element.textContent || ''
+          })
+        )
+        .catch(() => [] as string[])
+      const code = extractAuthorizationCode(
+        [this.page.url(), pageText, ...fieldValues],
+        expectedState
+      )
+      if (code) {
+        return code
+      }
+
+      await this.page.waitForTimeout(500)
+    }
+
+    throw new Error('Timed out waiting for Anthropic authorization approval.')
+  }
+
+  async close(): Promise<void> {
+    await this.context.close().catch(() => undefined)
+    await this.browser.close().catch(() => undefined)
+  }
+}
+
+export async function launchControlledOAuthBrowser(): Promise<ControlledOAuthBrowser> {
+  const configuredChannel = (process.env.OAUTH_BROWSER_CHANNEL || 'chrome').trim()
+  let browser: Browser
+
+  try {
+    browser = await chromium.launch({
+      headless: false,
+      channel: configuredChannel || undefined,
+    })
+  } catch (error) {
+    if (!configuredChannel) {
+      throw error
+    }
+    browser = await chromium.launch({ headless: false })
+  }
+
+  try {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    return new PlaywrightOAuthBrowser(browser, context, page)
+  } catch (error) {
+    await browser.close().catch(() => undefined)
+    throw error
+  }
+}

--- a/scripts/auth/oauth-login.ts
+++ b/scripts/auth/oauth-login.ts
@@ -26,6 +26,7 @@ const OAUTH_CONFIG = {
 export interface OAuthFlowOptions {
   openBrowser: boolean
   useClipboard: boolean
+  gmailAssisted: boolean
 }
 
 export interface OAuthLoginCliOptions extends OAuthFlowOptions {
@@ -36,6 +37,7 @@ export function parseOAuthLoginOptions(args: string[]): OAuthLoginCliOptions {
   const options: OAuthLoginCliOptions = {
     openBrowser: true,
     useClipboard: true,
+    gmailAssisted: false,
     help: false,
   }
 
@@ -44,6 +46,8 @@ export function parseOAuthLoginOptions(args: string[]): OAuthLoginCliOptions {
       options.openBrowser = false
     } else if (arg === '--no-clipboard') {
       options.useClipboard = false
+    } else if (arg === '--gmail') {
+      options.gmailAssisted = true
     } else if (arg === '--help' || arg === '-h') {
       options.help = true
     } else {
@@ -108,7 +112,7 @@ export async function exchangeCodeForTokens(
   scopes: string[]
   isMax: boolean
 }> {
-  const [code, state] = validateAuthorizationCode(codeWithState).split('#')
+  const [code, state] = validateAuthorizationCode(codeWithState, codeVerifier).split('#')
 
   const response = await fetch(OAUTH_CONFIG.tokenUrl, {
     method: 'POST',
@@ -147,6 +151,53 @@ export async function authorizeOAuthCredential(
   options: OAuthFlowOptions
 ): ReturnType<typeof exchangeCodeForTokens> {
   const { url, verifier } = generateAuthorizationUrl()
+
+  if (options.gmailAssisted) {
+    if (!accountEmail) {
+      throw new Error('Gmail-assisted relogin requires a stored credential email.')
+    }
+    if (!options.openBrowser) {
+      throw new Error('Gmail-assisted relogin requires the controlled browser.')
+    }
+
+    const [{ createGmailClient, waitForAnthropicLoginLink }, { launchControlledOAuthBrowser }] =
+      await Promise.all([import('./gmail-auth.ts'), import('./oauth-controlled-browser.ts')])
+    const gmail = await createGmailClient()
+    const browser = await launchControlledOAuthBrowser()
+
+    try {
+      console.log(`\nOpening an isolated browser for ${accountEmail}.`)
+      await browser.openAuthorization(url)
+
+      const requestedAfter = Date.now()
+      const emailSubmitted = await browser.submitAccountEmail(accountEmail)
+      if (emailSubmitted) {
+        console.log('Submitted the stored credential email. Waiting for Gmail...')
+      } else {
+        console.log(`Enter ${accountEmail} in the controlled browser and request the login email.`)
+        console.log('Waiting for Gmail while you complete that step...')
+      }
+
+      const configuredTimeout = Number(process.env.GMAIL_AUTH_POLL_TIMEOUT_MS)
+      const loginLink = await waitForAnthropicLoginLink(gmail, {
+        accountEmail,
+        requestedAfter,
+        timeoutMs:
+          Number.isFinite(configuredTimeout) && configuredTimeout > 0
+            ? configuredTimeout
+            : undefined,
+      })
+
+      console.log('Received and validated a fresh Anthropic login email.')
+      await browser.openLoginLink(loginLink.url)
+      console.log('Review the Anthropic request and click Authorize in the browser.')
+      const authorizationCode = await browser.waitForAuthorizationCode(verifier)
+      console.log('Authorization approved. Exchanging the code...')
+      return exchangeCodeForTokens(authorizationCode, verifier)
+    } finally {
+      await browser.close()
+    }
+  }
 
   if (accountEmail) {
     console.log(`\nSign in with: ${accountEmail}`)
@@ -264,7 +315,9 @@ if (import.meta.main) {
   try {
     const options = parseOAuthLoginOptions(process.argv.slice(2))
     if (options.help) {
-      console.log('Usage: bun run scripts/auth/oauth-login.ts [--no-browser] [--no-clipboard]')
+      console.log(
+        'Usage: bun run scripts/auth/oauth-login.ts [--gmail] [--no-browser] [--no-clipboard]'
+      )
     } else {
       await performOAuthLogin(options)
     }

--- a/scripts/auth/oauth-relogin-all.ts
+++ b/scripts/auth/oauth-relogin-all.ts
@@ -21,6 +21,7 @@ export function parseReloginOptions(args: string[]): ReloginCliOptions {
   const options: ReloginCliOptions = {
     openBrowser: true,
     useClipboard: true,
+    gmailAssisted: false,
     help: false,
   }
 
@@ -42,11 +43,17 @@ export function parseReloginOptions(args: string[]): ReloginCliOptions {
       options.openBrowser = false
     } else if (arg === '--no-clipboard') {
       options.useClipboard = false
+    } else if (arg === '--gmail') {
+      options.gmailAssisted = true
     } else if (arg === '--help' || arg === '-h') {
       options.help = true
     } else {
       throw new Error(`Unknown option: ${arg}`)
     }
+  }
+
+  if (options.gmailAssisted && !options.openBrowser) {
+    throw new Error('--gmail cannot be combined with --no-browser')
   }
 
   return options
@@ -164,7 +171,7 @@ if (import.meta.main) {
     const options = parseReloginOptions(process.argv.slice(2))
     if (options.help) {
       console.log(
-        'Usage: bun run scripts/auth/oauth-relogin-all.ts [--account <id>] [--no-browser] [--no-clipboard]'
+        'Usage: bun run scripts/auth/oauth-relogin-all.ts [--gmail] [--account <id>] [--no-browser] [--no-clipboard]'
       )
     } else {
       process.exitCode = await reloginAllOAuthCredentials(options)


### PR DESCRIPTION
## Summary

- add a one-time `auth:gmail-connect` desktop OAuth flow using `gmail.readonly`
- add opt-in `auth:oauth-relogin --gmail` support with one isolated Playwright context per credential
- auto-submit stored account emails, poll for fresh matching Anthropic mail, validate trusted links, and capture the final `code#state`
- keep the final Anthropic approval manual and retain the existing manual/headless fallback
- document setup, mailbox-wide scope implications, and the security decision in ADR-036

## Security

- store Google client/token files only under the ignored `credentials/` directory with owner-only permissions
- fetch message metadata first and read the body only after sender, recipient, and freshness checks pass
- allow only HTTPS links on Anthropic-controlled hosts
- never log message bodies, magic links, Google tokens, or Anthropic authorization codes
- require the returned OAuth state to match the active PKCE flow

## Testing

- `bun run typecheck`
- strict standalone TypeScript check for all auth scripts and tests
- `bun run build`
- `bun run lint`
- `bun run test:ci` (400 unit tests and 16 integration tests)
- focused auth suite (23 tests)
- Prettier and `git diff --check`

## Operator validation

A live Gmail/Anthropic round trip requires a local Google OAuth Desktop client. After placing it at `credentials/gmail-oauth-client.json`, run `bun run auth:gmail-connect`, then `bun run auth:oauth-relogin --gmail --account <id>`.

See `docs/04-Architecture/ADRs/adr-036-gmail-assisted-oauth-relogin.md` for the decision and threat model.