### PR TITLE
feat: coordinate Anthropic account rate limits across proxy instances

### DIFF
--- a/docs/02-User-Guide/authentication.md
+++ b/docs/02-User-Guide/authentication.md
@@ -395,16 +395,19 @@ When a project has **2 or more linked accounts**, the proxy automatically enable
 
 ### How It Works
 
-1. **Sticky routing**: The proxy sticks to the current account for a project until its utilization exceeds the configured threshold
-2. **Usage monitoring**: The proxy checks both the 5-hour and 7-day utilization windows via the Anthropic OAuth usage API (cached for 60 seconds)
-3. **Automatic switching**: When the current account exceeds its threshold in either window, the proxy switches to the least-loaded available account
-4. **Exhaustion handling**: If all accounts exceed their thresholds, the proxy returns HTTP 429 with an estimated reset time
+1. **Sticky routing**: PostgreSQL shares project affinity across all proxy instances
+2. **Usage monitoring**: One cluster-wide refresh per account caches Anthropic usage for five minutes
+3. **Automatic switching**: The proxy switches at 90% five-hour/session usage or 95% seven-day/weekly usage
+4. **Reactive failover**: An upstream 429 cools down that account/model and immediately tries one different pooled account
+5. **Exhaustion handling**: If no account remains, the proxy returns HTTP 429 with a `Retry-After` value based on upstream reset information
 
 ### Per-Account Threshold
 
-Each account has a `token_limit_threshold` (default: 95%) that controls when switching occurs. The threshold is stored in the `credentials` table and can be configured per account.
+Each account has `five_hour_limit_threshold` (default: 90%) and
+`seven_day_limit_threshold` (default: 95%) values in the `credentials` table.
 
-When either the 5-hour or 7-day utilization exceeds this threshold, the account is considered over-limit and the pool selects an alternative.
+Session limits use the five-hour threshold. Weekly and model-scoped weekly
+limits use the seven-day threshold.
 
 ### Pool Activation
 

--- a/docs/04-Architecture/ADRs/adr-031-account-pool-auto-switching.md
+++ b/docs/04-Architecture/ADRs/adr-031-account-pool-auto-switching.md
@@ -39,12 +39,14 @@ Add an `AccountPoolService` that automatically selects the best account from a p
 ### Key Design Decisions
 
 - **Usage source**: Anthropic OAuth usage API (`/api/oauth/usage`) — returns real utilization percentages for 5h and 7d windows, plus a structured `limits[]` array with model-scoped weekly limits (e.g. a separate Claude Fable 5 allowance)
-- **Trigger**: Switch when EITHER the 5-hour OR 7-day utilization exceeds the per-account threshold, or (amended 2026-07-05) when an active model-scoped limit matching the requested model exceeds the threshold — scoped limits gate only requests for that model, so a saturated Fable limit never blocks Sonnet/Opus traffic
-- **Threshold config**: Per-account `token_limit_threshold` column in `credentials` table (0-1 scale, default 0.95; raised from 0.80 on 2026-07-24 via migration 024)
+- **Trigger**: Switch at 90% five-hour/session utilization or 95% seven-day/weekly utilization. Active model-scoped weekly limits gate only requests for that model, so a saturated Fable limit never blocks Sonnet/Opus traffic.
+- **Threshold config**: Per-account `five_hour_limit_threshold` and `seven_day_limit_threshold` columns in `credentials` (0-1 scale, defaults 0.90 and 0.95). The legacy `token_limit_threshold` remains for rolling-deployment compatibility.
 - **Selection strategy**: Sticky least-loaded — stay on current account until threshold exceeded, then switch to least-loaded alternative
-- **Exhaustion behavior**: Return HTTP 429 with `estimated_reset` from `resets_at` and `Retry-After` header
+- **Reactive failover**: An upstream account-level 429 starts a shared credential/model cooldown and triggers one immediate attempt on a different eligible pooled account. The same credential is not retried.
+- **Exhaustion behavior**: Return HTTP 429 with reset information from `Retry-After`, Anthropic rate-limit reset headers, or cached usage `resets_at`
 - **Pool activation**: Implicit — projects with 2+ linked Anthropic accounts use the pool; 0-1 accounts use default account directly
 - **Bedrock accounts**: Excluded from pool (OAuth usage API is Anthropic-only)
+- **Coordination**: PostgreSQL stores affinity, model cooldowns, and in-flight counts across proxy instances; see [ADR-036](./adr-036-postgresql-account-pool-coordination.md)
 
 ### Implementation Details
 
@@ -54,11 +56,10 @@ Add an `AccountPoolService` that automatically selects the best account from a p
 selectAccount(projectId):
   1. Get linked credentials, filter to Anthropic only
      - If < 2 Anthropic accounts -> use default account (no pooling)
-  2. Check sticky account (in-memory map per project)
-     - If sticky is under threshold -> return immediately (fast path)
-  3. Fetch usage for ALL Anthropic accounts in parallel
-     - Filter to accounts under their threshold
-     - Pick lowest utilization -> set as new sticky
+  2. Read shared usage for all eligible Anthropic accounts in parallel
+     - Filter to accounts under both window-specific thresholds
+  3. Atomically reserve an account using shared affinity, cooldowns, utilization,
+     and in-flight counts
   4. If all over threshold -> throw AccountPoolExhaustedError (HTTP 429)
 ```
 
@@ -66,10 +67,12 @@ selectAccount(projectId):
 
 ```sql
 ALTER TABLE credentials
-  ADD COLUMN token_limit_threshold DECIMAL(3,2) NOT NULL DEFAULT 0.80;
+  ADD COLUMN five_hour_limit_threshold DECIMAL(3,2) NOT NULL DEFAULT 0.90,
+  ADD COLUMN seven_day_limit_threshold DECIMAL(3,2) NOT NULL DEFAULT 0.95;
 ```
 
-> Amended 2026-07-24 (migration 024): the column default was raised to `0.95`, and existing accounts still at the old `0.80` default were migrated to `0.95`.
+> The original `token_limit_threshold` was raised to `0.95` by migration 024.
+> Migration 025 supersedes it with separate five-hour and seven-day gates.
 
 **AuthenticationService integration:**
 
@@ -82,13 +85,15 @@ authenticate(context):
 
 ### Files
 
-| File                                                                 | Description                                   |
-| -------------------------------------------------------------------- | --------------------------------------------- |
-| `services/proxy/src/services/account-pool-service.ts`                | Core pool selection logic with sticky routing |
-| `services/proxy/src/services/AuthenticationService.ts`               | Delegates to AccountPoolService               |
-| `services/proxy/src/controllers/MessageController.ts`                | Handles AccountPoolExhaustedError as 429      |
-| `scripts/db/migrations/018-account-pool-threshold.ts`                | Adds `token_limit_threshold` column           |
-| `scripts/db/migrations/024-update-account-pool-threshold-default.ts` | Raises default threshold from 0.80 to 0.95    |
+| File                                                                 | Description                                 |
+| -------------------------------------------------------------------- | ------------------------------------------- |
+| `services/proxy/src/services/account-pool-service.ts`                | Core threshold and account selection logic  |
+| `services/proxy/src/services/account-pool-state-service.ts`          | PostgreSQL coordination and cooldown state  |
+| `services/proxy/src/services/AuthenticationService.ts`               | Delegates to AccountPoolService             |
+| `services/proxy/src/controllers/MessageController.ts`                | Handles AccountPoolExhaustedError as 429    |
+| `scripts/db/migrations/018-account-pool-threshold.ts`                | Adds `token_limit_threshold` column         |
+| `scripts/db/migrations/024-update-account-pool-threshold-default.ts` | Raises legacy threshold from 0.80 to 0.95   |
+| `scripts/db/migrations/025-cluster-account-pool-coordination.ts`     | Shared state and separate window thresholds |
 
 ## Consequences
 
@@ -102,7 +107,7 @@ authenticate(context):
 ### Negative
 
 - Depends on Anthropic OAuth usage API availability
-- In-memory sticky state is lost on process restart (acceptable — re-selects on next request)
+- Selection now performs lightweight PostgreSQL coordination operations
 - Only works for Anthropic accounts (Bedrock has no equivalent usage API)
 
 ### Risks and Mitigations
@@ -110,11 +115,12 @@ authenticate(context):
 - **Risk**: Anthropic usage API rate limits
   - **Mitigation**: Addressed by [ADR-032](./adr-032-centralized-usage-cache.md) with shared caching and extrapolation
 - **Risk**: Usage API returns stale data
-  - **Mitigation**: Configurable threshold (95% default) provides headroom before hard limits
+  - **Mitigation**: The 90% five-hour and 95% seven-day gates provide headroom before hard limits
 
 ## Links
 
 - [ADR-032: Centralized Usage Cache](./adr-032-centralized-usage-cache.md)
+- [ADR-036: PostgreSQL Account Pool Coordination](./adr-036-postgresql-account-pool-coordination.md)
 - [ADR-030: Multi-Provider Support](./adr-030-multi-provider-support.md)
 
 ---

--- a/docs/04-Architecture/ADRs/adr-032-centralized-usage-cache.md
+++ b/docs/04-Architecture/ADRs/adr-032-centralized-usage-cache.md
@@ -18,7 +18,7 @@ With multiple accounts and frequent requests, this hammers the Anthropic usage e
 - **API call reduction**: Minimize calls to Anthropic usage endpoint (~60x reduction target)
 - **Rate limit resilience**: Graceful degradation when API is unavailable
 - **Dashboard freshness**: Users need to know when data was last checked and whether it's estimated
-- **Simplicity**: In-memory caching, no external dependencies
+- **Simplicity**: Reuse PostgreSQL rather than introduce another dependency
 
 ## Considered Options
 
@@ -27,27 +27,35 @@ With multiple accounts and frequent requests, this hammers the Anthropic usage e
    - Pros: Minimal code change
    - Cons: Two caches still make independent API calls; no deduplication
 
-2. **Shared centralized cache (selected)**
+2. **Process-local centralized cache (initially selected)**
    - Description: Single UsageCacheService shared by both consumers
    - Pros: Single source of truth, deduplication, background refresh, extrapolation
    - Cons: More code, new service to maintain
 
-3. **External cache (Redis)**
+3. **PostgreSQL-coordinated cache (selected for multi-instance deployments)**
+   - Description: Store successful usage, refresh leases, and backoff in PostgreSQL
+   - Pros: Cross-instance deduplication using an existing required dependency
+   - Cons: Adds lightweight database operations to cache access
+
+4. **External cache (Redis)**
    - Description: Use Redis for cross-process caching
    - Pros: Survives restarts, works across instances
    - Cons: New dependency, overkill for single-process deployment
 
 ## Decision
 
-Extract usage fetching and caching into a single `UsageCacheService` singleton shared by both the account pool and dashboard API route.
+Keep a single `UsageCacheService` API shared by the account pool and dashboard,
+but coordinate durable state and refresh leases through PostgreSQL as described
+in [ADR-036](./adr-036-postgresql-account-pool-coordination.md).
 
 ### Key Design Decisions
 
 - **5-minute cache TTL** with background refresh at 80% (4 minutes)
-- **In-flight request deduplication**: `Map<string, Promise>` ensures at most 1 concurrent API call per credential
+- **Cluster-wide refresh deduplication**: a PostgreSQL lease ensures at most one OAuth usage call per credential across all proxy instances
 - **Rate-limit-aware extrapolation**: On API failure with previous data, estimate `lastValue + (elapsedMinutes / 10) * 2`, capped at 100
-- **Force refresh with 30s cooldown**: Dashboard manual refresh bypasses cache but respects cooldown
-- **Lazy evaluation in AccountPoolService**: Check sticky account first (1 cache lookup), only fetch all accounts when sticky exceeds threshold
+- **Failure backoff**: retain stale data and set `next_refresh_at` with exponential backoff and jitter
+- **Force refresh with 30s cooldown**: Dashboard manual refresh bypasses the normal TTL but respects a cluster-wide cooldown
+- **Parallel shared reads in AccountPoolService**: Evaluate all eligible accounts from hot/shared data before reserving the best account
 - **Uses existing `AnthropicOAuthUsageResponse` type** from `packages/shared` to preserve all windows including `extra_usage`
 
 ### Implementation Details
@@ -58,8 +66,8 @@ Extract usage fetching and caching into a single `UsageCacheService` singleton s
 AccountPoolService ──┐
                      ├──→ UsageCacheService ──→ Anthropic API
 Dashboard API route ─┘         │
-                          In-memory cache
-                          (5 min TTL, background refresh)
+                          PostgreSQL shared state
+                          + process-local hot cache
 ```
 
 **Cache entry shape:**
@@ -70,6 +78,8 @@ interface CachedUsageEntry {
   fetchedAt: number
   isEstimated: boolean
   lastSuccessfulUsage?: AnthropicOAuthUsageResponse
+  nextRefreshAt?: number
+  failureCount?: number
 }
 ```
 
@@ -79,25 +89,29 @@ interface CachedUsageEntry {
 getUsage(credential)
   ├─ Cache hit & age < 4 min (fresh) → return immediately
   ├─ Cache hit & age 4-5 min (stale) → return cached + background refresh
-  └─ Cache miss or age > 5 min → blocking fetch (deduplicated)
+  └─ Cache miss or age > 5 min → claim shared refresh lease
+       ├─ Lease held elsewhere → serve stale shared data
+       └─ Lease acquired → fetch from Anthropic
        ├─ Success → cache with isEstimated=false
-       └─ Failure + has lastSuccessfulUsage → extrapolate (isEstimated=true)
+       └─ Failure + has lastSuccessfulUsage → extrapolate and back off (isEstimated=true)
        └─ Failure + no previous data → return null (conservative)
 ```
 
-**Extrapolation behavior during extended outage:** Values increase toward 100% cap. An account at 50% reaches the 80% default threshold after ~2.5 hours. Once the API recovers, the next successful fetch replaces extrapolated data. `extra_usage` (billing data) is never extrapolated.
+**Extrapolation behavior during extended outage:** Values increase toward the 100% cap. An account at 50% reaches the 90% five-hour threshold after about 3 hours 20 minutes. Once the API recovers, the next successful fetch replaces extrapolated data. `extra_usage` (billing data) is never extrapolated.
 
 **Dashboard changes:** The Token Usage page shows relative time ("3 minutes ago"), an "estimated" badge when rate-limited, and a manual refresh button per account.
 
 ### Constants
 
-| Constant                       | Value           | Purpose                                   |
-| ------------------------------ | --------------- | ----------------------------------------- |
-| `USAGE_CACHE_TTL_MS`           | 300,000 (5 min) | Cache entry staleness threshold           |
-| `BACKGROUND_REFRESH_THRESHOLD` | 0.8 (4 min)     | When to trigger async background refresh  |
-| `EXTRAPOLATION_RATE_PER_10MIN` | 2               | Percentage increase per 10 minutes        |
-| `EXTRAPOLATION_CAP`            | 100             | Maximum extrapolated utilization          |
-| `FORCE_REFRESH_COOLDOWN_MS`    | 30,000 (30s)    | Minimum interval between manual refreshes |
+| Constant                       | Value            | Purpose                                   |
+| ------------------------------ | ---------------- | ----------------------------------------- |
+| `USAGE_CACHE_TTL_MS`           | 300,000 (5 min)  | Cache entry staleness threshold           |
+| `BACKGROUND_REFRESH_AT_MS`     | 240,000 (4 min)  | When to trigger async background refresh  |
+| `EXTRAPOLATION_RATE_PER_10MIN` | 2                | Percentage increase per 10 minutes        |
+| `EXTRAPOLATION_CAP`            | 100              | Maximum extrapolated utilization          |
+| `FORCE_REFRESH_COOLDOWN_MS`    | 30,000 (30s)     | Minimum interval between manual refreshes |
+| `FAILURE_BACKOFF_BASE_MS`      | 30,000 (30s)     | Initial failed-refresh backoff            |
+| `FAILURE_BACKOFF_MAX_MS`       | 900,000 (15 min) | Maximum failed-refresh backoff            |
 
 ### Files
 
