### PR TITLE
feat(proxy): raise account pool threshold default from 80% to 95%

### DIFF
--- a/docs/02-User-Guide/authentication.md
+++ b/docs/02-User-Guide/authentication.md
@@ -402,7 +402,7 @@ When a project has **2 or more linked accounts**, the proxy automatically enable
 
 ### Per-Account Threshold
 
-Each account has a `token_limit_threshold` (default: 80%) that controls when switching occurs. The threshold is stored in the `credentials` table and can be configured per account.
+Each account has a `token_limit_threshold` (default: 95%) that controls when switching occurs. The threshold is stored in the `credentials` table and can be configured per account.
 
 When either the 5-hour or 7-day utilization exceeds this threshold, the account is considered over-limit and the pool selects an alternative.
 

--- a/docs/04-Architecture/ADRs/adr-031-account-pool-auto-switching.md
+++ b/docs/04-Architecture/ADRs/adr-031-account-pool-auto-switching.md
@@ -40,7 +40,7 @@ Add an `AccountPoolService` that automatically selects the best account from a p
 
 - **Usage source**: Anthropic OAuth usage API (`/api/oauth/usage`) — returns real utilization percentages for 5h and 7d windows, plus a structured `limits[]` array with model-scoped weekly limits (e.g. a separate Claude Fable 5 allowance)
 - **Trigger**: Switch when EITHER the 5-hour OR 7-day utilization exceeds the per-account threshold, or (amended 2026-07-05) when an active model-scoped limit matching the requested model exceeds the threshold — scoped limits gate only requests for that model, so a saturated Fable limit never blocks Sonnet/Opus traffic
-- **Threshold config**: Per-account `token_limit_threshold` column in `credentials` table (0-1 scale, default 0.80)
+- **Threshold config**: Per-account `token_limit_threshold` column in `credentials` table (0-1 scale, default 0.95; raised from 0.80 on 2026-07-24 via migration 024)
 - **Selection strategy**: Sticky least-loaded — stay on current account until threshold exceeded, then switch to least-loaded alternative
 - **Exhaustion behavior**: Return HTTP 429 with `estimated_reset` from `resets_at` and `Retry-After` header
 - **Pool activation**: Implicit — projects with 2+ linked Anthropic accounts use the pool; 0-1 accounts use default account directly
@@ -69,6 +69,8 @@ ALTER TABLE credentials
   ADD COLUMN token_limit_threshold DECIMAL(3,2) NOT NULL DEFAULT 0.80;
 ```
 
+> Amended 2026-07-24 (migration 024): the column default was raised to `0.95`, and existing accounts still at the old `0.80` default were migrated to `0.95`.
+
 **AuthenticationService integration:**
 
 ```
@@ -80,12 +82,13 @@ authenticate(context):
 
 ### Files
 
-| File                                                   | Description                                   |
-| ------------------------------------------------------ | --------------------------------------------- |
-| `services/proxy/src/services/account-pool-service.ts`  | Core pool selection logic with sticky routing |
-| `services/proxy/src/services/AuthenticationService.ts` | Delegates to AccountPoolService               |
-| `services/proxy/src/controllers/MessageController.ts`  | Handles AccountPoolExhaustedError as 429      |
-| `scripts/db/migrations/018-account-pool-threshold.ts`  | Adds `token_limit_threshold` column           |
+| File                                                                 | Description                                   |
+| -------------------------------------------------------------------- | --------------------------------------------- |
+| `services/proxy/src/services/account-pool-service.ts`                | Core pool selection logic with sticky routing |
+| `services/proxy/src/services/AuthenticationService.ts`               | Delegates to AccountPoolService               |
+| `services/proxy/src/controllers/MessageController.ts`                | Handles AccountPoolExhaustedError as 429      |
+| `scripts/db/migrations/018-account-pool-threshold.ts`                | Adds `token_limit_threshold` column           |
+| `scripts/db/migrations/024-update-account-pool-threshold-default.ts` | Raises default threshold from 0.80 to 0.95    |
 
 ## Consequences
 
