### PR TITLE
fix: repair conversation linking for Claude Code 2.1 and add Claude Opus 5 limits/pricing

### DIFF
--- a/docs/04-Architecture/ADRs/adr-003-conversation-tracking.md
+++ b/docs/04-Architecture/ADRs/adr-003-conversation-tracking.md
@@ -187,7 +187,53 @@ To support accurate historical rebuilds and prevent future data from affecting p
 
 This enhancement is particularly important for systems that need to rebuild or analyze historical conversation data, ensuring that the reconstructed state accurately reflects what existed at any given point in time.
 
+### Enhancement: Injected `system` Messages Excluded from Hashing (2026-07-25)
+
+Claude Code 2.1 changed the wire format in ways that broke parent matching: a single session
+fragmented into many one- or two-request conversations. Measured over 10 hours of production
+traffic, only 72% of requests found a parent; after the fix, 93%.
+
+**What changed on the client side:**
+
+1. **`role: 'system'` messages inside the `messages` array.** Claude Code injects ephemeral
+   context (system-reminders, `SessionStart` hook output, tool nudges) as extra messages rather
+   than only inside `user` messages. These are volatile in three ways:
+   - they appear and disappear between turns, so a turn can grow the array by **3** messages
+     instead of the 2 that `parentMessageHash = messages.slice(0, -2)` assumes;
+   - the **same** reminder is sent as a plain string in one request and as a content block array
+     (carrying `cache_control`) in the next;
+   - their text changes even when the conversation does not.
+2. **`x-anthropic-billing-header:` prepended to the system prompt**, carrying `cc_version`. It
+   changes on every Claude Code release, so `system_hash` churned mid-session and the
+   priority-i (message + system) parent match almost always missed.
+3. **New system prompt openings** — `You are Claude Code, Anthropic's official CLI for Claude`
+   and `You are an agent for Claude Code, ...` — replacing the
+   `You are an interactive CLI tool...` prefix that the stable-prompt special case matched.
+
+**Changes:**
+
+1. **`ConversationLinker.filterConversationMessages()`**: keeps only `user`/`assistant` messages.
+   Applied before hashing, before the parent/grandparent offset arithmetic, and before
+   single-message compact/subtask detection — so subtask detection works again for subagent
+   requests, whose first request is now `[user, system]` rather than `[user]`.
+2. **`normalizeStringContent()`** now strips `<system-reminder>` blocks (and collapses to an
+   empty string when nothing remains), matching what the content-block path already did. String
+   and array representations of the same message now hash identically.
+3. **`getStableSystemPrompt()`** drops `x-anthropic-billing-header:` lines, recognises the new
+   Claude Code prompt markers, and truncates everything from `gitStatus:` onwards (previously a
+   non-greedy regex removed only the first paragraph).
+
+**Consequences:**
+
+- Hashes for requests containing injected `system` messages differ from those stored before this
+  change. Conversations already recorded keep their existing (fragmented) `conversation_id`;
+  run `bun run scripts/db/rebuild-conversations.ts` to re-link historical data.
+- Two requests differing only in injected `system` messages now hash identically and are treated
+  as siblings by the existing branch-detection logic.
+- `message_count` semantics are unchanged: it still counts every message in the request,
+  including injected `system` messages.
+
 ---
 
-Date: 2024-02-01 (Updated: 2025-06-28, 2025-07-02)
+Date: 2024-02-01 (Updated: 2025-06-28, 2025-07-02, 2026-07-25)
 Authors: Development Team

--- a/docs/04-Architecture/ADRs/adr-035-model-pricing-registry-and-fallback-cost-attribution.md
+++ b/docs/04-Architecture/ADRs/adr-035-model-pricing-registry-and-fallback-cost-attribution.md
@@ -44,7 +44,7 @@ A single "Fable 5 request" can therefore incur Opus 4.8 token costs. Attributing
 
 Add a shared pricing module `packages/shared/src/constants/model-pricing.ts`:
 
-- `MODEL_PRICING_RULES` / `getModelPricing(model)` — regex-matched USD-per-MTok rates for input, output, cache read, and cache write, including `claude-fable-5`/`claude-mythos-5` ($10/$50), Opus 4.5–4.8 ($5/$25), legacy Opus (4.0/4.1/3) ($15/$75), all Sonnet generations incl. Sonnet 5 ($3/$15), and the Haiku/Claude-2 tiers. Unknown models fall back to `DEFAULT_MODEL_PRICING` (Sonnet-tier) with `isEstimate: true`.
+- `MODEL_PRICING_RULES` / `getModelPricing(model)` — regex-matched USD-per-MTok rates for input, output, cache read, and cache write, including `claude-fable-5`/`claude-mythos-5`/`claude-mythos-preview` ($10/$50), `claude-opus-5` and Opus 4.5–4.8 ($5/$25), legacy Opus (4.0/4.1/3) ($15/$75), all Sonnet generations incl. Sonnet 5 ($3/$15), and the Haiku/Claude-2 tiers. Unknown models fall back to `DEFAULT_MODEL_PRICING` (Sonnet-tier) with `isEstimate: true`.
 - `calculateRequestCost(model, usage)` — single-model cost from camelCase token counts.
 - `getBilledUsageByModel(topLevelModel, usage)` / `calculateUsageCost(...)` — **fallback-aware**: when `usage.iterations` is present, cost is attributed per iteration to the model that ran it, and attempts that declined before producing output (`output_tokens === 0`) are dropped because they are not billed. With no iterations, the top-level usage is attributed to the request's model.
 
@@ -53,7 +53,7 @@ Consumers:
 - Dashboard per-model breakdown (`analytics-conversation.ts`) now attributes tokens **and** cost to the model that actually ran each attempt, replacing the obsolete Claude-3 rate map.
 - Single-request cost (`request-details.ts`) uses the registry (fallback-aware) instead of the flat `calculateCost`. `calculateCost` itself is left in place as a generic env-configurable fallback.
 - `packages/shared/src/types/claude.ts` gains an optional `iterations?: ClaudeUsageIteration[]` on the response `usage` type.
-- 1M context-window rules (`model-limits.ts`) add Fable 5/Mythos 5, Opus 4.7/4.8, and Sonnet 5.
+- 1M context-window rules (`model-limits.ts`) add Fable 5/Mythos 5/Mythos Preview, Opus 5, Opus 4.7/4.8, and Sonnet 5. `inferContextLimitByGeneration` is a generational safety net: an unrecognised `claude-<family>-<n>` model with `n >= 5` is treated as 1M (200k for Haiku) and flagged `isEstimate: true`, so a newly released model no longer silently inherits the 200k default — that gap made the dashboard context gauge read 300%+ for Opus 5.
 - `model-mapping.ts` gets a clarifying comment: newer models have no verified legacy ARN-versioned Bedrock IDs and intentionally pass through unchanged.
 
 ### Implementation Details