@@ -118,12 +132,12 @@ getUsage(credential)
 - ~60x fewer API calls to Anthropic usage endpoint
 - Graceful degradation via extrapolation instead of failure on rate limits
 - Dashboard shows data freshness and estimation status
-- No new external dependencies (pure in-memory)
+- No new external service dependency
 - Background refresh keeps data fresh without blocking requests
 
 ### Negative
 
-- Cache is lost on process restart (acceptable — rebuilds within 5 minutes)
+- Each cache access performs a small shared-state lookup after the local hot entry becomes stale
 - Extrapolated values may diverge from reality during long outages (mitigated by conservative cap at 100%)
 
 ### Risks and Mitigations
@@ -136,6 +150,7 @@ getUsage(credential)
 ## Links
 
 - [ADR-031: Account Pool Auto-Switching](./adr-031-account-pool-auto-switching.md)
+- [ADR-036: PostgreSQL Account Pool Coordination](./adr-036-postgresql-account-pool-coordination.md)
 
 ---
 

--- a/docs/04-Architecture/ADRs/adr-036-postgresql-account-pool-coordination.md
+++ b/docs/04-Architecture/ADRs/adr-036-postgresql-account-pool-coordination.md
@@ -1,0 +1,83 @@
+# ADR-036: PostgreSQL Account Pool Coordination
+
+## Status
+
+Accepted
+
+## Context
+
+The proxy runs multiple service instances, but account-pool affinity, OAuth usage
+caching, refresh deduplication, cooldowns, and request counts were process-local.
+Each instance therefore polled Anthropic independently and could continue routing
+requests to an account that another instance had just observed returning HTTP 429.
+The generic retry policy also retried that same credential after short local
+delays, even when Anthropic supplied a longer `Retry-After` value.
+
+## Decision
+
+Use PostgreSQL, which is already required by the proxy, as the coordination plane
+for account-pool runtime state.
+
+The database stores:
+
+- the last successful OAuth usage response and its refresh schedule;
+- a short refresh lease so only one proxy instance polls an account at a time;
+- exponential failure backoff and the next allowed refresh time;
+- per-credential, per-model upstream cooldowns;
+- project-to-credential affinity; and
+- the number of requests currently using each credential.
+
+On an account-level Anthropic 429, the proxy records a model cooldown using the
+upstream `Retry-After` or rate-limit reset headers, releases the account
+reservation, and immediately tries one different eligible pooled account. The
+ordinary Claude API retry policy does not retry 429 responses on the same
+credential. If no account remains, the proxy returns HTTP 429 and preserves the
+best known reset information for the client.
+
+Usage refreshes use a 30-second PostgreSQL lease. Successful results are shared
+for five minutes. Failures retain and conservatively extrapolate the last good
+result, while scheduling the next attempt with exponential backoff and jitter.
+Manual dashboard refreshes have a cluster-wide 30-second cooldown.
+
+The utilization gates are independent: 90% for the five-hour/session window and
+95% for seven-day/weekly windows. Model-scoped weekly limits use the seven-day
+threshold.
+
+## Consequences
+
+### Positive
+
+- Adding proxy instances no longer multiplies OAuth usage polling.
+- Every instance avoids accounts that recently returned a model-specific 429.
+- Client retry behavior follows Anthropic's real reset guidance.
+- Shared affinity and in-flight counts make routing state observable and
+  consistent across instances.
+
+### Negative
+
+- Account selection and cache refresh now depend on small PostgreSQL operations.
+- The migration must be applied before deploying this proxy version.
+- PostgreSQL is a coordination store rather than a dedicated distributed cache;
+  this is acceptable at the current account and request scale.
+
+## Alternatives Considered
+
+- **Add another proxy instance only**: rejected because it multiplies usage
+  polling and does not share cooldown knowledge.
+- **Redis coordination**: rejected because PostgreSQL already provides the
+  required atomic updates and avoids another production dependency.
+- **Retry every 429 with backoff**: rejected because account quota exhaustion is
+  better handled by immediate credential rotation and the upstream reset time.
+
+## Links
+
+- [ADR-031: Account Pool Auto-Switching](./adr-031-account-pool-auto-switching.md)
+- [ADR-032: Centralized Usage Cache](./adr-032-centralized-usage-cache.md)
+- [ADR-012: Database Schema Evolution Strategy](./adr-012-database-schema-evolution.md)
+- [Anthropic API rate limits](https://platform.claude.com/docs/en/api/rate-limits)
+- [Anthropic API errors](https://platform.claude.com/docs/en/api/errors)
+
+---
+
+Date: 2026-08-13
+Authors: AI Agent

--- a/packages/shared/src/database/queries/credential-queries-internal.ts
+++ b/packages/shared/src/database/queries/credential-queries-internal.ts
@@ -36,6 +36,8 @@ function toSafeAnthropicCredential(credential: AnthropicCredential): AnthropicCr
     created_at: credential.created_at,
     updated_at: credential.updated_at,
     token_limit_threshold: credential.token_limit_threshold,
+    five_hour_limit_threshold: credential.five_hour_limit_threshold,
+    seven_day_limit_threshold: credential.seven_day_limit_threshold,
     last_refresh_at: credential.last_refresh_at,
     token_status: tokenStatus,
   }
@@ -55,6 +57,8 @@ function toSafeBedrockCredential(credential: BedrockCredential): BedrockCredenti
     created_at: credential.created_at,
     updated_at: credential.updated_at,
     token_limit_threshold: credential.token_limit_threshold,
+    five_hour_limit_threshold: credential.five_hour_limit_threshold,
+    seven_day_limit_threshold: credential.seven_day_limit_threshold,
   }
 }
 

--- a/packages/shared/src/types/credentials.ts
+++ b/packages/shared/src/types/credentials.ts
@@ -14,7 +14,10 @@ export interface BaseCredential {
   provider: ProviderType
   created_at: Date
   updated_at: Date
+  /** @deprecated Use the window-specific thresholds. */
   token_limit_threshold: number
+  five_hour_limit_threshold?: number
+  seven_day_limit_threshold?: number
 }
 
 export interface AnthropicCredential extends BaseCredential {

--- a/packages/shared/src/types/errors.ts
+++ b/packages/shared/src/types/errors.ts
@@ -67,15 +67,18 @@ export class RateLimitError extends BaseError {
 
 export class UpstreamError extends BaseError {
   public readonly upstreamResponse?: any
+  public readonly upstreamHeaders?: Record<string, string>
 
   constructor(
     message: string,
     public readonly upstreamStatus?: number,
     context?: Record<string, any>,
-    upstreamResponse?: any
+    upstreamResponse?: any,
+    upstreamHeaders?: Record<string, string>
   ) {
     super('UPSTREAM_ERROR', message, upstreamStatus || 502, context)
     this.upstreamResponse = upstreamResponse
+    this.upstreamHeaders = upstreamHeaders
   }
 }
 

--- a/packages/shared/src/utils/retry.ts
+++ b/packages/shared/src/utils/retry.ts
@@ -233,21 +233,36 @@ export const retryConfigs = {
 
 // Helper to extract retry-after header
 export function getRetryAfter(error: any): number | null {
-  if (error.response?.headers) {
-    const retryAfter = error.response.headers['retry-after']
-    if (retryAfter) {
-      // Parse as seconds
-      const seconds = parseInt(retryAfter)
-      if (!isNaN(seconds)) {
-        return seconds * 1000 // Convert to milliseconds
-      }
+  const headerSources = [error?.upstreamHeaders, error?.response?.headers, error?.context?.headers]
+  let retryAfter: string | null = null
 
-      // Parse as HTTP date
-      const date = new Date(retryAfter)
-      if (!isNaN(date.getTime())) {
-        return Math.max(0, date.getTime() - Date.now())
-      }
+  for (const headers of headerSources) {
+    if (!headers) {
+      continue
     }
+    if (typeof headers.get === 'function') {
+      retryAfter = headers.get('retry-after')
+    } else {
+      const key = Object.keys(headers).find(name => name.toLowerCase() === 'retry-after')
+      retryAfter = key ? String(headers[key]) : null
+    }
+    if (retryAfter) {
+      break
+    }
+  }
+
+  if (!retryAfter) {
+    return null
+  }
+
+  const seconds = Number(retryAfter)
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000)
+  }
+
+  const date = new Date(retryAfter)
+  if (!Number.isNaN(date.getTime())) {
+    return Math.max(0, date.getTime() - Date.now())
   }
 
   return null

--- a/scripts/db/migrations/025-cluster-account-pool-coordination.ts
+++ b/scripts/db/migrations/025-cluster-account-pool-coordination.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env bun
+
+/**
+ * Migration: Coordinate account-pool state across proxy instances.
+ *
+ * Adds independent five-hour and seven-day thresholds plus PostgreSQL-backed
+ * usage refresh leases, account/model cooldowns, project affinity, and
+ * in-flight request counters. The legacy token_limit_threshold column is kept
+ * for rolling-deployment compatibility.
+ */
+
+import { Pool } from 'pg'
+
+async function up(pool: Pool): Promise<void> {
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    await client.query(`
+      ALTER TABLE credentials
+        ADD COLUMN IF NOT EXISTS five_hour_limit_threshold DECIMAL(3,2) NOT NULL DEFAULT 0.90,
+        ADD COLUMN IF NOT EXISTS seven_day_limit_threshold DECIMAL(3,2) NOT NULL DEFAULT 0.95
+    `)
+
+    await client.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'credentials_five_hour_limit_threshold_check'
+        ) THEN
+          ALTER TABLE credentials
+            ADD CONSTRAINT credentials_five_hour_limit_threshold_check
+            CHECK (five_hour_limit_threshold > 0 AND five_hour_limit_threshold <= 1);
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'credentials_seven_day_limit_threshold_check'
+        ) THEN
+          ALTER TABLE credentials
+            ADD CONSTRAINT credentials_seven_day_limit_threshold_check
+            CHECK (seven_day_limit_threshold > 0 AND seven_day_limit_threshold <= 1);
+        END IF;
+      END $$
+    `)
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS account_pool_account_state (
+        credential_id UUID PRIMARY KEY REFERENCES credentials(id) ON DELETE CASCADE,
+        usage JSONB,
+        usage_fetched_at TIMESTAMPTZ,
+        usage_next_refresh_at TIMESTAMPTZ,
+        usage_refresh_lease_until TIMESTAMPTZ,
+        usage_failure_count INTEGER NOT NULL DEFAULT 0 CHECK (usage_failure_count >= 0),
+        usage_last_force_refresh_at TIMESTAMPTZ,
+        in_flight_requests INTEGER NOT NULL DEFAULT 0 CHECK (in_flight_requests >= 0),
+        in_flight_updated_at TIMESTAMPTZ,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `)
+
+    await client.query(`
+      ALTER TABLE account_pool_account_state
+      ADD COLUMN IF NOT EXISTS in_flight_updated_at TIMESTAMPTZ
+    `)
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS account_pool_model_cooldowns (
+        credential_id UUID NOT NULL REFERENCES credentials(id) ON DELETE CASCADE,
+        model VARCHAR(255) NOT NULL,
+        cooldown_until TIMESTAMPTZ NOT NULL,
+        reason TEXT,
+        retry_after_seconds INTEGER CHECK (retry_after_seconds IS NULL OR retry_after_seconds >= 0),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (credential_id, model)
+      )
+    `)
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_account_pool_cooldowns_active
+      ON account_pool_model_cooldowns (model, cooldown_until)
+    `)
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS account_pool_project_affinity (
+        project_id VARCHAR(255) PRIMARY KEY REFERENCES projects(project_id) ON DELETE CASCADE,
+        credential_id UUID NOT NULL REFERENCES credentials(id) ON DELETE CASCADE,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `)
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_account_pool_affinity_credential
+      ON account_pool_project_affinity (credential_id)
+    `)
+
+    await client.query('COMMIT')
+    console.log('✅ Cluster account-pool coordination schema created successfully')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('❌ Failed to create cluster account-pool coordination schema:', error)
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+async function down(pool: Pool): Promise<void> {
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+    await client.query('DROP TABLE IF EXISTS account_pool_project_affinity')
+    await client.query('DROP TABLE IF EXISTS account_pool_model_cooldowns')
+    await client.query('DROP TABLE IF EXISTS account_pool_account_state')
+    await client.query(`
+      ALTER TABLE credentials
+        DROP CONSTRAINT IF EXISTS credentials_five_hour_limit_threshold_check,
+        DROP CONSTRAINT IF EXISTS credentials_seven_day_limit_threshold_check,
+        DROP COLUMN IF EXISTS five_hour_limit_threshold,
+        DROP COLUMN IF EXISTS seven_day_limit_threshold
+    `)
+    await client.query('COMMIT')
+    console.log('✅ Cluster account-pool coordination schema removed successfully')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('❌ Failed to remove cluster account-pool coordination schema:', error)
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    console.error('❌ DATABASE_URL environment variable is required')
+    process.exit(1)
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl })
+
+  try {
+    const action = process.argv[2] || 'up'
+    if (action === 'up') {
+      await up(pool)
+    } else if (action === 'down') {
+      await down(pool)
+    } else {
+      throw new Error(`Unknown action: ${action}. Use 'up' or 'down'`)
+    }
+  } finally {
+    await pool.end()
+  }
+}
+
+if (import.meta.main) {
+  main().catch(error => {
+    console.error('❌ Migration failed:', error)
+    process.exit(1)
+  })
+}

--- a/scripts/db/migrations/README.md
+++ b/scripts/db/migrations/README.md
@@ -210,6 +210,15 @@ from `0.80` to `0.95`:
 - Migrates existing accounts still at the old `0.80` default to `0.95`
   (rows with a customized value are left untouched)
 
+### 025-cluster-account-pool-coordination.ts
+
+Adds PostgreSQL coordination for multi-instance account pooling:
+
+- separate 90% five-hour and 95% seven-day credential thresholds
+- shared successful usage data, refresh leases, and failure backoff
+- per-credential/model upstream cooldowns
+- shared project affinity and in-flight request counts
+
 ## Future Migrations
 
 When adding new migrations:

--- a/services/proxy/src/controllers/BedrockNativeController.ts
+++ b/services/proxy/src/controllers/BedrockNativeController.ts
@@ -1,6 +1,6 @@
 import { Context } from 'hono'
 import { RequestContext } from '../domain/value-objects/RequestContext.js'
-import { AuthenticationService } from '../services/AuthenticationService.js'
+import { AuthenticationService, type AuthResult } from '../services/AuthenticationService.js'
 import { BedrockApiClient } from '../services/BedrockApiClient.js'
 import { MetricsService } from '../services/MetricsService.js'
 import { extractBedrockRegion } from '@agent-prompttrain/shared/config/model-mapping'
@@ -95,9 +95,10 @@ export class BedrockNativeController {
       )
     }
 
+    let authResult: AuthResult | undefined
     try {
       // Authenticate to get Bedrock credentials
-      const authResult = await this.authService.authenticate(requestContext)
+      authResult = await this.authService.authenticate(requestContext)
 
       // Verify this is a Bedrock account
       if (authResult.provider !== 'bedrock') {
@@ -271,6 +272,10 @@ export class BedrockNativeController {
         },
         statusCode as 500
       )
+    } finally {
+      if (authResult) {
+        await this.authService.release(authResult)
+      }
     }
   }
 