@@ -107,7 +110,7 @@ authenticate(context):
 - **Risk**: Anthropic usage API rate limits
   - **Mitigation**: Addressed by [ADR-032](./adr-032-centralized-usage-cache.md) with shared caching and extrapolation
 - **Risk**: Usage API returns stale data
-  - **Mitigation**: Conservative threshold (80% default) provides headroom
+  - **Mitigation**: Configurable threshold (95% default) provides headroom before hard limits
 
 ## Links
 

--- a/scripts/db/migrations/024-update-account-pool-threshold-default.ts
+++ b/scripts/db/migrations/024-update-account-pool-threshold-default.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env bun
+
+/**
+ * Migration: Raise the default token_limit_threshold from 0.80 to 0.95
+ *
+ * Migration 018 introduced the per-account `token_limit_threshold` column
+ * (account pool auto-switching, see ADR-031) with a default of 0.80. This
+ * migration raises that default to 0.95 so accounts run closer to their limit
+ * before the pool switches to an alternative.
+ *
+ * Because migration 018 already ran on existing databases, this migration:
+ *   1. Changes the column DEFAULT so newly-inserted credentials use 0.95.
+ *   2. Migrates existing rows that are still at the old 0.80 default to 0.95.
+ *      Rows with a customized value are left untouched (only rows exactly at
+ *      the old default are updated).
+ */
+
+import { Pool } from 'pg'
+
+const OLD_DEFAULT = '0.80'
+const NEW_DEFAULT = '0.95'
+
+async function up(pool: Pool): Promise<void> {
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    console.log(`Updating token_limit_threshold default ${OLD_DEFAULT} -> ${NEW_DEFAULT}...`)
+
+    // Step 1: Change the column default for newly-inserted credentials
+    await client.query(`
+      ALTER TABLE credentials
+      ALTER COLUMN token_limit_threshold SET DEFAULT ${NEW_DEFAULT}
+    `)
+    console.log(`✓ Set token_limit_threshold column default to ${NEW_DEFAULT}`)
+
+    // Step 2: Migrate existing rows still at the old default (custom values kept)
+    const updateResult = await client.query(
+      `
+      UPDATE credentials
+      SET token_limit_threshold = $1
+      WHERE token_limit_threshold = $2
+    `,
+      [NEW_DEFAULT, OLD_DEFAULT]
+    )
+    console.log(
+      `✓ Migrated ${updateResult.rowCount ?? 0} existing account(s) from ${OLD_DEFAULT} to ${NEW_DEFAULT}`
+    )
+
+    // Step 3: Verify the new default is in place
+    const result = await client.query(`
+      SELECT column_default
+      FROM information_schema.columns
+      WHERE table_name = 'credentials'
+        AND column_name = 'token_limit_threshold'
+    `)
+
+    const columnDefault = result.rows[0]?.column_default as string | undefined
+    if (!columnDefault || !columnDefault.includes(NEW_DEFAULT)) {
+      throw new Error(
+        `Verification failed: expected default ${NEW_DEFAULT}, found ${columnDefault ?? 'none'}`
+      )
+    }
+
+    console.log('✓ Verified column default:', columnDefault)
+
+    await client.query('COMMIT')
+    console.log(`✅ token_limit_threshold default raised to ${NEW_DEFAULT} successfully`)
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('❌ Failed to update token_limit_threshold default:', error)
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+async function down(pool: Pool): Promise<void> {
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    console.log(`Reverting token_limit_threshold default ${NEW_DEFAULT} -> ${OLD_DEFAULT}...`)
+
+    // Restore the previous column default
+    await client.query(`
+      ALTER TABLE credentials
+      ALTER COLUMN token_limit_threshold SET DEFAULT ${OLD_DEFAULT}
+    `)
+    console.log(`✓ Restored token_limit_threshold column default to ${OLD_DEFAULT}`)
+
+    // Best-effort inverse: move rows still at the new default back to the old one
+    const updateResult = await client.query(
+      `
+      UPDATE credentials
+      SET token_limit_threshold = $1
+      WHERE token_limit_threshold = $2
+    `,
+      [OLD_DEFAULT, NEW_DEFAULT]
+    )
+    console.log(
+      `✓ Reverted ${updateResult.rowCount ?? 0} account(s) from ${NEW_DEFAULT} to ${OLD_DEFAULT}`
+    )
+
+    await client.query('COMMIT')
+    console.log(`✅ token_limit_threshold default reverted to ${OLD_DEFAULT} successfully`)
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('❌ Failed to revert token_limit_threshold default:', error)
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+// Main execution
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    console.error('❌ DATABASE_URL environment variable is required')
+    process.exit(1)
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl })
+
+  try {
+    const action = process.argv[2] || 'up'
+
+    if (action === 'up') {
+      await up(pool)
+    } else if (action === 'down') {
+      await down(pool)
+    } else {
+      console.error(`❌ Unknown action: ${action}. Use 'up' or 'down'`)
+      process.exit(1)
+    }
+  } catch (error) {
+    console.error('❌ Migration failed:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+// Run if executed directly
+if (import.meta.main) {
+  main()
+}

--- a/scripts/db/migrations/README.md
+++ b/scripts/db/migrations/README.md
@@ -201,6 +201,15 @@ Adds an optional `account_email` column to `credentials` for OAuth maintenance
 scripts. The value is not included in safe credential payloads used by the
 dashboard.
 
+### 024-update-account-pool-threshold-default.ts
+
+Raises the default `token_limit_threshold` (account pool auto-switching, ADR-031)
+from `0.80` to `0.95`:
+
+- Changes the column `DEFAULT` to `0.95` so newly-added accounts use the higher threshold
+- Migrates existing accounts still at the old `0.80` default to `0.95`
+  (rows with a customized value are left untouched)
+
 ## Future Migrations
 
 When adding new migrations:


### PR DESCRIPTION
## Summary

Raises the per-account **`token_limit_threshold`** default — the "account sharing limit" that governs [ADR-031 account pool auto-switching](docs/04-Architecture/ADRs/adr-031-account-pool-auto-switching.md) — from **0.80 (80%)** to **0.95 (95%)**.

When a project has 2+ linked Anthropic accounts, the proxy switches to a less-loaded account once the current account's 5h/7d utilization exceeds this threshold. Raising it to 95% lets accounts run closer to their limit before switching.

## Changes

- **New migration `024-update-account-pool-threshold-default.ts`**
  - Changes the `credentials.token_limit_threshold` column `DEFAULT` to `0.95` (new accounts)
  - Migrates existing accounts **still at the old `0.80` default** to `0.95` — accounts with a customized threshold are left untouched (`WHERE token_limit_threshold = 0.80`)
  - Idempotent, transactional, with a symmetric `down` that restores `0.80`
- **Docs updated**: ADR-031 (amendment note + Files table), `docs/02-User-Guide/authentication.md`, and `scripts/db/migrations/README.md`

## Why a new migration (not editing 018)

The `0.80` default was introduced in already-applied migration `018`. Per the project's migration convention (README: "use the next sequential number") and CLAUDE.md rule #9, applied migrations aren't edited in place. A new migration is also required to take effect on existing databases, since editing 018 would only affect fresh installs.

## Scope notes

- The dashboard's separate red-above-80% utilization coloring (`token-usage.ts`) is intentionally **left unchanged** — it's an independent display concern, not the switching threshold.
- Existing unit tests set explicit `token_limit_threshold: 0.8` fixtures to exercise switching behavior; these are unaffected by the default change and still pass.

## Verification

- `bun run typecheck` — passes
- `bun test` (account-pool-service, usage-cache-service, oauth-cli) — **44 pass / 0 fail**
- Migration compiles via `bun build`; `prettier --check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