--- a/docs/04-Architecture/internals.md
+++ b/docs/04-Architecture/internals.md
@@ -157,47 +157,75 @@ class StreamingHandler {
 
 #### Message Hashing Algorithm
 
+`ConversationLinker` (`packages/shared/src/utils/conversation-linker.ts`) is the source of truth.
+The hash covers the **durable transcript only**: messages whose role is not `user` or `assistant`
+are dropped first, because Claude Code injects `role: 'system'` messages carrying ephemeral
+context (see [ADR-003](ADRs/adr-003-conversation-tracking.md)).
+
 ```typescript
-export function generateMessageHash(message: Message): string {
-  // 1. Normalize content
-  const normalizedContent = normalizeContent(message.content)
+// Simplified shape of ConversationLinker.computeMessageHash
+export function computeMessageHash(messages: Message[]): string {
+  const hash = crypto.createHash('sha256')
 
-  // 2. Create hash input
-  const hashInput = `${message.role}:${normalizedContent}`
+  // 1. Drop injected system messages, then drop messages with duplicated tool ids
+  const conversation = messages.filter(m => m.role === 'user' || m.role === 'assistant')
 
-  // 3. Generate SHA-256 hash
-  return crypto.createHash('sha256').update(hashInput).digest('hex')
+  for (const message of deduplicateMessages(conversation)) {
+    // 2. role, then normalized content, each newline-terminated
+    hash.update(`${message.role}\n`)
+    hash.update(`${normalizeContent(message.content)}\n`)
+  }
+
+  return hash.digest('hex')
 }
 
 function normalizeContent(content: string | ContentBlock[]): string {
+  // String and array forms must normalize identically - Claude Code sends the same
+  // message either way between requests
   if (typeof content === 'string') {
-    return content
+    const clean = stripSystemReminder(content).trim()
+    return clean.length === 0 ? '' : `[0]text:${clean}`
   }
 
-  // Filter system reminders and normalize
+  // Drop blocks that are nothing but a system-reminder, then serialize positionally
   return content
-    .filter(block => {
+    .filter(block => block.type !== 'text' || stripSystemReminder(block.text).trim().length > 0)
+    .map((block, i) => {
       if (block.type === 'text') {
-        return !block.text.startsWith('<system-reminder>')
+        return `[${i}]text:${stripSystemReminder(block.text).trim()}`
       }
-      return true
-    })
-    .map(block => {
-      if (block.type === 'text') return block.text
-      if (block.type === 'image') return `[image:${block.source.type}]`
-      return '[unknown]'
+      if (block.type === 'image') {
+        return `[${i}]image:${block.source.media_type}:${sha256(block.source.data)}`
+      }
+      if (block.type === 'tool_use') {
+        return `[${i}]tool_use:${block.name}:${block.id}:${JSON.stringify(block.input)}`
+      }
+      if (block.type === 'tool_result') {
+        return `[${i}]tool_result:${block.tool_use_id}:${normalizeToolResult(block.content)}`
+      }
+      return `[${i}]${block.type}:unknown`
     })
     .join('\n')
 }
 ```
 
+The system prompt is hashed separately (`hashSystemPrompt`) after volatile sections are removed:
+the `x-anthropic-billing-header:` prelude (its `cc_version` changes with every Claude Code
+release), `<system-reminder>` blocks, and everything from `gitStatus:` onwards.
+
 #### Conversation Linking
+
+Hashes cover the whole transcript, not a single message: the parent hash is the hash of the same
+transcript minus the last two conversation messages (the assistant reply and the user turn that
+followed it). A stored request whose `current_message_hash` equals that value is the parent.
 
 ```typescript
 async function linkConversation(messages: Message[], requestId: string): Promise<ConversationInfo> {
-  // 1. Generate hashes
-  const currentHash = generateMessageHash(messages[messages.length - 1])
-  const parentHash = messages.length > 1 ? generateMessageHash(messages[messages.length - 2]) : null
+  // 1. Generate hashes over user/assistant messages only
+  const conversation = messages.filter(m => m.role === 'user' || m.role === 'assistant')
+  const currentHash = computeMessageHash(conversation)
+  // A turn adds exactly two messages, so the parent is the transcript minus the last two
+  const parentHash = conversation.length >= 3 ? computeMessageHash(conversation.slice(0, -2)) : null
 
   // 2. Find existing conversation
   if (parentHash) {

--- a/docs/06-Reference/changelog.md
+++ b/docs/06-Reference/changelog.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Conversation detection no longer fragments a single Claude Code session into many 1-2 request conversations (see [ADR-003](../04-Architecture/ADRs/adr-003-conversation-tracking.md))
+  - Claude Code 2.1 injects `role: 'system'` messages into the `messages` array (system-reminders, hook output, tool nudges). They appear and disappear between turns and flip between plain-string and content-block form, which broke the prefix hashing that links a request to its parent
+  - `ConversationLinker` now hashes the durable transcript only (`user`/`assistant` messages), and applies the same filter to the parent/grandparent offsets and to single-message compact/subtask detection — restoring subtask linking for subagent requests, whose first request is now `[user, system]`
+  - String message content now has `<system-reminder>` blocks stripped, matching the content-block path, so both wire representations of the same message hash identically
+  - Measured on 10 hours of production traffic: parent-link rate 72% → 93%, i.e. 76% fewer conversations created
+  - Existing rows keep their fragmented `conversation_id`; run `bun run scripts/db/rebuild-conversations.ts` to re-link historical data
+- System prompt hash no longer churns mid-session: the `x-anthropic-billing-header:` prelude (whose `cc_version` changes on every Claude Code release) is dropped, the new Claude Code prompt markers (`You are Claude Code, ...`, `You are an agent for Claude Code, ...`) are recognised, and the whole `gitStatus:` tail is removed instead of only its first paragraph
+- Dashboard context gauge ("battery") no longer shows impossible percentages such as 300%+
+  - `claude-opus-5` had no context-window rule, so its ~780k-token contexts were measured against the 200k default
+  - Added rules for Claude Opus 5 and Mythos Preview (1M), plus `inferContextLimitByGeneration` so an unrecognised `claude-<family>-<n>` model with `n >= 5` is treated as 1M (200k for Haiku) and flagged as an estimate rather than silently defaulting to 200k
+- Claude Opus 5 costs are no longer understated: it had no pricing rule and fell back to the Sonnet-tier default ($3/$15 instead of the correct $5/$25). Also added `claude-mythos-preview` (Fable 5 rates) and an Opus 5 entry to `scripts/aws-bedrock-cost-report.ts`
 - Account pool no longer routes requests to accounts whose model-scoped limit is exhausted (fixes upstream `429 "This request could exceed your account's rate limit"` despite low 5h/7d usage)
   - Anthropic's OAuth usage response now carries a structured `limits[]` array with model-scoped weekly limits (e.g. a separate Claude Fable 5 allowance); the legacy `seven_day_opus`/`seven_day_sonnet` fields are null in live responses
   - Account selection is now model-aware: a saturated Fable-scoped limit exhausts the pool for Fable requests only, without blocking other models; sticky accounts are re-evaluated per requested model

--- a/packages/shared/src/constants/__tests__/model-limits.test.ts
+++ b/packages/shared/src/constants/__tests__/model-limits.test.ts
@@ -3,6 +3,7 @@ import {
   getModelContextLimit,
   getBatteryColor,
   getBatteryLevel,
+  inferContextLimitByGeneration,
   BATTERY_THRESHOLDS,
 } from '../model-limits'
 
@@ -15,6 +16,20 @@ describe('Model Context Limits', () => {
 
     it('should return 1M for Claude Mythos 5', () => {
       expect(getModelContextLimit('claude-mythos-5')).toEqual({ limit: 1000000, isEstimate: false })
+    })
+
+    it('should return 1M for Claude Mythos Preview', () => {
+      expect(getModelContextLimit('claude-mythos-preview')).toEqual({
+        limit: 1000000,
+        isEstimate: false,
+      })
+    })
+
+    // Test 1M context models - Claude Opus 5
+    // Regression: a missing rule here made the dashboard context gauge read 300%+
+    // because a ~780k-token Opus 5 context was measured against the 200k default.
+    it('should return 1M for Claude Opus 5', () => {
+      expect(getModelContextLimit('claude-opus-5')).toEqual({ limit: 1000000, isEstimate: false })
     })
 
     // Test 1M context models - Claude Opus 4.7 / 4.8
@@ -131,6 +146,43 @@ describe('Model Context Limits', () => {
     it('should match partial model names', () => {
       const result = getModelContextLimit('claude-3-sonnet')
       expect(result).toEqual({ limit: 200000, isEstimate: false })
+    })
+
+    // Generational safety net: an unreleased model must not silently inherit 200k
+    it('should infer 1M (as an estimate) for a future Opus generation', () => {
+      expect(getModelContextLimit('claude-opus-6')).toEqual({ limit: 1000000, isEstimate: true })
+    })
+
+    it('should infer 1M (as an estimate) for a future Sonnet generation', () => {
+      expect(getModelContextLimit('claude-sonnet-6-20270101')).toEqual({
+        limit: 1000000,
+        isEstimate: true,
+      })
+    })
+
+    it('should infer 200k (as an estimate) for a future Haiku generation', () => {
+      expect(getModelContextLimit('claude-haiku-5')).toEqual({ limit: 200000, isEstimate: true })
+    })
+  })
+
+  describe('inferContextLimitByGeneration', () => {
+    it('returns 1M for frontier families from generation 5 onwards', () => {
+      expect(inferContextLimitByGeneration('claude-opus-5')).toBe(1000000)
+      expect(inferContextLimitByGeneration('claude-sonnet-7')).toBe(1000000)
+      expect(inferContextLimitByGeneration('claude-fable-6')).toBe(1000000)
+    })
+
+    it('returns 200k for Haiku regardless of generation', () => {
+      expect(inferContextLimitByGeneration('claude-haiku-6')).toBe(200000)
+    })
+
+    it('returns null for pre-5 generations so explicit rules stay authoritative', () => {
+      expect(inferContextLimitByGeneration('claude-opus-4-5')).toBeNull()
+    })
+
+    it('returns null for unrecognised model id shapes', () => {
+      expect(inferContextLimitByGeneration('gpt-4')).toBeNull()
+      expect(inferContextLimitByGeneration('claude-x-experimental')).toBeNull()
     })
   })
 

--- a/packages/shared/src/constants/__tests__/model-pricing.test.ts
+++ b/packages/shared/src/constants/__tests__/model-pricing.test.ts
@@ -22,6 +22,21 @@ describe('Model Pricing', () => {
       )
     })
 
+    it('prices Claude Mythos Preview the same as Fable 5', () => {
+      expect(getModelPricing('claude-mythos-preview').isEstimate).toBe(false)
+      expect(getModelPricing('claude-mythos-preview').pricing).toEqual(
+        getModelPricing('claude-fable-5').pricing
+      )
+    })
+
+    // Regression: without an explicit rule, Opus 5 fell through to the Sonnet-tier
+    // default, understating dashboard costs by ~40%.
+    it('prices Claude Opus 5 at $5 / $25 per MTok', () => {
+      const { pricing, isEstimate } = getModelPricing('claude-opus-5')
+      expect(isEstimate).toBe(false)
+      expect(pricing).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 })
+    })
+
     it('prices Opus 4.8 at $5 / $25 per MTok', () => {
       const { pricing } = getModelPricing('claude-opus-4-8')
       expect(pricing).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 })

--- a/packages/shared/src/constants/model-limits.ts
+++ b/packages/shared/src/constants/model-limits.ts
@@ -17,9 +17,15 @@ export interface ModelContextRule {
  * Model context window rules
  * Order matters - more specific patterns should come before general ones
  *
- * Claude Fable 5, Opus 4.6/4.7/4.8, Sonnet 5 and Sonnet 4.6 support 1M context
- * windows. Models with "[1m]" suffix in their display name also indicate 1M
- * context. Earlier Claude 4.x models use 200k context windows.
+ * Claude Fable 5, Mythos 5, Opus 5, Opus 4.6/4.7/4.8, Sonnet 5 and Sonnet 4.6
+ * support 1M context windows. Models with "[1m]" suffix in their display name
+ * also indicate 1M context. Earlier Claude 4.x models and Haiku use 200k
+ * context windows.
+ *
+ * When a rule is missing for a released model the lookup silently falls back to
+ * {@link DEFAULT_CONTEXT_LIMIT} (200k), which makes the dashboard context gauge
+ * read several hundred percent for 1M-context models. {@link inferContextLimitByGeneration}
+ * is the safety net for that; new models should still get an explicit rule here.
  *
  * @see https://platform.claude.com/docs/en/about-claude/models/overview
  * @see https://claude.com/blog/1m-context-ga
@@ -34,8 +40,13 @@ export const MODEL_CONTEXT_RULES: ModelContextRule[] = [
   },
 
   // Claude Fable 5 / Mythos 5 - 1M context window (new top tier above Opus)
+  // Mythos Preview shares Fable 5's specs and pricing (Project Glasswing).
   // Source: https://platform.claude.com/docs/en/about-claude/models/overview
-  { pattern: /claude-(fable|mythos)-5/i, limit: 1000000 },
+  { pattern: /claude-(fable|mythos)-5|claude-mythos-preview/i, limit: 1000000 },
+
+  // Claude Opus 5 - 1M context window
+  // Source: https://platform.claude.com/docs/en/about-claude/models/overview
+  { pattern: /claude-opus-5/i, limit: 1000000 },
 
   // Claude Opus 4.6 / 4.7 / 4.8 - 1M context window
   // Source: https://platform.claude.com/docs/en/about-claude/models/overview
@@ -88,6 +99,56 @@ export const MODEL_CONTEXT_RULES: ModelContextRule[] = [
 export const DEFAULT_CONTEXT_LIMIT = 200000
 
 /**
+ * Context limit for 1M-context models
+ */
+export const LARGE_CONTEXT_LIMIT = 1000000
+
+/**
+ * First Claude generation where the frontier families (Opus/Sonnet/Fable/Mythos)
+ * ship with a 1M context window by default.
+ *
+ * Opus 4.6 was the first 1M model; every Opus/Sonnet/Fable release since has kept
+ * 1M, so an unrecognised model from generation 5 or later is far more likely to be
+ * 1M than 200k.
+ */
+const FIRST_LARGE_CONTEXT_GENERATION = 5
+
+/**
+ * Matches the modern `claude-<family>-<generation>[-<minor>]` id format,
+ * e.g. `claude-opus-5`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`.
+ */
+const MODEL_GENERATION_PATTERN = /claude-(opus|sonnet|haiku|fable|mythos)-(\d+)/i
+
+/**
+ * Best-effort context limit for a model with no explicit rule.
+ *
+ * This exists so that a newly released model does not silently inherit the 200k
+ * default - that under-reporting is what made the dashboard context gauge show
+ * 300%+ for Claude Opus 5 before it had a rule. Results are always flagged as
+ * estimates; add an explicit {@link MODEL_CONTEXT_RULES} entry once the real
+ * limit is published.
+ *
+ * @param model - The model identifier
+ * @returns The inferred limit, or null when the id shape is unrecognised
+ */
+export function inferContextLimitByGeneration(model: string): number | null {
+  const match = MODEL_GENERATION_PATTERN.exec(model)
+  if (!match) {
+    return null
+  }
+
+  const family = match[1].toLowerCase()
+  const generation = Number.parseInt(match[2], 10)
+
+  // Haiku has stayed at 200k across every generation released so far.
+  if (family === 'haiku') {
+    return DEFAULT_CONTEXT_LIMIT
+  }
+
+  return generation >= FIRST_LARGE_CONTEXT_GENERATION ? LARGE_CONTEXT_LIMIT : null
+}
+
+/**
  * Get the context limit for a given model
  * @param model - The model identifier (e.g., "claude-3-opus-20240229")
  * @returns An object with the limit and whether it's an estimate
@@ -98,6 +159,13 @@ export function getModelContextLimit(model: string): { limit: number; isEstimate
       return { limit: rule.limit, isEstimate: false }
     }
   }
+
+  // No explicit rule - infer from the model generation before falling back
+  const inferred = inferContextLimitByGeneration(model)
+  if (inferred !== null) {
+    return { limit: inferred, isEstimate: true }
+  }
+
   // Unknown model - return default with estimate flag
   return { limit: DEFAULT_CONTEXT_LIMIT, isEstimate: true }
 }

--- a/packages/shared/src/constants/model-pricing.ts
+++ b/packages/shared/src/constants/model-pricing.ts
@@ -49,9 +49,16 @@ export interface ModelPricingRule {
  */
 export const MODEL_PRICING_RULES: ModelPricingRule[] = [
   // Claude Fable 5 / Mythos 5 — top tier above Opus ($10 / $50 per MTok)
+  // Mythos Preview shares Fable 5's specs and pricing (Project Glasswing).
   {
-    pattern: /claude-(fable|mythos)-5/i,
+    pattern: /claude-(fable|mythos)-5|claude-mythos-preview/i,
     pricing: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  },
+
+  // Claude Opus 5 ($5 / $25 per MTok)
+  {
+    pattern: /claude-opus-5/i,
+    pricing: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   },
 
   // Claude Opus 4.5 / 4.6 / 4.7 / 4.8 ($5 / $25 per MTok)

--- a/packages/shared/src/utils/__tests__/injected-system-messages.test.ts
+++ b/packages/shared/src/utils/__tests__/injected-system-messages.test.ts
@@ -256,6 +256,171 @@ describe('Claude Code injected system messages', () => {
   })
 })
 