--- a/services/proxy/src/controllers/GenericProxyController.ts
+++ b/services/proxy/src/controllers/GenericProxyController.ts
@@ -2,7 +2,7 @@ import { Context } from 'hono'
 import { RequestContext } from '../domain/value-objects/RequestContext.js'
 import { BedrockEmulationService } from '../services/BedrockEmulationService.js'
 import { ClaudeApiClient } from '../services/ClaudeApiClient.js'
-import { AuthenticationService } from '../services/AuthenticationService.js'
+import { AuthenticationService, type AuthResult } from '../services/AuthenticationService.js'
 import { getRequestLogger } from '../middleware/logger.js'
 
 /**
@@ -23,9 +23,10 @@ export class GenericProxyController {
     const requestContext = RequestContext.fromHono(c)
     const path = c.req.path
 
+    let authResult: AuthResult | undefined
     try {
       // Authenticate to determine provider
-      const authResult = await this.authService.authenticate(requestContext)
+      authResult = await this.authService.authenticate(requestContext)
 
       logger.info('Handling generic proxy request', {
         path,
@@ -78,6 +79,10 @@ export class GenericProxyController {
         },
         statusCode as any
       )
+    } finally {
+      if (authResult) {
+        await this.authService.release(authResult)
+      }
     }
   }
 }

--- a/services/proxy/src/controllers/MessageController.ts
+++ b/services/proxy/src/controllers/MessageController.ts
@@ -1,7 +1,12 @@
 import { Context } from 'hono'
 import { ProxyService } from '../services/ProxyService'
 import { RequestContext } from '../domain/value-objects/RequestContext'
-import { validateClaudeRequest, ValidationError, serializeError } from '@agent-prompttrain/shared'
+import {
+  validateClaudeRequest,
+  ValidationError,
+  serializeError,
+  UpstreamError,
+} from '@agent-prompttrain/shared'
 import { getRequestLogger } from '../middleware/logger'
 import { AccountPoolExhaustedError } from '../services/account-pool-service'
 
@@ -54,12 +59,16 @@ export class MessageController {
 
       // Handle account pool exhaustion with Claude API error format
       if (error instanceof AccountPoolExhaustedError) {
+        if (error.retryAfterSeconds !== null) {
+          c.header('Retry-After', String(error.retryAfterSeconds))
+        }
         return c.json(
           {
             type: 'error',
             error: {
               type: 'rate_limit_error',
               message: error.message,
+              estimated_reset: error.estimatedReset,
             },
           },
           429
@@ -69,6 +78,20 @@ export class MessageController {
       // Serialize error for response
       const errorObj = error instanceof Error ? error : new Error(String(error))
       const errorResponse = serializeError(errorObj)
+
+      if (error instanceof UpstreamError && error.upstreamHeaders) {
+        for (const [name, value] of Object.entries(error.upstreamHeaders)) {
+          const normalized = name.toLowerCase()
+          if (
+            normalized === 'retry-after' ||
+            normalized === 'request-id' ||
+            normalized === 'x-request-id' ||
+            normalized.startsWith('anthropic-ratelimit-')
+          ) {
+            c.header(name, value)
+          }
+        }
+      }
 
       // Determine status code
       let statusCode = 500

--- a/services/proxy/src/controllers/__tests__/message-controller-rate-limit.test.ts
+++ b/services/proxy/src/controllers/__tests__/message-controller-rate-limit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import { UpstreamError } from '@agent-prompttrain/shared'
+import { MessageController } from '../MessageController'
+import { AccountPoolExhaustedError } from '../../services/account-pool-service'
+
+const body = {
+  model: 'claude-sonnet-5',
+  max_tokens: 64,
+  messages: [{ role: 'user', content: 'hello' }],
+}
+
+type TestEnv = { Variables: { requestId: string; projectId: string } }
+
+function appThatThrows(error: Error): Hono<TestEnv> {
+  const proxyService = {
+    handleRequest: async () => {
+      throw error
+    },
+  }
+  const controller = new MessageController(proxyService as any)
+  const app = new Hono<TestEnv>()
+  app.use('*', async (context, next) => {
+    context.set('requestId', 'req-1')
+    context.set('projectId', 'project-1')
+    await next()
+  })
+  app.post('/v1/messages', context => controller.handle(context))
+  return app
+}
+
+describe('MessageController rate-limit headers', () => {
+  test('forwards safe Anthropic rate-limit headers to the client', async () => {
+    const app = appThatThrows(
+      new UpstreamError(
+        'rate limited',
+        429,
+        undefined,
+        { type: 'error', error: { type: 'rate_limit_error', message: 'rate limited' } },
+        {
+          'retry-after': '120',
+          'anthropic-ratelimit-requests-reset': '2027-01-01T00:00:00Z',
+          'set-cookie': 'must-not-be-forwarded',
+        }
+      )
+    )
+
+    const response = await app.request('/v1/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('retry-after')).toBe('120')
+    expect(response.headers.get('anthropic-ratelimit-requests-reset')).toBe('2027-01-01T00:00:00Z')
+    expect(response.headers.get('set-cookie')).toBeNull()
+  })
+
+  test('returns Retry-After when the shared account pool is exhausted', async () => {
+    const reset = new Date(Date.now() + 120_000).toISOString()
+    const app = appThatThrows(new AccountPoolExhaustedError('pool exhausted', reset))
+
+    const response = await app.request('/v1/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    const responseBody = (await response.json()) as any
+
+    expect(response.status).toBe(429)
+    expect(Number(response.headers.get('retry-after'))).toBeGreaterThanOrEqual(119)
+    expect(responseBody.error.estimated_reset).toBe(reset)
+  })
+})

--- a/services/proxy/src/services/AuthenticationService.ts
+++ b/services/proxy/src/services/AuthenticationService.ts
@@ -5,6 +5,7 @@ import {
   type AnthropicCredential,
   type BedrockCredential,
   type ProviderType,
+  type UpstreamError,
 } from '@agent-prompttrain/shared'
 import { RequestContext } from '../domain/value-objects/RequestContext'
 import { getApiKey } from '../credentials'
@@ -21,6 +22,14 @@ export interface AuthResult {
   accountId: string
   accountName: string
   region?: string
+  credentialId?: string
+  fromPool?: boolean
+  reserved?: boolean
+  explicitlySelected?: boolean
+}
+
+export interface AuthenticationOptions {
+  excludeCredentialIds?: string[]
 }
 
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
@@ -30,9 +39,10 @@ export class AuthenticationService {
 
   constructor(
     private readonly pool: Pool,
-    private readonly usageCacheService: UsageCacheService
+    usageCacheService?: UsageCacheService
   ) {
-    this.accountPoolService = new AccountPoolService(this.pool, this.usageCacheService)
+    const sharedUsageCache = usageCacheService ?? new UsageCacheService(pool)
+    this.accountPoolService = new AccountPoolService(this.pool, sharedUsageCache)
   }
 
   /**
@@ -40,7 +50,11 @@ export class AuthenticationService {
    *   account pool so model-scoped limits (e.g. Claude Fable 5's separate
    *   weekly allowance) gate accounts for that model only.
    */
-  async authenticate(context: RequestContext, model?: string): Promise<AuthResult> {
+  async authenticate(
+    context: RequestContext,
+    model?: string,
+    options: AuthenticationOptions = {}
+  ): Promise<AuthResult> {
     const requestedAccount = context.account
     const projectId = context.projectId
 
@@ -68,13 +82,17 @@ export class AuthenticationService {
         })
       }
 
-      return this.buildAuthResult(allCredentials.rows[0], context)
+      return this.buildAuthResult(allCredentials.rows[0], context, {
+        fromPool: false,
+        reserved: false,
+        explicitlySelected: true,
+      })
     }
 
     // Priority 2: Account pool or default account
     let selection
     try {
-      selection = await this.accountPoolService.selectAccount(projectId, model)
+      selection = await this.accountPoolService.selectAccount(projectId, model, options)
     } catch (error) {
       if (error instanceof AccountPoolExhaustedError) {
         throw error
@@ -102,24 +120,86 @@ export class AuthenticationService {
       })
     }
 
-    return this.buildAuthResult(selection.credential, context)
+    try {
+      return await this.buildAuthResult(selection.credential, context, {
+        fromPool: selection.fromPool,
+        reserved: selection.reserved,
+        explicitlySelected: false,
+      })
+    } catch (error) {
+      if (selection.reserved) {
+        try {
+          await this.accountPoolService.releaseAccount(selection.credential.id)
+        } catch (releaseError) {
+          logger.error('Failed to release reservation after authentication error', {
+            metadata: {
+              credentialId: selection.credential.id,
+              error: releaseError instanceof Error ? releaseError.message : String(releaseError),
+            },
+          })
+        }
+      }
+      throw error
+    }
+  }
+
+  async release(auth: AuthResult): Promise<void> {
+    if (auth.reserved && auth.credentialId) {
+      auth.reserved = false
+      try {
+        await this.accountPoolService.releaseAccount(auth.credentialId)
+      } catch (error) {
+        logger.error('Failed to release account-pool reservation', {
+          metadata: {
+            credentialId: auth.credentialId,
+            accountId: auth.accountId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        })
+      }
+    }
+  }
+
+  async markRateLimited(
+    auth: AuthResult,
+    model: string | undefined,
+    error: UpstreamError
+  ): Promise<string | null> {
+    if (!auth.credentialId || auth.explicitlySelected || auth.accountId === 'passthrough') {
+      return null
+    }
+    try {
+      return await this.accountPoolService.markRateLimited(auth.credentialId, model, error)
+    } catch (stateError) {
+      logger.error('Failed to persist account rate-limit cooldown', {
+        metadata: {
+          credentialId: auth.credentialId,
+          accountId: auth.accountId,
+          model: model ?? '*',
+          error: stateError instanceof Error ? stateError.message : String(stateError),
+        },
+      })
+      return null
+    }
   }
 
   private async buildAuthResult(
     credential: Credential,
-    context: RequestContext
+    context: RequestContext,
+    routing: Pick<AuthResult, 'fromPool' | 'reserved' | 'explicitlySelected'>
   ): Promise<AuthResult> {
     if (credential.provider === 'bedrock') {
-      return this.buildBedrockAuthResult(credential, context)
+      return this.buildBedrockAuthResult(credential, context, routing)
     }
 
     // Default to Anthropic when provider is missing (backwards compatibility)
-    return this.buildAnthropicAuthResult(credential, context)
+    return this.buildAnthropicAuthResult(credential, context, routing)
   }
 
   private async buildAnthropicAuthResult(
     credential: AnthropicCredential,
-    context: RequestContext
+    context: RequestContext,
+    routing: Pick<AuthResult, 'fromPool' | 'reserved' | 'explicitlySelected'>
   ): Promise<AuthResult> {
     // Get current access token (will refresh if needed)
     const accessToken = await getApiKey(credential.id, this.pool)
@@ -152,12 +232,15 @@ export class AuthenticationService {
       betaHeader: OAUTH_BETA_HEADER,
       accountId: credential.account_id,
       accountName: credential.account_name,
+      credentialId: credential.id,
+      ...routing,
     }
   }
 
   private buildBedrockAuthResult(
     credential: BedrockCredential,
-    context: RequestContext
+    context: RequestContext,
+    routing: Pick<AuthResult, 'fromPool' | 'reserved' | 'explicitlySelected'>
   ): AuthResult {
     logger.info('Using Bedrock API key credentials for account', {
       requestId: context.requestId,
@@ -180,6 +263,8 @@ export class AuthenticationService {
       accountId: credential.account_id,
       accountName: credential.account_name,
       region: credential.aws_region,
+      credentialId: credential.id,
+      ...routing,
     }
   }
 

--- a/services/proxy/src/services/ClaudeApiClient.ts
+++ b/services/proxy/src/services/ClaudeApiClient.ts
@@ -8,6 +8,7 @@ import {
   ClaudeStreamEvent,
   isClaudeError,
   getErrorMessage,
+  isRetryableError,
 } from '@agent-prompttrain/shared'
 import { logger } from '../middleware/logger'
 import { retryWithBackoff, retryConfigs } from '../utils/retry'
@@ -47,7 +48,16 @@ export class ClaudeApiClient {
     // Use retry logic for transient failures
     return retryWithBackoff(
       async () => this.makeRequest(url, request, headers),
-      retryConfigs.standard,
+      {
+        ...retryConfigs.standard,
+        // Account-level quota exhaustion is handled by ProxyService, which
+        // immediately rotates credentials once. Never sleep and retry the same
+        // credential on a 429.
+        retryCondition: error => {
+          const status = (error as UpstreamError).upstreamStatus ?? (error as any).statusCode
+          return status !== 429 && isRetryableError(error)
+        },
+      },
       { requestId: request.requestId, operation: 'claude_api_call' }
     )
   }
@@ -90,6 +100,11 @@ export class ClaudeApiClient {
           parsedError = { error: { message: errorBody, type: 'api_error' } }
         }
 
+        const upstreamHeaders: Record<string, string> = {}
+        response.headers.forEach((value, key) => {
+          upstreamHeaders[key] = value
+        })
+
         throw new UpstreamError(
           errorMessage,
           response.status,
@@ -98,7 +113,8 @@ export class ClaudeApiClient {
             status: response.status,
             body: errorBody,
           },
-          parsedError
+          parsedError,
+          upstreamHeaders
         )
       }
 

--- a/services/proxy/src/services/ProxyService.ts
+++ b/services/proxy/src/services/ProxyService.ts
@@ -10,6 +10,7 @@ import {
   generateConversationId,
   config,
   ValidationError,
+  UpstreamError,
 } from '@agent-prompttrain/shared'
 import { getProjectSlackConfig } from '@agent-prompttrain/shared/database/queries'
 import { logger } from '../middleware/logger'
@@ -163,6 +164,8 @@ export class ProxyService {
       }
     }
 
+    let activeAuth: AuthResult | undefined
+
     try {
       // Authenticate
       let auth: AuthResult
@@ -191,6 +194,7 @@ export class ProxyService {
         // model-scoped limits (e.g. Claude Fable 5's separate weekly allowance)
         auth = await this.authService.authenticate(context, rawRequest.model)
       }
+      activeAuth = auth
 
       // Bedrock accounts are not supported on /v1/messages endpoint
       // They must use the native Bedrock endpoints: /model/{modelId}/invoke
@@ -226,7 +230,41 @@ export class ProxyService {
         })
       }
 
-      const claudeResponse = await this.apiClient.forward(request, auth, clientHeaders)
+      let claudeResponse: Response
+      try {
+        claudeResponse = await this.apiClient.forward(request, auth, clientHeaders)
+      } catch (error) {
+        if (this.isUpstreamRateLimit(error)) {
+          await this.authService.markRateLimited(auth, rawRequest.model, error)
+
+          const failedCredentialId = auth.credentialId
+          await this.authService.release(auth)
+
+          if (auth.fromPool && failedCredentialId && !context.account) {
+            log.warn('Upstream account rate-limited; trying one alternate account', {
+              accountId: auth.accountId,
+              model: rawRequest.model,
+            })
+            auth = await this.authService.authenticate(context, rawRequest.model, {
+              excludeCredentialIds: [failedCredentialId],
+            })
+            activeAuth = auth
+
+            try {
+              claudeResponse = await this.apiClient.forward(request, auth, clientHeaders)
+            } catch (alternateError) {
+              if (this.isUpstreamRateLimit(alternateError)) {
+                await this.authService.markRateLimited(auth, rawRequest.model, alternateError)
+              }
+              throw alternateError
+            }
+          } else {
+            throw error
+          }
+        } else {
+          throw error
+        }
+      }
 
       // Process response based on streaming mode
       let finalResponse: Response