+/**
+ * Excluding injected `system` messages makes hashing more permissive, so these tests pin
+ * the opposite property: unrelated transcripts must not end up in one conversation.
+ *
+ * The one case where discrimination is genuinely reduced is two sessions whose transcript
+ * is byte-identical up to a divergence point (e.g. the same subagent prompt launched
+ * twice). Hash-based tracking cannot tell those apart by design (ADR-003); what matters is
+ * that the divergence surfaces as a branch rather than a silently interleaved chain.
+ */
+describe('Conversation isolation', () => {
+  /** Minimal in-memory stand-in for writer.findParentRequests. */
+  function createStore() {
+    const rows: Array<{
+      request_id: string
+      conversation_id: string
+      branch_id: string
+      current_message_hash: string
+      parent_message_hash: string | null
+      system_hash: string | null
+    }> = []
+
+    const queryExecutor: QueryExecutor = async (criteria: ParentQueryCriteria) =>
+      rows
+        .filter(r => {
+          if (
+            criteria.currentMessageHash &&
+            r.current_message_hash !== criteria.currentMessageHash
+          ) {
+            return false
+          }
+          if (criteria.parentMessageHash && r.parent_message_hash !== criteria.parentMessageHash) {
+            return false
+          }
+          if (criteria.systemHash && r.system_hash !== criteria.systemHash) {
+            return false
+          }
+          if (criteria.excludeRequestId && r.request_id === criteria.excludeRequestId) {
+            return false
+          }
+          if (criteria.conversationId && r.conversation_id !== criteria.conversationId) {
+            return false
+          }
+          return true
+        })
+        .map(r => ({
+          request_id: r.request_id,
+          conversation_id: r.conversation_id,
+          branch_id: r.branch_id,
+          current_message_hash: r.current_message_hash,
+          system_hash: r.system_hash,
+        }))
+
+    return { rows, queryExecutor }
+  }
+
+  test('does not link a request whose prefix matches nothing', async () => {
+    const { rows, queryExecutor } = createStore()
+    const isolated = new ConversationLinker(queryExecutor, noopLogger)
+
+    // An unrelated conversation already exists
+    rows.push({
+      request_id: 'other-request',
+      conversation_id: 'other-conv',
+      branch_id: 'main',
+      current_message_hash: isolated.computeMessageHash([
+        { role: 'user', content: 'Unrelated topic' },
+      ]),
+      parent_message_hash: null,
+      system_hash: null,
+    })
+
+    const result = await isolated.linkConversation({
+      projectId: 'test-project',
+      messages: [
+        { role: 'user', content: 'A different topic entirely' },
+        { role: 'system', content: SKILLS_REMINDER },
+        { role: 'assistant', content: 'Sure' },
+        { role: 'user', content: 'Continue' },
+      ],
+      systemPrompt: 'Test system prompt',
+      requestId: 'new-request',
+      messageCount: 4,
+    })
+
+    expect(result.conversationId).toBeNull()
+    expect(result.parentRequestId).toBeNull()
+  })
+
+  test('keeps transcripts that differ only in user content apart', () => {
+    const hasher = new ConversationLinker(async () => [], noopLogger)
+    const withSameInjection = (question: string): ClaudeMessage[] => [
+      { role: 'user', content: question },
+      { role: 'system', content: SKILLS_REMINDER },
+    ]
+
+    expect(hasher.computeMessageHash(withSameInjection('Question A'))).not.toBe(
+      hasher.computeMessageHash(withSameInjection('Question B'))
+    )
+  })
+
+  test('keeps transcripts that differ only in assistant content apart', () => {
+    const hasher = new ConversationLinker(async () => [], noopLogger)
+    const withReply = (reply: string): ClaudeMessage[] => [
+      { role: 'user', content: 'Same question' },
+      { role: 'assistant', content: reply },
+      { role: 'user', content: 'Same follow-up' },
+    ]
+
+    expect(hasher.computeMessageHash(withReply('Answer A'))).not.toBe(
+      hasher.computeMessageHash(withReply('Answer B'))
+    )
+  })
+
+  test('surfaces a divergent continuation of a shared prefix as a branch', async () => {
+    const { rows, queryExecutor } = createStore()
+    const isolated = new ConversationLinker(queryExecutor, noopLogger)
+
+    // Two sessions opening with a byte-identical prompt: the root request is stored once,
+    // because both sessions hash to it.
+    const rootHash = isolated.computeMessageHash([{ role: 'user', content: 'Identical prompt' }])
+    rows.push({
+      request_id: 'root-request',
+      conversation_id: 'shared-conv',
+      branch_id: 'main',
+      current_message_hash: rootHash,
+      parent_message_hash: null,
+      system_hash: null,
+    })
+
+    const continueWith = (reply: string, followUp: string): LinkingRequest => ({
+      projectId: 'test-project',
+      messages: [
+        { role: 'user', content: 'Identical prompt' },
+        { role: 'system', content: SKILLS_REMINDER },
+        { role: 'assistant', content: reply },
+        { role: 'user', content: followUp },
+      ],
+      systemPrompt: 'Test system prompt',
+      requestId: `child-${reply}`,
+      messageCount: 4,
+    })
+
+    const first = await isolated.linkConversation(continueWith('Answer A', 'Follow-up A'))
+    expect(first.conversationId).toBe('shared-conv')
+    expect(first.branchId).toBe('main')
+
+    rows.push({
+      request_id: 'child-a',
+      conversation_id: first.conversationId!,
+      branch_id: first.branchId,
+      current_message_hash: first.currentMessageHash,
+      parent_message_hash: first.parentMessageHash,
+      system_hash: first.systemHash,
+    })
+
+    // The second session diverges from the same root - it must not be appended to the
+    // first session's chain, it must open a branch.
+    const second = await isolated.linkConversation(continueWith('Answer B', 'Follow-up B'))
+    expect(second.conversationId).toBe('shared-conv')
+    expect(second.branchId).not.toBe('main')
+    expect(second.branchId).toStartWith('branch_')
+    expect(second.currentMessageHash).not.toBe(first.currentMessageHash)
+  })
+})
+
 describe('System prompt hash stability', () => {
   const claudeCodePrompt = [
     "You are Claude Code, Anthropic's official CLI for Claude.",

--- a/packages/shared/src/utils/__tests__/injected-system-messages.test.ts
+++ b/packages/shared/src/utils/__tests__/injected-system-messages.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Regression tests for the Claude Code 2.1 wire format.
+ *
+ * Claude Code injects `role: 'system'` messages into the `messages` array to carry
+ * ephemeral context (system-reminders, hook output, tool nudges) and prepends an
+ * `x-anthropic-billing-header:` block to the system prompt. Both are volatile and used
+ * to break conversation linking, fragmenting a single session into many one-request
+ * conversations.
+ *
+ * @see ../conversation-linker.ts (ConversationLinker.filterConversationMessages)
+ */
+import { describe, test, expect, beforeEach } from 'bun:test'
+import {
+  ConversationLinker,
+  type QueryExecutor,
+  type LinkingRequest,
+  type ParentQueryCriteria,
+  type SubtaskQueryExecutor,
+  type RequestByIdExecutor,
+} from '../conversation-linker'
+import { extractMessageHashes, hashMessagesOnly, hashSystemPrompt } from '../conversation-hash.js'
+import type { ClaudeMessage } from '../../types/index.js'
+
+const SKILLS_REMINDER =
+  '<system-reminder>\nThe following skills are available for use with the Skill tool:\n\n- review\n</system-reminder>'
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as any
+
+describe('Claude Code injected system messages', () => {
+  let linker: ConversationLinker
+
+  beforeEach(() => {
+    linker = new ConversationLinker(async () => [], noopLogger)
+  })
+
+  describe('filterConversationMessages', () => {
+    test('keeps only user and assistant messages, in order', () => {
+      const messages: ClaudeMessage[] = [
+        { role: 'user', content: 'Do the thing' },
+        { role: 'system', content: SKILLS_REMINDER },
+        { role: 'assistant', content: 'On it' },
+      ]
+
+      expect(ConversationLinker.filterConversationMessages(messages)).toEqual([
+        { role: 'user', content: 'Do the thing' },
+        { role: 'assistant', content: 'On it' },
+      ])
+    })
+  })
+
+  describe('computeMessageHash', () => {
+    test('ignores injected system messages', () => {
+      const withInjection: ClaudeMessage[] = [
+        { role: 'user', content: 'Do the thing' },
+        { role: 'system', content: SKILLS_REMINDER },
+        { role: 'assistant', content: 'On it' },
+      ]
+      const withoutInjection: ClaudeMessage[] = [
+        { role: 'user', content: 'Do the thing' },
+        { role: 'assistant', content: 'On it' },
+      ]
+
+      expect(linker.computeMessageHash(withInjection)).toBe(
+        linker.computeMessageHash(withoutInjection)
+      )
+    })
+
+    test('ignores how many system messages were injected', () => {
+      const base: ClaudeMessage[] = [
+        { role: 'user', content: 'Do the thing' },
+        { role: 'assistant', content: 'On it' },
+      ]
+      const oneInjection: ClaudeMessage[] = [
+        base[0],
+        { role: 'system', content: SKILLS_REMINDER },
+        base[1],
+      ]
+      const twoInjections: ClaudeMessage[] = [
+        base[0],
+        { role: 'system', content: SKILLS_REMINDER },
+        base[1],
+        { role: 'system', content: '<system-reminder>Use your todo list</system-reminder>' },
+      ]
+
+      expect(linker.computeMessageHash(oneInjection)).toBe(linker.computeMessageHash(twoInjections))
+    })
+
+    test('hashes string and content-block reminders identically', () => {
+      // Claude Code sends the same reminder as a plain string in one request and as a
+      // content block array (carrying cache_control) in the next.
+      const asString: ClaudeMessage[] = [{ role: 'user', content: SKILLS_REMINDER }]
+      const asBlocks: ClaudeMessage[] = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: SKILLS_REMINDER, cache_control: { type: 'ephemeral' } } as any,
+          ],
+        },
+      ]
+
+      expect(linker.computeMessageHash(asString)).toBe(linker.computeMessageHash(asBlocks))
+    })
+
+    test('strips system-reminders from string content', () => {
+      const withReminder: ClaudeMessage[] = [
+        { role: 'user', content: `Real question\n${SKILLS_REMINDER}` },
+      ]
+      const withoutReminder: ClaudeMessage[] = [{ role: 'user', content: 'Real question' }]
+
+      expect(linker.computeMessageHash(withReminder)).toBe(
+        linker.computeMessageHash(withoutReminder)
+      )
+    })
+  })
+
+  describe('extractMessageHashes', () => {
+    test('computes the parent offset over conversation messages only', () => {
+      const messages: ClaudeMessage[] = [
+        { role: 'user', content: 'First' },
+        { role: 'system', content: SKILLS_REMINDER },
+        { role: 'assistant', content: 'Second' },
+        { role: 'user', content: 'Third' },
+        { role: 'system', content: SKILLS_REMINDER },
+      ]
+
+      const { currentMessageHash, parentMessageHash } = extractMessageHashes(messages)
+
+      // Parent is the first user message alone - the injected messages must not
+      // shift the "all but the last two" offset.
+      expect(parentMessageHash).toBe(hashMessagesOnly([{ role: 'user', content: 'First' }]))
+      expect(currentMessageHash).toBe(
+        hashMessagesOnly([
+          { role: 'user', content: 'First' },
+          { role: 'assistant', content: 'Second' },
+          { role: 'user', content: 'Third' },
+        ])
+      )
+    })
+
+    test('throws when there are no conversation messages', () => {
+      expect(() => extractMessageHashes([{ role: 'system', content: SKILLS_REMINDER }])).toThrow(
+        'Cannot extract hashes from empty messages array'
+      )
+    })
+  })
+
+  describe('linkConversation', () => {
+    test('links a request whose turn also appended a system message', async () => {
+      // Turn N:   [user, system]                    -> new conversation
+      // Turn N+1: [user, system, assistant, user, system]
+      // The turn grew by three messages, so the raw "last two" offset misses the parent.
+      const parentMessages: ClaudeMessage[] = [
+        { role: 'user', content: 'First' },
+        { role: 'system', content: SKILLS_REMINDER },
+      ]
+      const parentHash = linker.computeMessageHash(parentMessages)
+
+      const queryExecutor: QueryExecutor = async (criteria: ParentQueryCriteria) => {
+        if (criteria.currentMessageHash === parentHash) {
+          return [
+            {
+              request_id: 'parent-request',
+              conversation_id: 'conv-1',
+              branch_id: 'main',
+              current_message_hash: parentHash,
+              system_hash: null,
+            },
+          ]
+        }
+        return []
+      }
+
+      linker = new ConversationLinker(queryExecutor, noopLogger)
+
+      const request: LinkingRequest = {
+        projectId: 'test-project',
+        messages: [
+          { role: 'user', content: 'First' },
+          { role: 'system', content: SKILLS_REMINDER },
+          { role: 'assistant', content: 'Second' },
+          { role: 'user', content: 'Third' },
+          { role: 'system', content: '<system-reminder>Use your todo list</system-reminder>' },
+        ],
+        systemPrompt: 'Test system prompt',
+        requestId: 'child-request',
+        messageCount: 5,
+      }
+
+      const result = await linker.linkConversation(request)
+
+      expect(result.conversationId).toBe('conv-1')
+      expect(result.parentRequestId).toBe('parent-request')
+      expect(result.branchId).toBe('main')
+    })
+
+    test('still detects a subtask when a system message trails the prompt', async () => {
+      const subtaskPrompt = 'Analyze the authentication module'
+
+      const subtaskQueryExecutor: SubtaskQueryExecutor = async () => [
+        {
+          requestId: 'parent-task-request',
+          toolUseId: 'toolu_1',
+          prompt: subtaskPrompt,
+          timestamp: new Date('2026-07-25T10:00:00Z'),
+        },
+      ]
+
+      const requestByIdExecutor: RequestByIdExecutor = async requestId => ({
+        request_id: requestId,
+        conversation_id: 'parent-conv',
+        branch_id: 'main',
+        current_message_hash: 'parent-hash',
+        system_hash: null,
+      })
+
+      linker = new ConversationLinker(
+        async () => [],
+        noopLogger,
+        undefined,
+        requestByIdExecutor,
+        subtaskQueryExecutor,
+        async () => 0
+      )
+
+      const request: LinkingRequest = {
+        projectId: 'test-project',
+        messages: [
+          { role: 'user', content: subtaskPrompt },
+          { role: 'system', content: SKILLS_REMINDER },
+        ],
+        systemPrompt: 'Test system prompt',
+        requestId: 'subtask-request',
+        messageCount: 2,
+        timestamp: new Date('2026-07-25T10:00:05Z'),
+      }
+
+      const result = await linker.linkConversation(request)
+
+      expect(result.isSubtask).toBe(true)
+      expect(result.conversationId).toBe('parent-conv')
+      expect(result.parentTaskRequestId).toBe('parent-task-request')
+      expect(result.branchId).toBe('subtask_1')
+    })
+  })
+})
+
+describe('System prompt hash stability', () => {
+  const claudeCodePrompt = [
+    "You are Claude Code, Anthropic's official CLI for Claude.",
+    'You are an interactive agent that helps users with software engineering tasks.',
+    '',
+    '# Environment',
+    ' - Primary working directory: /home/dev/project',
+  ].join('\n')
+
+  test('ignores the volatile x-anthropic-billing-header block', () => {
+    const withVersionA = `x-anthropic-billing-header: cc_version=2.1.218.e2a; cc_entrypoint=cli;\n${claudeCodePrompt}`
+    const withVersionB = `x-anthropic-billing-header: cc_version=2.1.220.3fc; cc_entrypoint=cli;\n${claudeCodePrompt}`
+
+    expect(hashSystemPrompt(withVersionA)).toBe(hashSystemPrompt(withVersionB))
+  })
+
+  test('ignores the billing header in array form', () => {
+    const asArray = (version: string) => [
+      { type: 'text' as const, text: `x-anthropic-billing-header: cc_version=${version};` },
+      { type: 'text' as const, text: claudeCodePrompt },
+    ]
+
+    expect(hashSystemPrompt(asArray('2.1.218.e2a'))).toBe(hashSystemPrompt(asArray('2.1.220.3fc')))
+  })
+
+  test('ignores the git status section that changes on every commit', () => {
+    const withStatus = (commit: string) =>
+      `${claudeCodePrompt}\n\ngitStatus: This is the git status at the start of the conversation.\n\nCurrent branch: main\n\nRecent commits:\n${commit} some work\n`
+
+    expect(hashSystemPrompt(withStatus('aaaaaaa'))).toBe(hashSystemPrompt(withStatus('bbbbbbb')))
+  })
+
+  test('recognises the Claude Code subagent prompt', () => {
+    const subagentPrompt = `x-anthropic-billing-header: cc_version=2.1.219.d53; cc_is_subagent=true;\nYou are an agent for Claude Code, Anthropic's official CLI for Claude. Given the user's message, you should use the tools available.`
+
+    expect(hashSystemPrompt(subagentPrompt)).toBeTruthy()
+    // Collapses to the stable marker, so unrelated tail changes do not churn the hash
+    expect(hashSystemPrompt(`${subagentPrompt}\n\nExtra environment details`)).toBe(
+      hashSystemPrompt(subagentPrompt)
+    )
+  })
+
+  test('still distinguishes unrelated system prompts', () => {
+    expect(hashSystemPrompt('You are a helpful assistant')).not.toBe(
+      hashSystemPrompt('You are a coding assistant')
+    )
+  })
+
+  test('returns null when the prompt is only a billing header', () => {
+    expect(hashSystemPrompt('x-anthropic-billing-header: cc_version=2.1.220.3fc;')).toBeNull()
+  })
+})

--- a/packages/shared/src/utils/__tests__/injected-system-messages.test.ts
+++ b/packages/shared/src/utils/__tests__/injected-system-messages.test.ts
@@ -106,6 +106,13 @@ describe('Claude Code injected system messages', () => {
       expect(linker.computeMessageHash(asString)).toBe(linker.computeMessageHash(asBlocks))
     })
 
+    test('refuses to hash a request with no user or assistant messages', () => {
+      // Guards against every all-system request sharing the hash of an empty input
+      expect(() =>
+        linker.computeMessageHash([{ role: 'system', content: SKILLS_REMINDER }])
+      ).toThrow('no user or assistant messages')
+    })
+
     test('strips system-reminders from string content', () => {
       const withReminder: ClaudeMessage[] = [
         { role: 'user', content: `Real question\n${SKILLS_REMINDER}` },

--- a/packages/shared/src/utils/conversation-hash.ts
+++ b/packages/shared/src/utils/conversation-hash.ts
@@ -105,22 +105,54 @@ function normalizeMessageContent(content: string | any[]): string {
 // Use ConversationLinker.computeMessageHash for production code
 
 /**
+ * Volatile prelude Claude Code prepends to the system prompt, e.g.
+ * `x-anthropic-billing-header: cc_version=2.1.219.d53; cc_entrypoint=cli; ...`
+ *
+ * The `cc_version` changes with every Claude Code release, so leaving it in makes the
+ * system hash churn mid-session and defeats the exact (message + system) parent match.
+ */
+const BILLING_HEADER_PATTERN = /^[ \t]*x-anthropic-billing-header:.*$/gim
+
+/**
+ * Stable opening lines of the Claude Code system prompts. Everything after the marker is
+ * environment- and repo-specific (working directory, model name, git status), so the
+ * marker alone is hashed - mirroring the long-standing behaviour for the original
+ * "You are an interactive CLI tool..." prompt.
+ */
+const CLAUDE_CODE_PROMPT_MARKERS = [
+  'You are an interactive CLI tool that helps users with software engineering tasks',
+  "You are Claude Code, Anthropic's official CLI for Claude",
+  "You are an agent for Claude Code, Anthropic's official CLI for Claude",
+] as const
+
+/**
+ * Finds the Claude Code prompt marker the text starts with, if any.
+ */
+function matchClaudeCodePromptMarker(text: string): string | null {
+  const trimmed = text.trim()
+  return CLAUDE_CODE_PROMPT_MARKERS.find(marker => trimmed.startsWith(marker)) ?? null
+}
+
+/**
  * Removes transient/volatile context from system prompts to ensure stable hashing
  * @param systemPrompt - The system prompt content
  * @returns The stable part of the system prompt
  */
 function getStableSystemPrompt(systemPrompt: string | any[]): string {
   if (typeof systemPrompt === 'string') {
-    // Special case: If the system prompt starts with the CLI tool text,
+    // Drop the billing header prelude before looking for the prompt marker - since
+    // Claude Code 2.1 it is prepended ahead of the actual system prompt.
+    const withoutBillingHeader = systemPrompt.replace(BILLING_HEADER_PATTERN, '')
+
+    // Special case: If the system prompt starts with a known Claude Code prompt,
     // only include this stable snippet to avoid dynamic content differences
-    const cliToolPrefix =
-      'You are an interactive CLI tool that helps users with software engineering tasks'
-    if (systemPrompt.trim().startsWith(cliToolPrefix)) {
+    const marker = matchClaudeCodePromptMarker(withoutBillingHeader)
+    if (marker) {
       // Return just the stable prefix, ignoring all the dynamic content that follows
-      return cliToolPrefix
+      return marker
     }
 
-    let stable = systemPrompt
+    let stable = withoutBillingHeader
 
     // Remove transient_context blocks (future-proofing)
     stable = stable.replace(/<transient_context>[\s\S]*?<\/transient_context>/g, '')
@@ -128,9 +160,9 @@ function getStableSystemPrompt(systemPrompt: string | any[]): string {
     // Remove system-reminder blocks
     stable = stripSystemReminder(stable)
 
-    // Remove git status sections (common in Claude Code)
-    // Pattern: "gitStatus: " followed by content until double newline or end
-    stable = stable.replace(/gitStatus:[\s\S]*?(?:\n\n|$)/g, '\n\n')
+    // Remove the git status section. Claude Code appends it last and it changes on
+    // every commit, so everything from the marker onwards is dropped.
+    stable = stable.replace(/gitStatus:[\s\S]*$/, '')
 
     // Remove standalone Status: sections that contain git information
     // This captures multi-line status blocks that contain file changes
@@ -151,28 +183,33 @@ function getStableSystemPrompt(systemPrompt: string | any[]): string {
     return stable.trim()
   }
 
-  // For array content, check if any text item contains the CLI tool prefix
-  const cliToolPrefix =
-    'You are an interactive CLI tool that helps users with software engineering tasks'
-
   if (Array.isArray(systemPrompt)) {
-    for (const item of systemPrompt) {
-      if (
-        item.type === 'text' &&
-        typeof item.text === 'string' &&
-        item.text.trim().startsWith(cliToolPrefix)
-      ) {
-        // Found CLI tool text - return normalized content with just the first item and the CLI prefix
-        const stableContent = [
-          systemPrompt[0], // Keep the first item (usually "You are Claude Code...")
-          { type: 'text', text: cliToolPrefix }, // Replace the second item with just the prefix
-        ]
-        return normalizeMessageContent(stableContent)
+    // Drop the volatile billing-header block (cc_version changes every release)
+    const stableItems = systemPrompt.filter(
+      item =>
+        !(
+          item?.type === 'text' &&
+          typeof item.text === 'string' &&
+          /^\s*x-anthropic-billing-header:/i.test(item.text)
+        )
+    )
+
+    // If any block is a known Claude Code prompt, hash only that marker so the
+    // environment-specific tail (cwd, model, git status) cannot churn the hash.
+    for (const item of stableItems) {
+      if (item?.type !== 'text' || typeof item.text !== 'string') {
+        continue
+      }
+      const marker = matchClaudeCodePromptMarker(item.text)
+      if (marker) {
+        return normalizeMessageContent([{ type: 'text', text: marker }])
       }
     }
+
+    // No Claude Code prompt - apply normalization which already filters system-reminders
+    return normalizeMessageContent(stableItems)
   }
 
-  // For array content without CLI prefix, apply normalization which already filters system-reminders
   return normalizeMessageContent(systemPrompt)
 }
 
@@ -253,8 +290,16 @@ export function extractMessageHashes(
     throw new Error('Cannot extract hashes from empty messages array')
   }
 
+  // Injected `role: 'system'` messages are ephemeral and must not shift the
+  // parent-hash offsets - see ConversationLinker.filterConversationMessages
+  const conversationMessages = ConversationLinker.filterConversationMessages(messages)
+
+  if (conversationMessages.length === 0) {
+    throw new Error('Cannot extract hashes from empty messages array')
+  }
+
   // Hash messages only (no system) for conversation linking
-  const currentMessageHash = hashMessagesOnly(messages)
+  const currentMessageHash = hashMessagesOnly(conversationMessages)
 
   // Hash system separately for tracking context changes
   const systemHash = hashSystemPrompt(system)
@@ -264,18 +309,18 @@ export function extractMessageHashes(
   // If we have 1-2 messages, this is likely a new conversation
   let parentMessageHash: string | null = null
 
-  if (messages.length === 1) {
+  if (conversationMessages.length === 1) {
     // First message in conversation, no parent
     parentMessageHash = null
-  } else if (messages.length === 2) {
+  } else if (conversationMessages.length === 2) {
     // This shouldn't happen in normal Claude conversations (should be user -> assistant -> user)
     // But handle it anyway - parent would be first message only
-    parentMessageHash = hashMessagesOnly(messages.slice(0, 1))
+    parentMessageHash = hashMessagesOnly(conversationMessages.slice(0, 1))
   } else {
     // Normal case: we have at least 3 messages
     // The parent request would have had all messages except the last 2
     // (removing the most recent user message and the assistant response before it)
-    parentMessageHash = hashMessagesOnly(messages.slice(0, -2))
+    parentMessageHash = hashMessagesOnly(conversationMessages.slice(0, -2))
   }
 
   return { currentMessageHash, parentMessageHash, systemHash }

--- a/packages/shared/src/utils/conversation-linker.ts
+++ b/packages/shared/src/utils/conversation-linker.ts
@@ -141,8 +141,17 @@ export class ConversationLinker {
     }
 
     try {
+      // Work from the durable transcript only - injected `role: 'system'` messages are
+      // ephemeral and would otherwise shift the parent-hash offsets (see
+      // ConversationLinker.filterConversationMessages).
+      const conversationMessages = ConversationLinker.filterConversationMessages(messages)
+
+      if (conversationMessages.length === 0) {
+        throw new Error('Cannot compute hash: no user or assistant messages in request')
+      }
+
       // Compute hashes with error handling
-      const currentMessageHash = this.computeMessageHash(messages)
+      const currentMessageHash = this.computeMessageHash(conversationMessages)
 
       // Convert system prompt to string if it's an array
       let systemPromptStr: string | undefined
@@ -163,21 +172,25 @@ export class ConversationLinker {
           currentMessageHash,
           systemHash,
           messageCount: messages.length,
+          conversationMessageCount: conversationMessages.length,
         },
       })
 
       // Case 1: Single message handling
-      if (messages.length === 1) {
+      if (conversationMessages.length === 1) {
         this.logger.debug('Processing single message', {
           projectId,
           metadata: {
             ...traceMeta,
-            messageRole: messages[0].role,
+            messageRole: conversationMessages[0].role,
           },
         })
 
         // Check for subtask first
-        const subtaskResult = await this.detectSubtask(request, traceMeta)
+        const subtaskResult = await this.detectSubtask(
+          { ...request, messages: conversationMessages },
+          traceMeta
+        )
         if (
           subtaskResult.isSubtask &&
           subtaskResult.parentTaskRequestId &&
@@ -222,7 +235,7 @@ export class ConversationLinker {
           }
         }
 
-        const compactInfo = this.detectCompactConversation(messages[0])
+        const compactInfo = this.detectCompactConversation(conversationMessages[0])
         if (compactInfo) {
           this.logger.debug('Detected compact conversation', {
             projectId,
@@ -287,13 +300,14 @@ export class ConversationLinker {
 
       // Case 2: Multiple messages - check if we can compute parent hash
       // First deduplicate to see how many unique messages we have
-      const deduplicatedMessages = this.deduplicateMessages(messages)
+      const deduplicatedMessages = this.deduplicateMessages(conversationMessages)
 
       this.logger.debug('Processing multiple messages', {
         projectId,
         metadata: {
           ...traceMeta,
           originalCount: messages.length,
+          conversationCount: conversationMessages.length,
           deduplicatedCount: deduplicatedMessages.length,
         },
       })
@@ -609,6 +623,28 @@ export class ConversationLinker {
     }
   }
 
+  /**
+   * Keeps only messages that are part of the durable conversation transcript.
+   *
+   * Claude Code injects `role: 'system'` messages into the `messages` array to carry
+   * ephemeral context (system-reminders, hook output, tool nudges). They are volatile
+   * in three ways that break prefix hashing:
+   *  - they appear and disappear between turns, so a turn can grow by 3 messages
+   *    instead of the 2 the parent-hash offset assumes;
+   *  - the same reminder is sent as a plain string in one request and as a content
+   *    block array (with `cache_control`) in the next;
+   *  - their text changes even when the conversation has not.
+   *
+   * Excluding them keeps `currentMessageHash` stable across requests, which is what
+   * lets a request find its parent.
+   *
+   * @param messages - Raw messages from the request
+   * @returns Only the user/assistant messages, in order
+   */
+  public static filterConversationMessages(messages: ClaudeMessage[]): ClaudeMessage[] {
+    return messages.filter(message => message?.role === 'user' || message?.role === 'assistant')
+  }
+
   public computeMessageHash(messages: ClaudeMessage[]): string {
     try {
       const hash = createHash('sha256')
@@ -617,8 +653,9 @@ export class ConversationLinker {
         throw new Error('Cannot compute hash for empty messages array')
       }
 
-      // Deduplicate messages first
-      const deduplicatedMessages = this.deduplicateMessages(messages)
+      // Drop injected system messages, then deduplicate
+      const conversationMessages = ConversationLinker.filterConversationMessages(messages)
+      const deduplicatedMessages = this.deduplicateMessages(conversationMessages)
 
       for (const message of deduplicatedMessages) {
         if (!message || !message.role) {
@@ -684,8 +721,20 @@ export class ConversationLinker {
   }
 
   private normalizeStringContent(content: string): string {
-    // Normalize string content to match array format for consistency
-    return `[0]text:${content.trim().replace(/\r\n/g, '\n')}`
+    // Normalize string content to match array format for consistency.
+    // System-reminders must be stripped here too: Claude Code sends the same
+    // reminder as a plain string in one request and as a content block array in
+    // the next, and the array path already strips them (filterSystemReminders +
+    // serializeTextItem). Without this, the two representations hash differently.
+    const cleanText = stripSystemReminder(content).trim().replace(/\r\n/g, '\n')
+
+    // An all-reminder string collapses to nothing, matching the array path where
+    // every block gets filtered out and serialization yields an empty string.
+    if (cleanText.length === 0) {
+      return ''
+    }
+
+    return `[0]text:${cleanText}`
   }
 
   private filterSystemReminders(content: ClaudeContent[]): ClaudeContent[] {

--- a/packages/shared/src/utils/conversation-linker.ts
+++ b/packages/shared/src/utils/conversation-linker.ts
@@ -655,6 +655,13 @@ export class ConversationLinker {
 
       // Drop injected system messages, then deduplicate
       const conversationMessages = ConversationLinker.filterConversationMessages(messages)
+
+      // Guard the invariant that a hash always covers at least one real message -
+      // otherwise every all-system request would share the hash of an empty input.
+      if (conversationMessages.length === 0) {
+        throw new Error('Cannot compute hash: no user or assistant messages in request')
+      }
+
       const deduplicatedMessages = this.deduplicateMessages(conversationMessages)
 
       for (const message of deduplicatedMessages) {

--- a/scripts/aws-bedrock-cost-report.ts
+++ b/scripts/aws-bedrock-cost-report.ts
@@ -267,6 +267,19 @@ const MODEL_PRICING: readonly ModelPricingEntry[] = [
     },
   },
   {
+    // Bedrock ID: anthropic.claude-opus-5 — same $5/$25 per MTok tier as Opus 4.7/4.8
+    alias: 'claude-opus-5',
+    displayName: 'Claude Opus 5',
+    matchers: ['opus-5'],
+    regions: {
+      global: {
+        standard: { inputPerThousand: 0.005, outputPerThousand: 0.025 },
+        cacheReadPerThousand: 0.0005,
+        cacheWritePerThousand: 0.00625,
+      },
+    },
+  },
+  {
     alias: 'claude-opus-4-8',
     displayName: 'Claude Opus 4.8',
     matchers: ['opus', '4-8'],


### PR DESCRIPTION
## Problem

Two dashboard signals broke as Claude Code and the Anthropic model lineup moved on.

### 1. Context gauge ("battery") showed 300%+

`claude-opus-5` had **no rule** in `MODEL_CONTEXT_RULES`, so the lookup fell through to the 200k default while real Opus 5 contexts reach ~780k tokens.

```
model                       max context observed   limit used   displayed
claude-opus-5                          784,238        200,000        392%
```

The same registry staleness hit `model-pricing.ts`: Opus 5 matched no rule and fell back to `DEFAULT_MODEL_PRICING` (Sonnet-tier **$3/$15** instead of **$5/$25**), understating costs on ~1.9k requests/week.

### 2. One Claude Code session produced many 1-2 request conversations

Claude Code 2.1 injects **`role: 'system'` messages into the `messages` array** to carry ephemeral context (system-reminders, `SessionStart` hook output, tool nudges). They are volatile in three ways, each of which breaks the prefix hashing that links a request to its parent:

| Symptom | Effect on linking |
|---|---|
| Injected/removed between turns | A turn grows the array by **3** messages, but `parentMessageHash = messages.slice(0, -2)` assumes 2 |
| Same reminder sent as a plain **string** in one request and a **content block array** (with `cache_control`) in the next | Only the array path stripped `<system-reminder>`; the string path hashed the full 6kB reminder → prefix mismatch |
| Reminder text changes without the conversation changing | Hash changes anyway |

Confirmed on live data — the same `system` message, one request apart, normalizing two different ways:

```
PREV[1] role=system norm=""
TARG[1] role=system norm="[0]text:<system-reminder>\nThe following skills are available..."
```

Over 3 days: **4,435 single-request conversations**, 3,663 of which had no parent hash at all. Subtask detection was also dead, because it only runs when a request has exactly one message and a subagent's first request is now `[user, system]`.

Separately, the `x-anthropic-billing-header: cc_version=…` block Claude Code now prepends to the system prompt made `system_hash` churn on every Claude Code release, so the priority-i (message + system) parent match almost always missed and fell through to the hash-only fallback.

## Fix

**Conversation linking** (`packages/shared/src/utils/`)
- `ConversationLinker.filterConversationMessages()` — hash the durable transcript only (`user`/`assistant`). Applied before hashing, before the parent/grandparent offset arithmetic, and before single-message compact/subtask detection, which restores subtask linking.
- `normalizeStringContent()` — strip `<system-reminder>` blocks and collapse to an empty string when nothing remains, so string and content-block forms of the same message hash identically.
- `getStableSystemPrompt()` — drop the `x-anthropic-billing-header:` prelude, recognise the new Claude Code prompt markers (`You are Claude Code, …`, `You are an agent for Claude Code, …`), and truncate the whole `gitStatus:` tail instead of only its first paragraph.

**Model registries** (`packages/shared/src/constants/`)
- Context rules for Claude Opus 5 and Mythos Preview (1M), verified against [the models overview](https://platform.claude.com/docs/en/about-claude/models/overview).
- `inferContextLimitByGeneration()` — safety net so the *next* model release can't silently inherit 200k: an unrecognised `claude-<family>-<n>` with `n >= 5` is treated as 1M (200k for Haiku) and flagged `isEstimate: true`.
- Pricing rules for Opus 5 ($5/$25) and Mythos Preview (Fable 5 rates), plus an Opus 5 entry in `scripts/aws-bedrock-cost-report.ts`, which maintains its own table.

## Verification

Replaying 10 hours of real production request bodies through the shipped code:

```
project              n     BEFORE linked        AFTER linked
alan-personal      524     348 (66.4%)          496 (94.7%)
alan-msi           220     179 (81.4%)          206 (93.6%)
ocl-privacy        214     163 (76.2%)          192 (89.7%)
TOTAL              958     690 (72.0%)          894 (93.3%)
Conversations created: 268 -> 64 (76% fewer)
```

### Does a real session actually become one conversation?

Replaying real request bodies through the actual `ConversationLinker`, with an in-memory store
mirroring `writer.findParentRequests` semantics (no project filter, `ORDER BY timestamp DESC LIMIT 100`).
Sessions are grouped by their first user message, then compared: how many `conversation_id`s does the
session have in the DB today, versus after the fix?

```
alan-msi, last 72h - 1744 requests, 72 sessions
  reqs   DB convs   SIM convs   max msgs
   392         53           1        665
   177         24           1        321
   142         18           1        281
   121         17           1        237
    97         16           1        155
All 72 sessions: DB 301 conversations -> simulated 74

alan-personal, last 24h - 556 requests, 30 sessions (mostly subagent traffic)
  reqs   DB convs   SIM convs   max msgs
   170         33           1        379
    60         19           1        119
    41         13           1         81
    36         12           1         71
All 30 sessions: DB 187 conversations -> simulated 30
```

Every session collapses to exactly **one** conversation. The worst case today — a 392-request,
665-message session shattered into **53** conversations — becomes 1.

This simulation is a conservative floor: compact-conversation search and subtask detection were
disabled in it, and both only ever *add* links. In production, subagent sessions additionally attach
to their parent as `subtask_N` branches.

### Do two separate conversations ever get merged by mistake?

Excluding injected `system` messages makes hashing *more* permissive, so the inverse property
needs checking too. Ground truth here is derived independently of linking: a resumable Claude
transcript can only relate to another by **prefix containment**, so a rolling hash chain (digest
after each message) plus union-find yields the real conversation trees. A **false merge** is one
`conversation_id` containing two requests with no prefix relation between them.

```
                                 trees   convs   false merges   over-splits
alan-msi,      72h (1630 reqs)
  before (DB)                       54     269              0            22
  after  (this PR)                  54      55              0             1
alan-personal, 24h (614 reqs)
  before (DB)                       32     201              0            23
  after  (this PR)                  32      32              0             0
```

No merging in either direction. alan-personal lands on exactly its 32 real trees; alan-msi still
over-splits one chain, so the linker stays conservative rather than over-eager.

**The one case this ground truth cannot see** is two sessions whose transcript is byte-identical up
to a divergence point (the same subagent prompt launched twice) — they are one tree by construction.
This is also the only place discrimination genuinely drops, since the volatile injected system
message previously acted as an accidental salt. Measured separately by grouping requests on their
opening-message digest and looking for groups that share an opening but then diverge:

```
alan-personal, 24h: 613 requests, 32 distinct openings, 27 shared by >1 request -> 0 ambiguous
alan-msi,      72h: 1630 requests, 54 distinct openings, 32 shared by >1 request -> 0 ambiguous
```

Zero across 2,243 requests. Rather than rely on that, the behaviour is pinned in
`Conversation isolation` tests: a request whose prefix matches nothing stays a new conversation,
transcripts differing only in user *or* assistant content keep distinct hashes, and a divergence
from an identical opening opens a `branch_` instead of being appended to the other chain.

Residual, stated plainly: two sessions with a byte-identical prefix are indistinguishable to
hash-based tracking **by design** (ADR-003 — there is no session id to fall back on). The outcome is
one conversation with two visible branches, not a scrambled chain.

Context gauge over 3 days of traffic — no request exceeds 100% any more:

```
model                       limit     estimate   requests   >100%   max%
claude-opus-5             1000000        false       2397       0   78.4
claude-opus-4-8           1000000        false      10416       0   77.1
claude-sonnet-5           1000000        false       4249       0   25.4
```

- **21 new/updated tests.** 13 of the 15 new linking/system-prompt tests fail against the pre-fix code (the other 2 are controls).
- `bun run typecheck`, `format:check`, `lint` (0 errors), `test:ci` (415 pass / 0 fail) all green.
- Full `bun test` shows the same 14 pre-existing environmental failures as `main` (Docker E2E, integration suites needing running services, DB pool) — no new failures.
- `scripts/db/rebuild-conversations.ts` verified in dry-run mode against the live DB with the new logic.

## Scope notes

- **`message_count` semantics are unchanged** (it still counts every message, including injected ones), because `conversation-graph.ts` uses `messageCount === 1` as a branch-root heuristic.
- **Fix-forward only.** Requests already stored keep their fragmented `conversation_id`; run `bun run scripts/db/rebuild-conversations.ts --execute` to re-link historical data.
- **Not included:** Sonnet 5's introductory $2/$10 pricing (in effect through 2026-08-31). It needs date-aware pricing, so it ships separately in #204.

## Docs

- [ADR-003](docs/04-Architecture/ADRs/adr-003-conversation-tracking.md) — new "Injected `system` Messages Excluded from Hashing (2026-07-25)" section documenting the wire-format change and its consequences.
- [ADR-035](docs/04-Architecture/ADRs/adr-035-model-pricing-registry-and-fallback-cost-attribution.md) — pricing/context rule lists updated.
- [internals.md](docs/04-Architecture/internals.md) — the hashing and linking pseudocode was materially wrong (hashed only the last message, no reminder handling); rewritten to match the implementation.
- [changelog.md](docs/06-Reference/changelog.md) — entries under Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