@@ -241,20 +279,32 @@ export class ProxyService {
           conversationData,
           sampleId
         )
+        // The stream processor owns the reservation until its background work
+        // completes, so the outer error handler must not release it early.
+        activeAuth = undefined
       } else {
-        finalResponse = await this.handleNonStreamingResponse(
-          claudeResponse,
-          request,
-          response,
-          context,
-          auth,
-          conversationData,
-          sampleId
-        )
+        try {
+          finalResponse = await this.handleNonStreamingResponse(
+            claudeResponse,
+            request,
+            response,
+            context,
+            auth,
+            conversationData,
+            sampleId
+          )
+        } finally {
+          await this.authService.release(auth)
+          activeAuth = undefined
+        }
       }
 
       return finalResponse
     } catch (error) {
+      if (activeAuth) {
+        await this.authService.release(activeAuth)
+        activeAuth = undefined
+      }
       // Flush test sample with error info so failed requests can be inspected
       if (sampleId) {
         await testSampleCollector.flushPendingSample(sampleId, {
@@ -483,30 +533,34 @@ export class ProxyService {
       auth,
       conversationData,
       sampleId
-    ).catch(async error => {
-      log.error(
-        'Stream processing error',
-        error instanceof Error ? error : new Error(String(error))
-      )
-
-      // Try to send error to client in SSE format
-      try {
-        const encoder = new TextEncoder()
-        const errorEvent = {
-          type: 'error',
-          error: {
-            type: 'stream_error',
-            message: error instanceof Error ? error.message : String(error),
-          },
-        }
-        await writer.write(encoder.encode(`data: ${JSON.stringify(errorEvent)}\n\n`))
-      } catch (writeError) {
+    )
+      .catch(async error => {
         log.error(
-          'Failed to write error to stream',
-          writeError instanceof Error ? writeError : undefined
+          'Stream processing error',
+          error instanceof Error ? error : new Error(String(error))
         )
-      }
-    })
+
+        // Try to send error to client in SSE format
+        try {
+          const encoder = new TextEncoder()
+          const errorEvent = {
+            type: 'error',
+            error: {
+              type: 'stream_error',
+              message: error instanceof Error ? error.message : String(error),
+            },
+          }
+          await writer.write(encoder.encode(`data: ${JSON.stringify(errorEvent)}\n\n`))
+        } catch (writeError) {
+          log.error(
+            'Failed to write error to stream',
+            writeError instanceof Error ? writeError : undefined
+          )
+        }
+      })
+      .finally(async () => {
+        await this.authService.release(auth)
+      })
 
     // Return streaming response immediately
     return new Response(readable, {
@@ -677,6 +731,10 @@ export class ProxyService {
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-API-Key',
     }
+  }
+
+  private isUpstreamRateLimit(error: unknown): error is UpstreamError {
+    return error instanceof UpstreamError && error.upstreamStatus === 429
   }
 
   /**

--- a/services/proxy/src/services/__tests__/account-pool-service.test.ts
+++ b/services/proxy/src/services/__tests__/account-pool-service.test.ts
@@ -1,9 +1,10 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test'
-import type {
-  AnthropicCredential,
-  AnthropicOAuthUsageResponse,
-  BedrockCredential,
-  Credential,
+import {
+  UpstreamError,
+  type AnthropicCredential,
+  type AnthropicOAuthUsageResponse,
+  type BedrockCredential,
+  type Credential,
 } from '@agent-prompttrain/shared'
 
 // ── Mock functions ──────────────────────────────────────────────────────────
@@ -56,6 +57,8 @@ function makeAnthropicCredential(
     account_name: 'Test Account 1',
     provider: 'anthropic',
     token_limit_threshold: 0.8,
+    five_hour_limit_threshold: 0.9,
+    seven_day_limit_threshold: 0.95,
     oauth_access_token: 'access-token',
     oauth_refresh_token: 'refresh-token',
     oauth_expires_at: new Date(Date.now() + 3600_000),
@@ -75,6 +78,8 @@ function makeBedrockCredential(overrides: Partial<BedrockCredential> = {}): Bedr
     account_name: 'Bedrock Account',
     provider: 'bedrock',
     token_limit_threshold: 0.8,
+    five_hour_limit_threshold: 0.9,
+    seven_day_limit_threshold: 0.95,
     aws_region: 'us-east-1',
     aws_api_key: 'fake-key',
     created_at: new Date(),
@@ -85,8 +90,8 @@ function makeBedrockCredential(overrides: Partial<BedrockCredential> = {}): Bedr
 
 function makeUsageResponse(fiveHour = 50, sevenDay = 30): AnthropicOAuthUsageResponse {
   return {
-    five_hour: { utilization: fiveHour, resets_at: '2026-02-24T12:00:00Z' },
-    seven_day: { utilization: sevenDay, resets_at: '2026-02-28T00:00:00Z' },
+    five_hour: { utilization: fiveHour, resets_at: '2027-02-24T12:00:00Z' },
+    seven_day: { utilization: sevenDay, resets_at: '2027-02-28T00:00:00Z' },
     seven_day_oauth_apps: null,
     seven_day_opus: null,
     seven_day_sonnet: null,
@@ -222,7 +227,7 @@ describe('AccountPoolService', () => {
       // Now cred-1 five_hour spikes above threshold, cred-2 is still under
       usageCacheService.clearCache()
       mockFetchWithUsage({
-        'cred-1': makeUsageResponse(85, 20), // 5h over 0.80 threshold
+        'cred-1': makeUsageResponse(90, 20), // 5h reaches the 90% threshold
         'cred-2': makeUsageResponse(50, 40),
       })
 
@@ -259,7 +264,7 @@ describe('AccountPoolService', () => {
       // Now cred-1 seven_day goes over threshold, but five_hour stays low
       usageCacheService.clearCache()
       mockFetchWithUsage({
-        'cred-1': makeUsageResponse(30, 85), // 7d over 0.80 threshold
+        'cred-1': makeUsageResponse(30, 95), // 7d reaches the 95% threshold
         'cred-2': makeUsageResponse(50, 40),
       })
 
@@ -298,7 +303,7 @@ describe('AccountPoolService', () => {
         expect(error).toBeInstanceOf(AccountPoolExhaustedError)
         const poolError = error as AccountPoolExhaustedError
         expect(poolError.statusCode).toBe(429)
-        expect(poolError.estimatedReset).toBe('2026-02-24T12:00:00Z')
+        expect(poolError.estimatedReset).toBe('2027-02-24T12:00:00.000Z')
         expect(poolError.message).toContain('project-1')
         expect(poolError.message).toContain('2')
       }
@@ -502,6 +507,55 @@ describe('AccountPoolService', () => {
     })
   })
 
+  describe('shared upstream cooldowns', () => {
+    test('skips a rate-limited credential for the affected model', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1', account_id: 'acct-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2', account_id: 'acct-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+      mockFetchWithUsage({
+        'cred-1': makeUsageResponse(20, 10),
+        'cred-2': makeUsageResponse(40, 30),
+      })
+
+      const first = await service.selectAccount('project-1', 'claude-sonnet-5')
+      expect(first.credential.id).toBe('cred-1')
+
+      const reset = await service.markRateLimited(
+        first.credential.id,
+        'claude-sonnet-5',
+        new UpstreamError('rate_limit_error: exhausted', 429, undefined, undefined, {
+          'retry-after': '120',
+        })
+      )
+      await service.releaseAccount(first.credential.id)
+
+      const second = await service.selectAccount('project-1', 'claude-sonnet-5')
+      expect(second.credential.id).toBe('cred-2')
+      expect(new Date(reset).getTime()).toBeGreaterThan(Date.now() + 115_000)
+    })
+
+    test('keeps cooldowns model-specific', async () => {
+      const cred1 = makeAnthropicCredential({ id: 'cred-1', account_id: 'acct-1' })
+      const cred2 = makeAnthropicCredential({ id: 'cred-2', account_id: 'acct-2' })
+      mockGetProjectLinkedCredentials.mockImplementation(() => Promise.resolve([cred1, cred2]))
+      mockFetchWithUsage({
+        'cred-1': makeUsageResponse(20, 10),
+        'cred-2': makeUsageResponse(40, 30),
+      })
+
+      const first = await service.selectAccount('project-1', 'claude-fable-5')
+      await service.markRateLimited(
+        first.credential.id,
+        'claude-fable-5',
+        new UpstreamError('rate limited', 429, undefined, undefined, { 'retry-after': '120' })
+      )
+      await service.releaseAccount(first.credential.id)
+
+      const sonnet = await service.selectAccount('project-1', 'claude-sonnet-5')
+      expect(sonnet.credential.id).toBe('cred-1')
+    })
+  })
+
   // ── Scenario: model-scoped limits (limits[] array) ────────────────────────
   //
   // Anthropic's OAuth usage response carries a `limits` array with entries like
@@ -524,7 +578,7 @@ describe('AccountPoolService', () => {
             group: 'session',
             percent: fiveHour,
             severity: 'normal',
-            resets_at: '2026-02-24T12:00:00Z',
+            resets_at: '2027-02-24T12:00:00Z',
             scope: null,
             is_active: true,
           },
@@ -533,7 +587,7 @@ describe('AccountPoolService', () => {
             group: 'weekly',
             percent: sevenDay,
             severity: 'normal',
-            resets_at: '2026-02-28T00:00:00Z',
+            resets_at: '2027-02-28T00:00:00Z',
             scope: null,
             is_active: true,
           },
@@ -542,7 +596,7 @@ describe('AccountPoolService', () => {
             group: 'weekly',
             percent: fableUtilization,
             severity: fableUtilization >= 100 ? 'exceeded' : 'normal',
-            resets_at: '2026-03-01T00:00:00Z',
+            resets_at: '2027-03-01T00:00:00Z',
             scope: { model: { id: null, display_name: 'Fable' }, surface: null },
             is_active: fableUtilization > 0,
           },
@@ -609,7 +663,7 @@ describe('AccountPoolService', () => {
             group: 'weekly',
             percent: 100,
             severity: 'exceeded',
-            resets_at: '2026-03-01T00:00:00Z',
+            resets_at: '2027-03-01T00:00:00Z',
             scope: { model: { id: 'claude-fable-5', display_name: null }, surface: null },
             is_active: true,
           },

--- a/services/proxy/src/services/__tests__/claude-api-client-rate-limit.test.ts
+++ b/services/proxy/src/services/__tests__/claude-api-client-rate-limit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { getRetryAfter, UpstreamError } from '@agent-prompttrain/shared'
+import { ProxyRequest } from '../../domain/entities/ProxyRequest'
+import { ClaudeApiClient } from '../ClaudeApiClient'
+import type { AuthResult } from '../AuthenticationService'
+
+describe('ClaudeApiClient rate-limit handling', () => {
+  test('preserves upstream headers and does not retry a 429 on the same credential', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchMock = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            type: 'error',
+            error: { type: 'rate_limit_error', message: 'account exhausted' },
+          }),
+          {
+            status: 429,
+            headers: {
+              'retry-after': '180',
+              'anthropic-ratelimit-requests-reset': '2026-08-13T22:00:00Z',
+            },
+          }
+        )
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    try {
+      const client = new ClaudeApiClient({ baseUrl: 'https://api.anthropic.test', timeout: 1_000 })
+      const request = new ProxyRequest(
+        {
+          model: 'claude-sonnet-5',
+          max_tokens: 64,
+          messages: [{ role: 'user', content: 'hello' }],
+        },
+        'project-1',
+        'req-1'
+      )
+      const auth: AuthResult = {
+        provider: 'anthropic',
+        type: 'oauth',
+        headers: { Authorization: 'Bearer token' },
+        key: 'token',
+        accountId: 'account-1',
+        accountName: 'account-1',
+      }
+
+      try {
+        await client.forward(request, auth)
+        expect.unreachable('forward should throw')
+      } catch (error) {
+        expect(error).toBeInstanceOf(UpstreamError)
+        const upstreamError = error as UpstreamError
+        expect(upstreamError.upstreamHeaders?.['retry-after']).toBe('180')
+        expect(getRetryAfter(upstreamError)).toBe(180_000)
+      }
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/services/proxy/src/services/__tests__/proxy-service-rate-limit.test.ts
+++ b/services/proxy/src/services/__tests__/proxy-service-rate-limit.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { UpstreamError, type ClaudeMessagesRequest } from '@agent-prompttrain/shared'
+import { RequestContext } from '../../domain/value-objects/RequestContext'
+import { ProxyService } from '../ProxyService'
+import type { AuthResult } from '../AuthenticationService'
+
+function requestBody(): ClaudeMessagesRequest {
+  return {
+    model: 'claude-sonnet-5',
+    max_tokens: 64,
+    messages: [{ role: 'user', content: 'hello' }],
+  }
+}
+
+function auth(credentialId: string, accountId: string): AuthResult {
+  return {
+    provider: 'anthropic',
+    type: 'oauth',
+    headers: { Authorization: `Bearer token-${credentialId}` },
+    key: `token-${credentialId}`,
+    accountId,
+    accountName: accountId,
+    credentialId,
+    fromPool: true,
+    reserved: true,
+    explicitlySelected: false,
+  }
+}
+
+function rateLimitError(): UpstreamError {
+  return new UpstreamError(
+    'rate_limit_error: account exhausted',
+    429,
+    { requestId: 'req-1' },
+    { type: 'error', error: { type: 'rate_limit_error', message: 'account exhausted' } },
+    { 'retry-after': '120' }
+  )
+}
+
+function successfulClaudeResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'msg-1',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-5',
+      content: [{ type: 'text', text: 'hello' }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  )
+}
+
+function makeDependencies(forward: (authResult: AuthResult) => Promise<Response>) {
+  const accounts = [auth('credential-1', 'account-1'), auth('credential-2', 'account-2')]
+  const authenticate = mock<
+    (
+      context: RequestContext,
+      model?: string,
+      options?: { excludeCredentialIds?: string[] }
+    ) => Promise<AuthResult>
+  >(async () => accounts.shift()!)
+  const markRateLimited = mock(async () => '2026-08-13T22:00:00.000Z')
+  const release = mock(async () => undefined)
+  const authService = { authenticate, markRateLimited, release }
+
+  const apiClient = {
+    forward: mock(async (_request: unknown, authResult: AuthResult) => forward(authResult)),
+    processResponse: mock(async (response: Response) => response.json()),
+  }
+  const metricsService = {
+    trackRequest: mock(async () => undefined),
+    trackError: mock(async () => undefined),
+  }
+  const notificationService = {
+    notify: mock(async () => undefined),
+    notifyError: mock(async () => undefined),
+  }
+
+  return { authService, apiClient, metricsService, notificationService }
+}
+
+describe('ProxyService account rate-limit failover', () => {
+  test('marks the failed credential and immediately tries one different pooled account', async () => {
+    let forwardAttempt = 0
+    const dependencies = makeDependencies(async () => {
+      forwardAttempt += 1
+      if (forwardAttempt === 1) {
+        throw rateLimitError()
+      }
+      return successfulClaudeResponse()
+    })
+    const service = new ProxyService(
+      dependencies.authService as any,
+      dependencies.apiClient as any,
+      dependencies.notificationService as any,
+      dependencies.metricsService as any
+    )
+
+    const response = await service.handleRequest(
+      requestBody(),
+      new RequestContext('req-1', 'project-1', 'POST', '/v1/messages', Date.now(), {})
+    )
+
+    expect(response.status).toBe(200)
+    expect(dependencies.apiClient.forward).toHaveBeenCalledTimes(2)
+    expect(dependencies.authService.markRateLimited).toHaveBeenCalledTimes(1)
+    expect(dependencies.authService.release).toHaveBeenCalledTimes(2)
+    expect(dependencies.authService.authenticate.mock.calls[1]?.[2]).toEqual({
+      excludeCredentialIds: ['credential-1'],
+    })
+  })
+
+  test('stops after the single alternate attempt when both accounts return 429', async () => {
+    const dependencies = makeDependencies(async () => {
+      throw rateLimitError()
+    })
+    const service = new ProxyService(
+      dependencies.authService as any,
+      dependencies.apiClient as any,
+      dependencies.notificationService as any,
+      dependencies.metricsService as any
+    )
+
+    await expect(
+      service.handleRequest(
+        requestBody(),
+        new RequestContext('req-1', 'project-1', 'POST', '/v1/messages', Date.now(), {})
+      )
+    ).rejects.toBeInstanceOf(UpstreamError)
+
+    expect(dependencies.apiClient.forward).toHaveBeenCalledTimes(2)
+    expect(dependencies.authService.authenticate).toHaveBeenCalledTimes(2)
+    expect(dependencies.authService.markRateLimited).toHaveBeenCalledTimes(2)
+    expect(dependencies.authService.release).toHaveBeenCalledTimes(2)
+  })
+})

--- a/services/proxy/src/services/account-pool-service.ts
+++ b/services/proxy/src/services/account-pool-service.ts
@@ -1,315 +1,388 @@
-import { Pool } from 'pg'
-import type {
-  Credential,
-  AnthropicCredential,
-  AnthropicOAuthUsageResponse,
-  OAuthLimitEntry,
+import type { Pool } from 'pg'
+import {
+  getRetryAfter,
+  type Credential,
+  type AnthropicCredential,
+  type AnthropicOAuthUsageResponse,
+  type OAuthLimitEntry,
+  type UpstreamError,
 } from '@agent-prompttrain/shared'
 import {
   getProjectLinkedCredentials,
   getProjectCredentials,
 } from '@agent-prompttrain/shared/database/queries'
 import { UsageCacheService, type CachedUsageEntry } from './usage-cache-service'
+import { AccountPoolStateService, type AccountCandidate } from './account-pool-state-service'
 import { logger } from '../middleware/logger'
 
-/**
- * Thrown when all accounts in a pool have exceeded their utilization threshold.
- */
+const DEFAULT_FIVE_HOUR_THRESHOLD = 0.9
+const DEFAULT_SEVEN_DAY_THRESHOLD = 0.95
+const FALLBACK_COOLDOWN_MS = 60_000
+
 export class AccountPoolExhaustedError extends Error {
   readonly statusCode = 429
-  readonly estimatedReset: string | null
+  readonly retryAfterSeconds: number | null
 
-  constructor(message: string, estimatedReset: string | null = null) {
+  constructor(
+    message: string,
+    readonly estimatedReset: string | null = null
+  ) {
     super(message)
     this.name = 'AccountPoolExhaustedError'
-    this.estimatedReset = estimatedReset
+    this.retryAfterSeconds = estimatedReset
+      ? Math.max(0, Math.ceil((new Date(estimatedReset).getTime() - Date.now()) / 1000))
+      : null
   }
 }
 
-/**
- * Result of selecting an account from the pool.
- */
 export interface AccountSelection {
-  /** The selected credential to use for the request */
   credential: Credential
-  /** Highest utilization across 5h and 7d windows (0-1, normalized) */
   maxUtilization: number
-  /** True if selected from a multi-account pool, false if using default account */
   fromPool: boolean
+  reserved: boolean
 }
 
-/**
- * AccountPoolService selects the best account for a project based on real-time
- * OAuth utilization data from the Anthropic API. When a project has 2+ linked
- * accounts, it automatically switches to the least-utilized account that is
- * still under its configured threshold.
- *
- * Uses sticky routing to maintain account affinity per project until the
- * current account exceeds its threshold.
- */
+export interface AccountSelectionOptions {
+  excludeCredentialIds?: string[]
+}
+
+interface UsageEvaluation {
+  maxUtilization: number
+  pressure: number
+  available: boolean
+}
+
+/** Selects and reserves Anthropic accounts using shared PostgreSQL state. */
 export class AccountPoolService {
-  /** Sticky mapping: projectId -> credentialId */
-  private stickyMap: Map<string, string> = new Map()
+  private readonly stateService: AccountPoolStateService
 
   constructor(
     private readonly pool: Pool,
-    private readonly usageCacheService: UsageCacheService
-  ) {}
+    private readonly usageCacheService: UsageCacheService,
+    stateService?: AccountPoolStateService
+  ) {
+    this.stateService = stateService ?? usageCacheService.stateService
+  }
 
-  /**
-   * Select the best account for a project.
-   *
-   * If the project has fewer than 2 linked accounts, falls back to the
-   * project's default account (non-pool mode).
-   *
-   * If the project has 2+ linked accounts, enters pool mode:
-   * 1. Checks sticky account first and reuses it if under threshold
-   * 2. If sticky is over threshold, evaluates all linked Anthropic accounts
-   * 3. Picks the account with the lowest max utilization that is under threshold
-   * 4. Throws AccountPoolExhaustedError if no accounts are available
-   *
-   * @param model - The Claude model requested (e.g. "claude-fable-5"). When
-   *   provided, model-scoped limits from the usage response (e.g. the separate
-   *   Claude Fable 5 weekly allowance) gate accounts for that model only.
-   */
-  async selectAccount(projectId: string, model?: string): Promise<AccountSelection> {
-    // Try pool mode: check if project has 2+ linked accounts
+  async selectAccount(
+    projectId: string,
+    model?: string,
+    options: AccountSelectionOptions = {}
+  ): Promise<AccountSelection> {
     let linkedCredentials: Credential[] = []
     try {
       linkedCredentials = await getProjectLinkedCredentials(this.pool, projectId)
     } catch {
-      // project_accounts table may not exist yet — fall back to default account
+      // A rolling deployment may not have project_accounts yet.
     }
 
-    // Filter to Anthropic accounts (only these support usage checks for pool mode)
-    const anthropicCredentials = linkedCredentials.filter(
-      (c): c is AnthropicCredential => c.provider === 'anthropic'
+    const allAnthropicCredentials = linkedCredentials.filter(
+      (credential): credential is AnthropicCredential => credential.provider === 'anthropic'
     )
+    const excluded = new Set(options.excludeCredentialIds ?? [])
 
-    // Pool mode requires 2+ Anthropic accounts; otherwise use default account
-    if (anthropicCredentials.length < 2) {
-      return this.selectDefaultAccount(projectId)
+    if (allAnthropicCredentials.length < 2) {
+      return this.selectDefaultAccount(projectId, model, excluded)
     }
 
-    // Check sticky account first
-    const stickyCredentialId = this.stickyMap.get(projectId)
-    if (stickyCredentialId) {
-      const stickyCredential = anthropicCredentials.find(c => c.id === stickyCredentialId)
-      if (stickyCredential) {
-        const cachedEntry = await this.usageCacheService.getUsage(stickyCredential)
-        const maxUtilization = this.computeMaxUtilization(cachedEntry?.usage ?? null, model)
-
-        if (maxUtilization < stickyCredential.token_limit_threshold) {
-          logger.debug('Reusing sticky account (under threshold)', {
-            metadata: {
-              projectId,
-              accountId: stickyCredential.account_id,
-              maxUtilization,
-              threshold: stickyCredential.token_limit_threshold,
-            },
-          })
-          return {
-            credential: stickyCredential,
-            maxUtilization,
-            fromPool: true,
-          }
-        }
-
-        logger.info('Sticky account over threshold, searching pool', {
-          metadata: {
-            projectId,
-            accountId: stickyCredential.account_id,
-            maxUtilization,
-            threshold: stickyCredential.token_limit_threshold,
-          },
-        })
-      }
-    }
-
-    // Fetch usage for all Anthropic accounts in parallel
-    const usageMap = await this.usageCacheService.getUsageMultiple(anthropicCredentials)
-    const usageResults = anthropicCredentials.map(credential => {
-      const entry = usageMap.get(credential.id)
-      const maxUtilization = this.computeMaxUtilization(entry?.usage ?? null, model)
-      return { credential, maxUtilization }
-    })
-
-    // Filter to accounts under their respective thresholds
-    const available = usageResults.filter(
-      ({ credential, maxUtilization }) => maxUtilization < credential.token_limit_threshold
-    )
+    const credentials = allAnthropicCredentials.filter(credential => !excluded.has(credential.id))
+    const usageMap = await this.usageCacheService.getUsageMultiple(credentials)
+    const evaluated = credentials.map(credential => ({
+      credential,
+      evaluation: this.evaluateUsage(credential, usageMap.get(credential.id)?.usage ?? null, model),
+    }))
+    const available = evaluated.filter(result => result.evaluation.available)
 
     if (available.length === 0) {
-      // Find the earliest reset time across all accounts for the error
-      const estimatedReset = this.findEarliestReset(anthropicCredentials, usageMap, model)
-
-      logger.warn('All accounts in pool exhausted', {
-        metadata: {
-          projectId,
-          accountCount: anthropicCredentials.length,
-          utilizations: usageResults.map(r => ({
-            accountId: r.credential.account_id,
-            maxUtilization: r.maxUtilization,
-            threshold: r.credential.token_limit_threshold,
-          })),
-          estimatedReset,
-        },
-      })
-
+      const estimatedReset = this.findEarliestReset(credentials, usageMap, model)
+      this.logExhaustion(projectId, evaluated, estimatedReset)
       throw new AccountPoolExhaustedError(
-        `All ${anthropicCredentials.length} accounts in pool for project "${projectId}" have exceeded their utilization threshold`,
+        `All ${allAnthropicCredentials.length} accounts in pool for project "${projectId}" are unavailable or over their utilization thresholds`,
         estimatedReset
       )
     }
 
-    // Pick the account with the lowest max utilization
-    available.sort((a, b) => a.maxUtilization - b.maxUtilization)
-    const best = available[0]
+    const candidates: AccountCandidate[] = available.map(({ credential, evaluation }) => ({
+      credentialId: credential.id,
+      pressure: evaluation.pressure,
+    }))
+    const reservation = await this.stateService.reserveBestAccount(projectId, model, candidates)
+    if (!reservation.credentialId) {
+      this.logExhaustion(projectId, evaluated, reservation.earliestCooldownReset)
+      throw new AccountPoolExhaustedError(
+        `All ${allAnthropicCredentials.length} accounts in pool for project "${projectId}" are cooling down after upstream rate limits`,
+        reservation.earliestCooldownReset
+      )
+    }
 
-    // Update sticky map
-    this.stickyMap.set(projectId, best.credential.id)
+    const selected = available.find(result => result.credential.id === reservation.credentialId)
+    if (!selected) {
+      throw new Error(`Reserved credential ${reservation.credentialId} was not a pool candidate`)
+    }
+    const { credential, evaluation } = selected
 
     logger.info('Selected account from pool', {
       metadata: {
         projectId,
-        accountId: best.credential.account_id,
-        maxUtilization: best.maxUtilization,
-        threshold: best.credential.token_limit_threshold,
-        poolSize: anthropicCredentials.length,
+        accountId: credential.account_id,
+        maxUtilization: evaluation.maxUtilization,
+        fiveHourThreshold: this.fiveHourThreshold(credential),
+        sevenDayThreshold: this.sevenDayThreshold(credential),
+        poolSize: allAnthropicCredentials.length,
         availableCount: available.length,
       },
     })
 
     return {
-      credential: best.credential,
-      maxUtilization: best.maxUtilization,
+      credential,
+      maxUtilization: evaluation.maxUtilization,
       fromPool: true,
+      reserved: true,
     }
   }
 
-  /**
-   * Fall back to the project's default account (non-pool mode).
-   */
-  private async selectDefaultAccount(projectId: string): Promise<AccountSelection> {
-    const credentials = await getProjectCredentials(this.pool, projectId)
+  async releaseAccount(credentialId: string): Promise<void> {
+    await this.stateService.releaseAccount(credentialId)
+  }
 
+  async markRateLimited(
+    credentialId: string,
+    model: string | undefined,
+    error: UpstreamError
+  ): Promise<string> {
+    const retryAfterMs = getRetryAfter(error)
+    const headerReset = this.findHeaderReset(error.upstreamHeaders)
+    const usageReset = await this.findCredentialReset(credentialId, model)
+    const resetTimestamp =
+      retryAfterMs !== null
+        ? Date.now() + retryAfterMs
+        : (headerReset ?? usageReset ?? Date.now() + FALLBACK_COOLDOWN_MS)
+    const cooldownUntil = new Date(Math.max(Date.now(), resetTimestamp))
+    const retryAfterSeconds = Math.max(0, Math.ceil((cooldownUntil.getTime() - Date.now()) / 1000))
+
+    await this.stateService.markCooldown(
+      credentialId,
+      model,
+      cooldownUntil,
+      retryAfterSeconds,
+      error.message
+    )
+
+    logger.warn('Account placed in shared model cooldown after upstream 429', {
+      metadata: {
+        credentialId,
+        model: model ?? '*',
+        cooldownUntil: cooldownUntil.toISOString(),
+        retryAfterSeconds,
+      },
+    })
+    return cooldownUntil.toISOString()
+  }
+
+  clearStickyState(): void {
+    this.stateService.clearInMemoryState()
+  }
+
+  private async selectDefaultAccount(
+    projectId: string,
+    model: string | undefined,
+    excluded: Set<string>
+  ): Promise<AccountSelection> {
+    const credentials = await getProjectCredentials(this.pool, projectId)
     if (credentials.length === 0) {
       throw new Error(`No default credential found for project "${projectId}"`)
     }
 
     const credential = credentials[0]
-    return {
-      credential,
-      maxUtilization: 0,
-      fromPool: false,
+    if (excluded.has(credential.id)) {
+      throw new AccountPoolExhaustedError(
+        `No alternative account is available for project "${projectId}"`
+      )
     }
+
+    if (credential.provider !== 'anthropic') {
+      return { credential, maxUtilization: 0, fromPool: false, reserved: false }
+    }
+
+    const reservation = await this.stateService.reserveBestAccount(projectId, model, [
+      { credentialId: credential.id, pressure: 0 },
+    ])
+    if (!reservation.credentialId) {
+      throw new AccountPoolExhaustedError(
+        `The account for project "${projectId}" is cooling down after an upstream rate limit`,
+        reservation.earliestCooldownReset
+      )
+    }
+
+    return { credential, maxUtilization: 0, fromPool: false, reserved: true }
   }
 
-  /**
-   * Compute the maximum utilization across 5-hour and 7-day windows plus any
-   * applicable entries in the structured `limits` array.
-   * Returns 1 (treat as over threshold) if usage data is null (conservative).
-   *
-   * Model-scoped limits (e.g. the separate Claude Fable 5 weekly allowance)
-   * only count when the requested `model` matches the limit's scope — a
-   * saturated Fable limit must not block Sonnet/Opus traffic. Unscoped active
-   * limits count for every request.
-   */
-  private computeMaxUtilization(usage: AnthropicOAuthUsageResponse | null, model?: string): number {
+  private evaluateUsage(
+    credential: AnthropicCredential,
+    usage: AnthropicOAuthUsageResponse | null,
+    model?: string
+  ): UsageEvaluation {
     if (!usage) {
-      return 1
+      return { maxUtilization: 1, pressure: Number.POSITIVE_INFINITY, available: false }
     }
 
-    // API returns utilization as 0-100, normalize to 0-1 to match token_limit_threshold
-    const fiveHour = (usage.five_hour?.utilization ?? 0) / 100
-    const sevenDay = (usage.seven_day?.utilization ?? 0) / 100
-    let max = Math.max(fiveHour, sevenDay)
+    let fiveHour = (usage.five_hour?.utilization ?? 0) / 100
+    let sevenDay = (usage.seven_day?.utilization ?? 0) / 100
 
     for (const limit of usage.limits ?? []) {
       if (!this.limitApplies(limit, model)) {
         continue
       }
-      max = Math.max(max, (limit.percent ?? 0) / 100)
+      const utilization = (limit.percent ?? 0) / 100
+      if (this.isSessionLimit(limit)) {
+        fiveHour = Math.max(fiveHour, utilization)
+      } else {
+        sevenDay = Math.max(sevenDay, utilization)
+      }
     }
 
-    return max
+    const fiveHourThreshold = this.fiveHourThreshold(credential)
+    const sevenDayThreshold = this.sevenDayThreshold(credential)
+    return {
+      maxUtilization: Math.max(fiveHour, sevenDay),
+      pressure: Math.max(fiveHour / fiveHourThreshold, sevenDay / sevenDayThreshold),
+      available: fiveHour < fiveHourThreshold && sevenDay < sevenDayThreshold,
+    }
   }
 
-  /**
-   * Whether a limit entry applies to a request for the given model.
-   *
-   * - Inactive limits never apply.
-   * - Unscoped (global) limits always apply. These duplicate the legacy
-   *   five_hour/seven_day windows today, so including them is a no-op now and
-   *   a safety net if the legacy fields are ever dropped.
-   * - Model-scoped limits apply only when the requested model matches the
-   *   scope's `model.id` (exact) or `model.display_name` (substring, e.g.
-   *   display_name "Fable" matches "claude-fable-5"). With no model provided
-   *   (non-Messages endpoints), scoped limits are skipped — blocking all
-   *   traffic on a single-model limit would be worse than the upstream 429.
-   */
   private limitApplies(limit: OAuthLimitEntry, model?: string): boolean {
     if (!limit.is_active) {
       return false
     }
-
     const scopedModel = limit.scope?.model
     if (!scopedModel) {
       return true
     }
-
     if (!model) {
       return false
     }
-
     if (scopedModel.id) {
       return scopedModel.id.toLowerCase() === model.toLowerCase()
     }
-    if (scopedModel.display_name) {
-      return model.toLowerCase().includes(scopedModel.display_name.toLowerCase())
-    }
-    return false
+    return scopedModel.display_name
+      ? model.toLowerCase().includes(scopedModel.display_name.toLowerCase())
+      : false
   }
 
-  /**
-   * Find the earliest reset time from cached usage data for the given credentials.
-   * Returns null if no reset times are available.
-   */
+  private isSessionLimit(limit: OAuthLimitEntry): boolean {
+    const kind = limit.kind.toLowerCase()
+    const group = limit.group?.toLowerCase() ?? ''
+    return kind.includes('session') || kind.includes('hour') || group.includes('session')
+  }
+
+  private fiveHourThreshold(credential: AnthropicCredential): number {
+    return Number(credential.five_hour_limit_threshold ?? DEFAULT_FIVE_HOUR_THRESHOLD)
+  }
+
+  private sevenDayThreshold(credential: AnthropicCredential): number {
+    return Number(credential.seven_day_limit_threshold ?? DEFAULT_SEVEN_DAY_THRESHOLD)
+  }
+
   private findEarliestReset(
     credentials: AnthropicCredential[],
     usageMap: Map<string, CachedUsageEntry>,
     model?: string
   ): string | null {
-    let earliest: string | null = null
+    const accountResets = credentials
+      .map(credential => {
+        const usage = usageMap.get(credential.id)?.usage
+        return usage ? this.blockingReset(usage, model, credential) : null
+      })
+      .filter((value): value is string => Boolean(value))
+    return this.earliestReset(accountResets)
+  }
 
-    for (const credential of credentials) {
-      const cached = usageMap.get(credential.id)
-      if (!cached?.usage) {
+  private async findCredentialReset(credentialId: string, model?: string): Promise<number | null> {
+    const usage = (await this.usageCacheService.getLastKnownUsage(credentialId))?.usage
+    const reset = usage ? this.blockingReset(usage, model) : null
+    return reset ? new Date(reset).getTime() : null
+  }
+
+  private blockingReset(
+    usage: AnthropicOAuthUsageResponse,
+    model?: string,
+    credential?: AnthropicCredential
+  ): string | null {
+    const fiveHourThreshold = credential
+      ? this.fiveHourThreshold(credential)
+      : DEFAULT_FIVE_HOUR_THRESHOLD
+    const sevenDayThreshold = credential
+      ? this.sevenDayThreshold(credential)
+      : DEFAULT_SEVEN_DAY_THRESHOLD
+    const blockingResets: string[] = []
+
+    if (usage.five_hour && usage.five_hour.utilization / 100 >= fiveHourThreshold) {
+      blockingResets.push(usage.five_hour.resets_at)
+    }
+    if (usage.seven_day && usage.seven_day.utilization / 100 >= sevenDayThreshold) {
+      blockingResets.push(usage.seven_day.resets_at)
+    }
+    for (const limit of usage.limits ?? []) {
+      if (!this.limitApplies(limit, model) || !limit.resets_at) {
         continue
       }
-
-      const resetTimes = [
-        cached.usage.five_hour?.resets_at,
-        cached.usage.seven_day?.resets_at,
-        ...(cached.usage.limits ?? [])
-          .filter(limit => this.limitApplies(limit, model))
-          .map(limit => limit.resets_at),
-      ].filter((t): t is string => t !== null && t !== undefined)
-
-      for (const resetTime of resetTimes) {
-        if (!earliest || new Date(resetTime).getTime() < new Date(earliest).getTime()) {
-          earliest = resetTime
-        }
+      const threshold = this.isSessionLimit(limit) ? fiveHourThreshold : sevenDayThreshold
+      if ((limit.percent ?? 0) / 100 >= threshold) {
+        blockingResets.push(limit.resets_at)
       }
     }
 
-    return earliest
+    if (blockingResets.length === 0) {
+      return null
+    }
+
+    // An account blocked by multiple windows is eligible only after all of its
+    // blocking windows reset, so use the latest reset for that account.
+    const timestamps = blockingResets
+      .map(reset => new Date(reset).getTime())
+      .filter(timestamp => Number.isFinite(timestamp) && timestamp > Date.now())
+    return timestamps.length ? new Date(Math.max(...timestamps)).toISOString() : null
   }
 
-  /**
-   * Clear sticky routing state. Useful for testing.
-   */
-  clearStickyState(): void {
-    this.stickyMap.clear()
+  private findHeaderReset(headers?: Record<string, string>): number | null {
+    if (!headers) {
+      return null
+    }
+    const timestamps = Object.entries(headers)
+      .filter(([name]) => name.toLowerCase().startsWith('anthropic-ratelimit-'))
+      .filter(([name]) => name.toLowerCase().endsWith('-reset'))
+      .map(([, value]) => new Date(value).getTime())
+      .filter(timestamp => Number.isFinite(timestamp) && timestamp > Date.now())
+    // Retry-After is preferred above. Without it, use the most conservative
+    // reset because the response headers describe multiple independent
+    // limiters and do not reliably identify which one produced the 429.
+    return timestamps.length ? Math.max(...timestamps) : null
+  }
+
+  private earliestReset(resetTimes: string[]): string | null {
+    const timestamps = resetTimes
+      .map(resetTime => new Date(resetTime).getTime())
+      .filter(timestamp => Number.isFinite(timestamp) && timestamp > Date.now())
+    return timestamps.length ? new Date(Math.min(...timestamps)).toISOString() : null
+  }
+
+  private logExhaustion(
+    projectId: string,
+    evaluated: Array<{ credential: AnthropicCredential; evaluation: UsageEvaluation }>,
+    estimatedReset: string | null
+  ): void {
+    logger.warn('All accounts in pool exhausted', {
+      metadata: {
+        projectId,
+        accountCount: evaluated.length,
+        utilizations: evaluated.map(({ credential, evaluation }) => ({
+          accountId: credential.account_id,
+          maxUtilization: evaluation.maxUtilization,
+          fiveHourThreshold: this.fiveHourThreshold(credential),
+          sevenDayThreshold: this.sevenDayThreshold(credential),
+        })),
+        estimatedReset,
+      },
+    })
   }
 }

--- a/services/proxy/src/services/account-pool-state-service.ts
+++ b/services/proxy/src/services/account-pool-state-service.ts
@@ -1,0 +1,496 @@
+import type { Pool, PoolClient } from 'pg'
+import type { AnthropicOAuthUsageResponse } from '@agent-prompttrain/shared'
+
+const USAGE_REFRESH_LEASE_MS = 30_000
+const FORCE_REFRESH_COOLDOWN_MS = 30_000
+const STALE_IN_FLIGHT_MS = 900_000
+
+export interface SharedUsageState {
+  usage: AnthropicOAuthUsageResponse | null
+  fetchedAt: number
+  nextRefreshAt: number
+  failureCount: number
+}
+
+export interface AccountCandidate {
+  credentialId: string
+  pressure: number
+}
+
+export interface AccountReservation {
+  credentialId: string | null
+  earliestCooldownReset: string | null
+}
+
+interface MemoryAccountState extends SharedUsageState {
+  refreshLeaseUntil: number
+  lastForceRefreshAt: number
+  inFlightRequests: number
+}
+
+interface RuntimeRow {
+  credential_id: string
+  usage: AnthropicOAuthUsageResponse | null
+  usage_fetched_at: Date | string | null
+  usage_next_refresh_at: Date | string | null
+  usage_failure_count: number | string
+  in_flight_requests: number | string
+  cooldown_until?: Date | string | null
+}
+
+/**
+ * PostgreSQL coordination for account pooling. A small in-memory implementation
+ * is retained for isolated unit tests that intentionally do not provide a pool.
+ */
+export class AccountPoolStateService {
+  private readonly memoryAccounts = new Map<string, MemoryAccountState>()
+  private readonly memoryCooldowns = new Map<string, number>()
+  private readonly memoryAffinity = new Map<string, string>()
+
+  constructor(private readonly pool?: Pool | null) {}
+
+  get isPersistent(): boolean {
+    return Boolean(
+      this.pool &&
+        typeof (this.pool as Pool).query === 'function' &&
+        typeof (this.pool as Pool).connect === 'function'
+    )
+  }
+
+  async getUsageState(credentialId: string): Promise<SharedUsageState | null> {
+    if (!this.isPersistent) {
+      const state = this.memoryAccounts.get(credentialId)
+      return state ? this.toSharedUsageState(state) : null
+    }
+
+    const result = await this.pool!.query<RuntimeRow>(
+      `
+      SELECT credential_id, usage, usage_fetched_at, usage_next_refresh_at,
+             usage_failure_count, in_flight_requests
+      FROM account_pool_account_state
+      WHERE credential_id = $1
+      `,
+      [credentialId]
+    )
+
+    return result.rows[0] ? this.rowToUsageState(result.rows[0]) : null
+  }
+
+  async claimUsageRefresh(credentialId: string, force = false): Promise<boolean> {
+    const now = Date.now()
+
+    if (!this.isPersistent) {
+      const state = this.getOrCreateMemoryAccount(credentialId)
+      const forceAllowed = now - state.lastForceRefreshAt >= FORCE_REFRESH_COOLDOWN_MS
+      const scheduled = state.nextRefreshAt === 0 || state.nextRefreshAt <= now
+      if (state.refreshLeaseUntil > now || (force ? !forceAllowed : !scheduled)) {
+        return false
+      }
+      state.refreshLeaseUntil = now + USAGE_REFRESH_LEASE_MS
+      if (force) {
+        state.lastForceRefreshAt = now
+      }
+      return true
+    }
+
+    await this.ensureAccountState(credentialId)
+    const result = await this.pool!.query(
+      `
+      UPDATE account_pool_account_state
+      SET usage_refresh_lease_until = NOW() + ($2 * INTERVAL '1 millisecond'),
+          usage_last_force_refresh_at = CASE WHEN $3 THEN NOW() ELSE usage_last_force_refresh_at END,
+          updated_at = NOW()
+      WHERE credential_id = $1
+        AND (usage_refresh_lease_until IS NULL OR usage_refresh_lease_until <= NOW())
+        AND (
+          ($3 = FALSE AND (usage_next_refresh_at IS NULL OR usage_next_refresh_at <= NOW()))
+          OR
+          ($3 = TRUE AND (
+            usage_last_force_refresh_at IS NULL
+            OR usage_last_force_refresh_at <= NOW() - ($4 * INTERVAL '1 millisecond')
+          ))
+        )
+      RETURNING credential_id
+      `,
+      [credentialId, USAGE_REFRESH_LEASE_MS, force, FORCE_REFRESH_COOLDOWN_MS]
+    )
+
+    return (result.rowCount ?? 0) > 0
+  }
+
+  async saveUsageSuccess(
+    credentialId: string,
+    usage: AnthropicOAuthUsageResponse,
+    fetchedAt: number,
+    nextRefreshAt: number
+  ): Promise<void> {
+    if (!this.isPersistent) {
+      const state = this.getOrCreateMemoryAccount(credentialId)
+      state.usage = usage
+      state.fetchedAt = fetchedAt
+      state.nextRefreshAt = nextRefreshAt
+      state.failureCount = 0
+      state.refreshLeaseUntil = 0
+      return
+    }
+
+    await this.pool!.query(
+      `
+      INSERT INTO account_pool_account_state (
+        credential_id, usage, usage_fetched_at, usage_next_refresh_at,
+        usage_failure_count, usage_refresh_lease_until, updated_at
+      ) VALUES ($1, $2::jsonb, $3, $4, 0, NULL, NOW())
+      ON CONFLICT (credential_id) DO UPDATE
+      SET usage = EXCLUDED.usage,
+          usage_fetched_at = EXCLUDED.usage_fetched_at,
+          usage_next_refresh_at = EXCLUDED.usage_next_refresh_at,
+          usage_failure_count = 0,
+          usage_refresh_lease_until = NULL,
+          updated_at = NOW()
+      `,
+      [credentialId, JSON.stringify(usage), new Date(fetchedAt), new Date(nextRefreshAt)]
+    )
+  }
+
+  async saveUsageFailure(credentialId: string, nextRefreshAt: number): Promise<number> {
+    if (!this.isPersistent) {
+      const state = this.getOrCreateMemoryAccount(credentialId)
+      state.failureCount += 1
+      state.nextRefreshAt = nextRefreshAt
+      state.refreshLeaseUntil = 0
+      return state.failureCount
+    }
+
+    await this.ensureAccountState(credentialId)
+    const result = await this.pool!.query<{ usage_failure_count: number | string }>(
+      `
+      UPDATE account_pool_account_state
+      SET usage_failure_count = usage_failure_count + 1,
+          usage_next_refresh_at = $2,
+          usage_refresh_lease_until = NULL,
+          updated_at = NOW()
+      WHERE credential_id = $1
+      RETURNING usage_failure_count
+      `,
+      [credentialId, new Date(nextRefreshAt)]
+    )
+
+    return Number(result.rows[0]?.usage_failure_count ?? 1)
+  }
+
+  async releaseUsageRefresh(credentialId: string): Promise<void> {
+    if (!this.isPersistent) {
+      this.getOrCreateMemoryAccount(credentialId).refreshLeaseUntil = 0
+      return
+    }
+
+    await this.pool!.query(
+      `
+      UPDATE account_pool_account_state
+      SET usage_refresh_lease_until = NULL, updated_at = NOW()
+      WHERE credential_id = $1
+      `,
+      [credentialId]
+    )
+  }
+
+  async reserveBestAccount(
+    projectId: string,
+    model: string | undefined,
+    candidates: AccountCandidate[]
+  ): Promise<AccountReservation> {
+    if (candidates.length === 0) {
+      return { credentialId: null, earliestCooldownReset: null }
+    }
+
+    const modelKey = this.modelKey(model)
+    if (!this.isPersistent) {
+      return this.reserveBestAccountInMemory(projectId, modelKey, candidates)
+    }
+
+    const client = await this.pool!.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        `account-pool:${projectId}:${modelKey}`,
+      ])
+      await this.ensureAccountStates(
+        client,
+        candidates.map(candidate => candidate.credentialId)
+      )
+
+      const affinityResult = await client.query<{ credential_id: string }>(
+        'SELECT credential_id FROM account_pool_project_affinity WHERE project_id = $1',
+        [projectId]
+      )
+      const affinityId = affinityResult.rows[0]?.credential_id
+
+      const stateResult = await client.query<RuntimeRow>(
+        `
+        SELECT state.credential_id, state.usage, state.usage_fetched_at,
+               state.usage_next_refresh_at, state.usage_failure_count,
+               CASE
+                 WHEN state.in_flight_updated_at IS NULL
+                   OR state.in_flight_updated_at <= NOW() - ($3 * INTERVAL '1 millisecond')
+                 THEN 0
+                 ELSE state.in_flight_requests
+               END AS in_flight_requests,
+               cooldown.cooldown_until
+        FROM account_pool_account_state state
+        LEFT JOIN account_pool_model_cooldowns cooldown
+          ON cooldown.credential_id = state.credential_id
+         AND cooldown.model = $2
+         AND cooldown.cooldown_until > NOW()
+        WHERE state.credential_id = ANY($1::uuid[])
+        FOR UPDATE OF state
+        `,
+        [candidates.map(candidate => candidate.credentialId), modelKey, STALE_IN_FLIGHT_MS]
+      )
+
+      const stateByCredential = new Map(stateResult.rows.map(row => [row.credential_id, row]))
+      const available = candidates.filter(candidate => {
+        const row = stateByCredential.get(candidate.credentialId)
+        return row && !row.cooldown_until
+      })
+
+      let selected = available.find(candidate => candidate.credentialId === affinityId)
+      if (!selected) {
+        selected = [...available].sort((left, right) => {
+          const leftInFlight = Number(
+            stateByCredential.get(left.credentialId)?.in_flight_requests ?? 0
+          )
+          const rightInFlight = Number(
+            stateByCredential.get(right.credentialId)?.in_flight_requests ?? 0
+          )
+          return left.pressure + leftInFlight * 0.01 - (right.pressure + rightInFlight * 0.01)
+        })[0]
+      }
+
+      if (!selected) {
+        const earliestCooldownReset = this.earliestDate(
+          stateResult.rows.map(row => row.cooldown_until)
+        )
+        await client.query('COMMIT')
+        return { credentialId: null, earliestCooldownReset }
+      }
+
+      await client.query(
+        `
+        UPDATE account_pool_account_state
+        SET in_flight_requests = CASE
+              WHEN in_flight_updated_at IS NULL
+                OR in_flight_updated_at <= NOW() - ($2 * INTERVAL '1 millisecond')
+              THEN 1
+              ELSE in_flight_requests + 1
+            END,
+            in_flight_updated_at = NOW(),
+            updated_at = NOW()
+        WHERE credential_id = $1
+        `,
+        [selected.credentialId, STALE_IN_FLIGHT_MS]
+      )
+      await client.query(
+        `
+        INSERT INTO account_pool_project_affinity (project_id, credential_id, updated_at)
+        VALUES ($1, $2, NOW())
+        ON CONFLICT (project_id) DO UPDATE
+        SET credential_id = EXCLUDED.credential_id, updated_at = NOW()
+        `,
+        [projectId, selected.credentialId]
+      )
+
+      await client.query('COMMIT')
+      return { credentialId: selected.credentialId, earliestCooldownReset: null }
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async releaseAccount(credentialId: string): Promise<void> {
+    if (!this.isPersistent) {
+      const state = this.getOrCreateMemoryAccount(credentialId)
+      state.inFlightRequests = Math.max(0, state.inFlightRequests - 1)
+      return
+    }
+
+    await this.pool!.query(
+      `
+      UPDATE account_pool_account_state
+      SET in_flight_requests = GREATEST(0, in_flight_requests - 1),
+          in_flight_updated_at = NOW(),
+          updated_at = NOW()
+      WHERE credential_id = $1
+      `,
+      [credentialId]
+    )
+  }
+
+  async markCooldown(
+    credentialId: string,
+    model: string | undefined,
+    cooldownUntil: Date,
+    retryAfterSeconds: number,
+    reason: string
+  ): Promise<void> {
+    const modelKey = this.modelKey(model)
+
+    if (!this.isPersistent) {
+      this.memoryCooldowns.set(this.cooldownKey(credentialId, modelKey), cooldownUntil.getTime())
+      for (const [projectId, affinityId] of this.memoryAffinity) {
+        if (affinityId === credentialId) {
+          this.memoryAffinity.delete(projectId)
+        }
+      }
+      return
+    }
+
+    await this.pool!.query(
+      `
+      INSERT INTO account_pool_model_cooldowns (
+        credential_id, model, cooldown_until, reason, retry_after_seconds, updated_at
+      ) VALUES ($1, $2, $3, $4, $5, NOW())
+      ON CONFLICT (credential_id, model) DO UPDATE
+      SET cooldown_until = GREATEST(
+            account_pool_model_cooldowns.cooldown_until,
+            EXCLUDED.cooldown_until
+          ),
+          reason = EXCLUDED.reason,
+          retry_after_seconds = EXCLUDED.retry_after_seconds,
+          updated_at = NOW()
+      `,
+      [credentialId, modelKey, cooldownUntil, reason, retryAfterSeconds]
+    )
+    await this.pool!.query('DELETE FROM account_pool_project_affinity WHERE credential_id = $1', [
+      credentialId,
+    ])
+  }
+
+  clearInMemoryState(): void {
+    if (!this.isPersistent) {
+      this.memoryAccounts.clear()
+      this.memoryCooldowns.clear()
+      this.memoryAffinity.clear()
+    }
+  }
+
+  private async ensureAccountState(credentialId: string): Promise<void> {
+    await this.pool!.query(
+      `
+      INSERT INTO account_pool_account_state (credential_id)
+      VALUES ($1)
+      ON CONFLICT (credential_id) DO NOTHING
+      `,
+      [credentialId]
+    )
+  }
+
+  private async ensureAccountStates(client: PoolClient, credentialIds: string[]): Promise<void> {
+    await client.query(
+      `
+      INSERT INTO account_pool_account_state (credential_id)
+      SELECT UNNEST($1::uuid[])
+      ON CONFLICT (credential_id) DO NOTHING
+      `,
+      [credentialIds]
+    )
+  }
+
+  private reserveBestAccountInMemory(
+    projectId: string,
+    modelKey: string,
+    candidates: AccountCandidate[]
+  ): AccountReservation {
+    const now = Date.now()
+    const available = candidates.filter(candidate => {
+      const cooldown = this.memoryCooldowns.get(this.cooldownKey(candidate.credentialId, modelKey))
+      return !cooldown || cooldown <= now
+    })
+    const affinityId = this.memoryAffinity.get(projectId)
+    let selected = available.find(candidate => candidate.credentialId === affinityId)
+    if (!selected) {
+      selected = [...available].sort((left, right) => {
+        const leftState = this.getOrCreateMemoryAccount(left.credentialId)
+        const rightState = this.getOrCreateMemoryAccount(right.credentialId)
+        return (
+          left.pressure +
+          leftState.inFlightRequests * 0.01 -
+          (right.pressure + rightState.inFlightRequests * 0.01)
+        )
+      })[0]
+    }
+
+    if (!selected) {
+      const resets = candidates
+        .map(candidate =>
+          this.memoryCooldowns.get(this.cooldownKey(candidate.credentialId, modelKey))
+        )
+        .filter((value): value is number => Boolean(value && value > now))
+      return {
+        credentialId: null,
+        earliestCooldownReset: resets.length ? new Date(Math.min(...resets)).toISOString() : null,
+      }
+    }
+
+    const state = this.getOrCreateMemoryAccount(selected.credentialId)
+    state.inFlightRequests += 1
+    this.memoryAffinity.set(projectId, selected.credentialId)
+    return { credentialId: selected.credentialId, earliestCooldownReset: null }
+  }
+
+  private getOrCreateMemoryAccount(credentialId: string): MemoryAccountState {
+    let state = this.memoryAccounts.get(credentialId)
+    if (!state) {
+      state = {
+        usage: null,
+        fetchedAt: 0,
+        nextRefreshAt: 0,
+        failureCount: 0,
+        refreshLeaseUntil: 0,
+        lastForceRefreshAt: 0,
+        inFlightRequests: 0,
+      }
+      this.memoryAccounts.set(credentialId, state)
+    }
+    return state
+  }
+
+  private toSharedUsageState(state: MemoryAccountState): SharedUsageState {
+    return {
+      usage: state.usage,
+      fetchedAt: state.fetchedAt,
+      nextRefreshAt: state.nextRefreshAt,
+      failureCount: state.failureCount,
+    }
+  }
+
+  private rowToUsageState(row: RuntimeRow): SharedUsageState {
+    return {
+      usage: row.usage,
+      fetchedAt: this.toTimestamp(row.usage_fetched_at),
+      nextRefreshAt: this.toTimestamp(row.usage_next_refresh_at),
+      failureCount: Number(row.usage_failure_count ?? 0),
+    }
+  }
+
+  private modelKey(model?: string): string {
+    return model?.trim().toLowerCase().slice(0, 255) || '*'
+  }
+
+  private cooldownKey(credentialId: string, modelKey: string): string {
+    return `${credentialId}:${modelKey}`
+  }
+
+  private toTimestamp(value: Date | string | null | undefined): number {
+    return value ? new Date(value).getTime() : 0
+  }
+
+  private earliestDate(values: Array<Date | string | null | undefined>): string | null {
+    const timestamps = values
+      .map(value => this.toTimestamp(value))
+      .filter(timestamp => timestamp > Date.now())
+    return timestamps.length ? new Date(Math.min(...timestamps)).toISOString() : null
+  }
+}

--- a/services/proxy/src/services/usage-cache-service.ts
+++ b/services/proxy/src/services/usage-cache-service.ts
@@ -1,90 +1,99 @@
-import { Pool } from 'pg'
+import type { Pool } from 'pg'
 import type { AnthropicCredential, AnthropicOAuthUsageResponse } from '@agent-prompttrain/shared'
 import { getApiKey } from '../credentials'
 import { logger } from '../middleware/logger'
+import { AccountPoolStateService, type SharedUsageState } from './account-pool-state-service'
 
 export interface CachedUsageEntry {
   usage: AnthropicOAuthUsageResponse | null
   fetchedAt: number
   isEstimated: boolean
   lastSuccessfulUsage?: AnthropicOAuthUsageResponse
+  nextRefreshAt?: number
+  failureCount?: number
 }
 
-/** 5 minutes */
 const USAGE_CACHE_TTL_MS = 300_000
-
-/** Trigger background refresh at 80% of TTL (4 minutes) */
-const BACKGROUND_REFRESH_THRESHOLD = 0.8
-
-/** Extrapolation: +2% per 10 minutes */
+const BACKGROUND_REFRESH_AT_MS = USAGE_CACHE_TTL_MS * 0.8
 const EXTRAPOLATION_RATE_PER_10MIN = 2
-
-/** Max extrapolated utilization */
 const EXTRAPOLATION_CAP = 100
-
-/** Minimum interval between force-refreshes per account */
-const FORCE_REFRESH_COOLDOWN_MS = 30_000
+const FAILURE_BACKOFF_BASE_MS = 30_000
+const FAILURE_BACKOFF_MAX_MS = 900_000
+const SHARED_REFRESH_WAIT_MS = 100
+const SHARED_REFRESH_WAIT_ATTEMPTS = 20
 
 const ANTHROPIC_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
 
 /**
- * Centralized cache for Anthropic OAuth usage data.
- * Shared by AccountPoolService (proxy requests) and dashboard API route.
- *
- * Features:
- * - 5-minute TTL with background refresh at 4 minutes
- * - In-flight request deduplication (at most 1 API call per credential)
- * - Rate-limit-aware extrapolation (+2%/10min from last known value)
- * - Force-refresh with 30s cooldown for dashboard manual refresh
+ * Shared Anthropic OAuth usage cache. PostgreSQL owns durable successful data,
+ * refresh leases, and failure backoff; the local map is only a hot cache.
  */
 export class UsageCacheService {
-  private cache: Map<string, CachedUsageEntry> = new Map()
-  private inFlight: Map<string, Promise<CachedUsageEntry | null>> = new Map()
-  private lastForceRefresh: Map<string, number> = new Map()
+  private readonly cache = new Map<string, CachedUsageEntry>()
+  private readonly inFlight = new Map<string, Promise<CachedUsageEntry | null>>()
+  private readonly localLastForceRefresh = new Map<string, number>()
+  readonly stateService: AccountPoolStateService
 
-  constructor(private readonly pool: Pool) {}
-
-  /**
-   * Get usage for a single account. Returns cached, fresh, or extrapolated data.
-   */
-  async getUsage(credential: AnthropicCredential): Promise<CachedUsageEntry | null> {
-    const cached = this.cache.get(credential.id)
-    const now = Date.now()
-
-    if (cached && cached.fetchedAt > 0) {
-      const age = now - cached.fetchedAt
-      const backgroundThreshold = USAGE_CACHE_TTL_MS * BACKGROUND_REFRESH_THRESHOLD
-
-      // Fresh: return immediately
-      if (age < backgroundThreshold) {
-        return cached
-      }
-
-      // Stale but not expired: return cached + trigger background refresh
-      if (age < USAGE_CACHE_TTL_MS) {
-        this.triggerBackgroundRefresh(credential)
-        return cached
-      }
-    }
-
-    // Cache miss or expired: blocking fetch
-    return this.fetchWithDeduplication(credential)
+  constructor(
+    private readonly pool?: Pool | null,
+    stateService?: AccountPoolStateService
+  ) {
+    this.stateService = stateService ?? new AccountPoolStateService(pool)
   }
 
-  /**
-   * Get usage for multiple accounts in parallel. Key is credential.id.
-   */
+  async getUsage(credential: AnthropicCredential): Promise<CachedUsageEntry | null> {
+    if (!this.stateService.isPersistent) {
+      return this.getUsageLocally(credential)
+    }
+
+    const now = Date.now()
+    const local = this.cache.get(credential.id)
+    if (local?.fetchedAt && now - local.fetchedAt < BACKGROUND_REFRESH_AT_MS) {
+      return local
+    }
+
+    const shared = await this.stateService.getUsageState(credential.id)
+    const sharedEntry = shared ? this.entryFromSharedState(shared) : null
+    if (sharedEntry) {
+      this.cache.set(credential.id, sharedEntry)
+    }
+
+    const entry = sharedEntry ?? local ?? null
+    const age = entry?.fetchedAt ? now - entry.fetchedAt : Number.POSITIVE_INFINITY
+    const refreshDue = !shared?.nextRefreshAt || shared.nextRefreshAt <= now
+
+    if (!refreshDue) {
+      return entry
+    }
+
+    if (entry && age < USAGE_CACHE_TTL_MS) {
+      this.triggerBackgroundRefresh(credential)
+      return entry
+    }
+
+    const refreshed = await this.fetchWithDeduplication(credential)
+    if (refreshed) {
+      return refreshed
+    }
+
+    if (entry) {
+      return entry
+    }
+
+    return this.waitForSharedRefresh(credential.id)
+  }
+
   async getUsageMultiple(
     credentials: AnthropicCredential[]
   ): Promise<Map<string, CachedUsageEntry>> {
-    const results = new Map<string, CachedUsageEntry>()
     const entries = await Promise.all(
-      credentials.map(async cred => {
-        const entry = await this.getUsage(cred)
-        return { id: cred.id, entry }
-      })
+      credentials.map(async credential => ({
+        id: credential.id,
+        entry: await this.getUsage(credential),
+      }))
     )
+    const results = new Map<string, CachedUsageEntry>()
     for (const { id, entry } of entries) {
       if (entry) {
         results.set(id, entry)
@@ -93,68 +102,78 @@ export class UsageCacheService {
     return results
   }
 
-  /**
-   * Force-refresh a single account (for dashboard manual refresh).
-   * Rate-limited to once per 30s per account.
-   */
   async forceRefresh(credential: AnthropicCredential): Promise<CachedUsageEntry | null> {
-    const now = Date.now()
-    const lastRefresh = this.lastForceRefresh.get(credential.id) ?? 0
-
-    if (now - lastRefresh < FORCE_REFRESH_COOLDOWN_MS) {
-      // Return current cached value if within cooldown
-      return this.cache.get(credential.id) ?? null
+    if (!this.stateService.isPersistent) {
+      const now = Date.now()
+      const lastForceRefresh = this.localLastForceRefresh.get(credential.id) ?? 0
+      if (now - lastForceRefresh < 30_000) {
+        return this.cache.get(credential.id) ?? null
+      }
+      this.localLastForceRefresh.set(credential.id, now)
+      return this.fetchWithDeduplication(credential, true)
     }
 
-    this.lastForceRefresh.set(credential.id, now)
-    // Expire the cache entry to force a fresh fetch, but preserve
-    // lastSuccessfulUsage so extrapolation works if the fetch fails
-    const existing = this.cache.get(credential.id)
-    if (existing) {
-      existing.fetchedAt = 0 // Mark as expired
+    const refreshed = await this.fetchWithDeduplication(credential, true)
+    if (refreshed) {
+      return refreshed
+    }
+    const shared = await this.stateService.getUsageState(credential.id)
+    return shared ? this.entryFromSharedState(shared) : (this.cache.get(credential.id) ?? null)
+  }
+
+  getCachedUsage(credentialId: string): CachedUsageEntry | null {
+    return this.cache.get(credentialId) ?? null
+  }
+
+  async getLastKnownUsage(credentialId: string): Promise<CachedUsageEntry | null> {
+    const local = this.cache.get(credentialId)
+    if (local) {
+      return local
+    }
+    const shared = await this.stateService.getUsageState(credentialId)
+    return shared ? this.entryFromSharedState(shared) : null
+  }
+
+  clearCache(): void {
+    this.cache.clear()
+    this.inFlight.clear()
+    this.localLastForceRefresh.clear()
+  }
+
+  private async getUsageLocally(credential: AnthropicCredential): Promise<CachedUsageEntry | null> {
+    const cached = this.cache.get(credential.id)
+    const now = Date.now()
+    if (cached?.fetchedAt) {
+      const age = now - cached.fetchedAt
+      if (age < BACKGROUND_REFRESH_AT_MS) {
+        return cached
+      }
+      if (age < USAGE_CACHE_TTL_MS) {
+        this.triggerBackgroundRefresh(credential)
+        return cached
+      }
     }
     return this.fetchWithDeduplication(credential)
   }
 
-  /**
-   * Clear all cached data. Useful for testing.
-   */
-  clearCache(): void {
-    this.cache.clear()
-    this.inFlight.clear()
-    this.lastForceRefresh.clear()
-  }
-
-  /**
-   * Trigger a non-blocking background refresh for a credential.
-   * Deduplicated: skips if a fetch is already in-flight.
-   */
   private triggerBackgroundRefresh(credential: AnthropicCredential): void {
     if (this.inFlight.has(credential.id)) {
-      return // Already refreshing
+      return
     }
-
-    // Fire and forget - don't await
-    this.fetchWithDeduplication(credential).catch(() => {
-      // Errors handled inside fetchWithDeduplication
-    })
+    this.fetchWithDeduplication(credential).catch(() => undefined)
   }
 
-  /**
-   * Fetch usage from Anthropic API with in-flight deduplication.
-   * At most one concurrent API call per credential.
-   */
   private async fetchWithDeduplication(
-    credential: AnthropicCredential
+    credential: AnthropicCredential,
+    force = false
   ): Promise<CachedUsageEntry | null> {
     const existing = this.inFlight.get(credential.id)
     if (existing) {
       return existing
     }
 
-    const promise = this.doFetch(credential)
+    const promise = this.refreshUsage(credential, force)
     this.inFlight.set(credential.id, promise)
-
     try {
       return await promise
     } finally {
@@ -162,12 +181,24 @@ export class UsageCacheService {
     }
   }
 
-  /**
-   * Perform the actual API fetch and update the cache.
-   */
+  private async refreshUsage(
+    credential: AnthropicCredential,
+    force: boolean
+  ): Promise<CachedUsageEntry | null> {
+    if (this.stateService.isPersistent) {
+      const claimed = await this.stateService.claimUsageRefresh(credential.id, force)
+      if (!claimed) {
+        const shared = await this.stateService.getUsageState(credential.id)
+        return shared ? this.entryFromSharedState(shared) : null
+      }
+    }
+
+    return this.doFetch(credential)
+  }
+
   private async doFetch(credential: AnthropicCredential): Promise<CachedUsageEntry | null> {
     try {
-      const token = await getApiKey(credential.id, this.pool)
+      const token = await getApiKey(credential.id, this.pool as Pool)
       if (!token) {
         logger.warn('Failed to get OAuth token for usage fetch', {
           metadata: { accountId: credential.account_id, credentialId: credential.id },
@@ -192,23 +223,32 @@ export class UsageCacheService {
             accountId: credential.account_id,
             credentialId: credential.id,
             status: response.status,
+            retryAfter: response.headers.get('retry-after'),
             error: errorText,
           },
         })
-        return this.handleFetchFailure(credential.id)
+        return this.handleFetchFailure(
+          credential.id,
+          this.parseRetryAfter(response.headers.get('retry-after'))
+        )
       }
 
-      const rawData = (await response.json()) as AnthropicOAuthUsageResponse
+      const usage = (await response.json()) as AnthropicOAuthUsageResponse
       const now = Date.now()
-
+      const nextRefreshAt = now + BACKGROUND_REFRESH_AT_MS
       const entry: CachedUsageEntry = {
-        usage: rawData,
+        usage,
         fetchedAt: now,
         isEstimated: false,
-        lastSuccessfulUsage: rawData,
+        lastSuccessfulUsage: usage,
+        nextRefreshAt,
+        failureCount: 0,
       }
 
       this.cache.set(credential.id, entry)
+      if (this.stateService.isPersistent) {
+        await this.stateService.saveUsageSuccess(credential.id, usage, now, nextRefreshAt)
+      }
       return entry
     } catch (error) {
       logger.warn('Error fetching OAuth usage', {
@@ -222,61 +262,138 @@ export class UsageCacheService {
     }
   }
 
-  /**
-   * Handle a fetch failure. If we have previous successful data,
-   * extrapolate; otherwise return null.
-   */
-  private handleFetchFailure(credentialId: string): CachedUsageEntry | null {
-    const cached = this.cache.get(credentialId)
+  private async handleFetchFailure(
+    credentialId: string,
+    retryAfterMs: number | null = null
+  ): Promise<CachedUsageEntry | null> {
+    let cached = this.cache.get(credentialId) ?? null
+    let failureCount = cached?.failureCount ?? 0
 
-    if (cached?.lastSuccessfulUsage && cached.fetchedAt > 0) {
-      return this.extrapolate(credentialId, cached)
+    if (this.stateService.isPersistent) {
+      const shared = await this.stateService.getUsageState(credentialId)
+      if (shared) {
+        cached = this.entryFromSharedState(shared)
+        failureCount = shared.failureCount
+      }
+
+      const backoff = this.failureBackoffMs(failureCount + 1)
+      const nextRefreshAt = Date.now() + Math.max(backoff, retryAfterMs ?? 0)
+      const persistedFailureCount = await this.stateService.saveUsageFailure(
+        credentialId,
+        nextRefreshAt
+      )
+
+      if (!cached?.lastSuccessfulUsage || !cached.fetchedAt) {
+        return null
+      }
+      const estimated = this.extrapolate(cached, nextRefreshAt, persistedFailureCount)
+      this.cache.set(credentialId, estimated)
+      return estimated
     }
 
-    return null
+    if (!cached?.lastSuccessfulUsage || !cached.fetchedAt) {
+      return null
+    }
+    const estimated = this.extrapolate(
+      cached,
+      Date.now() + FAILURE_BACKOFF_BASE_MS,
+      failureCount + 1
+    )
+    this.cache.set(credentialId, estimated)
+    return estimated
   }
 
-  /**
-   * Extrapolate usage from last known values.
-   * Formula: estimated = lastValue + (elapsedMinutes / 10) * 2
-   * Only non-null windows are extrapolated. Capped at 100.
-   */
-  private extrapolate(credentialId: string, cached: CachedUsageEntry): CachedUsageEntry {
-    const base = cached.lastSuccessfulUsage!
-    const elapsedMinutes = (Date.now() - cached.fetchedAt) / 60_000
-    const increase = (elapsedMinutes / 10) * EXTRAPOLATION_RATE_PER_10MIN
+  private entryFromSharedState(shared: SharedUsageState): CachedUsageEntry | null {
+    if (!shared.usage || !shared.fetchedAt) {
+      return null
+    }
+    const base: CachedUsageEntry = {
+      usage: shared.usage,
+      fetchedAt: shared.fetchedAt,
+      isEstimated: false,
+      lastSuccessfulUsage: shared.usage,
+      nextRefreshAt: shared.nextRefreshAt,
+      failureCount: shared.failureCount,
+    }
+    return shared.failureCount > 0
+      ? this.extrapolate(base, shared.nextRefreshAt, shared.failureCount)
+      : base
+  }
 
+  private extrapolate(
+    cached: CachedUsageEntry,
+    nextRefreshAt: number,
+    failureCount: number
+  ): CachedUsageEntry {
+    const base = cached.lastSuccessfulUsage
+    if (!base) {
+      throw new Error('Cannot extrapolate usage without a successful baseline')
+    }
+    const elapsedMinutes = Math.max(0, Date.now() - cached.fetchedAt) / 60_000
+    const increase = (elapsedMinutes / 10) * EXTRAPOLATION_RATE_PER_10MIN
+    const extrapolateValue = (value: number): number =>
+      Math.min(EXTRAPOLATION_CAP, value + increase)
     const extrapolateWindow = (
       window: { utilization: number; resets_at: string } | null | undefined
-    ) => {
-      if (!window) {
-        return window
-      }
-      return {
-        utilization: Math.min(EXTRAPOLATION_CAP, window.utilization + increase),
-        resets_at: window.resets_at,
-      }
-    }
+    ) =>
+      window
+        ? { utilization: extrapolateValue(window.utilization), resets_at: window.resets_at }
+        : window
 
-    const extrapolated: AnthropicOAuthUsageResponse = {
+    const usage: AnthropicOAuthUsageResponse = {
       five_hour: extrapolateWindow(base.five_hour) ?? null,
       seven_day: extrapolateWindow(base.seven_day) ?? null,
       seven_day_oauth_apps: extrapolateWindow(base.seven_day_oauth_apps) ?? null,
       seven_day_opus: extrapolateWindow(base.seven_day_opus) ?? null,
       seven_day_sonnet: extrapolateWindow(base.seven_day_sonnet) ?? null,
       iguana_necktie: extrapolateWindow(base.iguana_necktie) ?? null,
-      // extra_usage is billing data, not extrapolated
+      limits: base.limits?.map(limit => ({
+        ...limit,
+        percent: limit.percent === null ? null : extrapolateValue(limit.percent),
+      })),
       extra_usage: base.extra_usage,
     }
 
-    const entry: CachedUsageEntry = {
-      usage: extrapolated,
-      fetchedAt: cached.fetchedAt, // Preserve original fetch time
+    return {
+      usage,
+      fetchedAt: cached.fetchedAt,
       isEstimated: true,
-      lastSuccessfulUsage: cached.lastSuccessfulUsage,
+      lastSuccessfulUsage: base,
+      nextRefreshAt,
+      failureCount,
     }
+  }
 
-    this.cache.set(credentialId, entry)
-    return entry
+  private failureBackoffMs(failureCount: number): number {
+    const exponential = Math.min(
+      FAILURE_BACKOFF_BASE_MS * Math.pow(2, Math.max(0, failureCount - 1)),
+      FAILURE_BACKOFF_MAX_MS
+    )
+    return Math.floor(exponential * (1 + Math.random() * 0.25))
+  }
+
+  private parseRetryAfter(value: string | null): number | null {
+    if (!value) {
+      return null
+    }
+    const seconds = Number(value)
+    if (Number.isFinite(seconds)) {
+      return Math.max(0, seconds * 1000)
+    }
+    const timestamp = new Date(value).getTime()
+    return Number.isNaN(timestamp) ? null : Math.max(0, timestamp - Date.now())
+  }
+
+  private async waitForSharedRefresh(credentialId: string): Promise<CachedUsageEntry | null> {
+    for (let attempt = 0; attempt < SHARED_REFRESH_WAIT_ATTEMPTS; attempt += 1) {
+      await new Promise(resolve => setTimeout(resolve, SHARED_REFRESH_WAIT_MS))
+      const shared = await this.stateService.getUsageState(credentialId)
+      const entry = shared ? this.entryFromSharedState(shared) : null
+      if (entry) {
+        this.cache.set(credentialId, entry)
+        return entry
+      }
+    }
+    return null
   }
 }


### PR DESCRIPTION
## Summary

- stop retrying HTTP 429 on the same Anthropic credential and make one immediate attempt on a different eligible pooled account
- preserve and honor Retry-After plus safe Anthropic rate-limit/reset headers
- coordinate usage data, refresh leases, failure backoff, model cooldowns, project affinity, and in-flight counts through PostgreSQL
- serve stale extrapolated usage during polling failures, with cluster-wide exponential backoff and jitter
- split utilization gates into 90% for five-hour/session limits and 95% for seven-day/weekly limits

## Deployment

Migration 025 must run before deploying this proxy version:

    DATABASE_URL=... bun run scripts/db/migrations/025-cluster-account-pool-coordination.ts

The migration is transactional and idempotent. It keeps the legacy token_limit_threshold column for rolling-deployment compatibility.

## Validation

- bun run typecheck
- bun run build:proxy
- bun run format:check
- bun run --cwd services/proxy lint (0 errors)
- bun run test:ci
- focused rate-limit/account-pool suite: 55 passing
- migration applied twice against disposable PostgreSQL, then exercised from two coordinator instances and rolled back successfully

## Architecture

ADR-036 records the PostgreSQL coordination decision and updates ADR-031/ADR-032 for reactive failover, shared polling, and the independent window thresholds.